### PR TITLE
Avoid installing dev dependencies recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ download/node/bin/npm: download/arch/$(NODE_TAR)
 	touch $@
 
 build/node_modules.stamp: package.json
-	npm update --dev
+	rm -rf node_modules
+	CINDYJS_BUILDING=true npm install
 	@mkdir -p $(@D)
 	touch $@
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "source-map": "^0.4.4"
   },
   "scripts": {
-    "prepublish": "make clean && make && make alltests",
+    "prepublish": "test -n \"$CINDYJS_BUILDING\" || { make clean && make && make alltests; }",
     "test": "make tests"
   },
   "repository": {


### PR DESCRIPTION
Apparently, `npm update --dev` has a far more dramatic effect than just calling `npm update …` on all the `devDependencies`.  The flag seems to be recursive, causing the installation of all dev dependencies of all the packages, possibly triggering hundreds of warnings.

So instead of `npm update` we now use `npm install`.  By removing the `node_modules` directory first, we can ensure that we get the latest allowed version of each dependency.  We use an environment variable to avoid infinite recursion due to the `prepublish` script.

To test this, please verify that the following work for you:
* `make clean && make`
* `git clean -fdx && make`
* `git clean -fdx && npm install`