### PR TITLE
Adapt random number tests to reduced number of decimal digits

### DIFF
--- a/ref/Arithmetic_Operators.md
+++ b/ref/Arithmetic_Operators.md
@@ -301,19 +301,19 @@ The following operators generate pseudo random numbers.
 
     > random()
     < 0.468
-    ~ 0\.\d+
+    ~ 0(\.\d+)?
     > 1000*random()
     < 278.4083
-    ~ \d+\.\d+
+    ~ \d+(\.\d+)?
 
 #### (0,1)-normally distributed random number: `randomnormal()`
 
     > randomnormal()
     < 0.1325
-    ~ -?\d+\.\d+
+    ~ -?\d+(\.\d+)?
     > 1000*randomnormal()
     < -1199.8909
-    ~ -?\d+\.\d+
+    ~ -?\d+(\.\d+)?
 
 #### Random boolean value `true` or `false`: `randombool()`
 
@@ -325,13 +325,13 @@ The following operators generate pseudo random numbers.
 
     > random(10)
     < 7.089
-    ~ \d\.\d+
+    ~ \d(\.\d+)?
     > random(1000)
     < 882.4784
-    ~ \d+\.\d+
+    ~ \d+(\.\d+)?
     > sum(1..1000, random(5))
     < 2464.8004
-    ~ 2\d\d\d\.\d+
+    ~ 2\d\d\d(\.\d+)?
 
 #### Uniformly distributed random integer number between 0 and `‹number›`: `randomint(‹number›)`
 

--- a/ref/Arithmetic_Operators.md
+++ b/ref/Arithmetic_Operators.md
@@ -300,14 +300,20 @@ The following operators generate pseudo random numbers.
 #### Uniformly distributed random real number between 0 and 1: `random()`
 
     > random()
-    < 0.4680764123124367
-    ~ 0\.\d{4,}
+    < 0.468
+    ~ 0\.\d{2,}
+    > 1000*random()
+    < 278.4083
+    ~ \d{2,3}\.\d{2,}
 
 #### (0,1)-normally distributed random number: `randomnormal()`
 
     > randomnormal()
-    < 0.1325114717517828
-    ~ -?\d+\.\d{4,}
+    < 0.1325
+    ~ -?\d+\.\d{2,}
+    > 1000*randomnormal()
+    < -1199.8909
+    ~ -?\d+\.\d{2,}
 
 #### Random boolean value `true` or `false`: `randombool()`
 
@@ -318,10 +324,13 @@ The following operators generate pseudo random numbers.
 #### Uniformly distributed random real number between 0 and `‹number›`: `random(‹number›)`
 
     > random(10)
-    < 7.089078226464412
-    ~ \d\.\d{3,}
+    < 7.089
+    ~ \d\.\d{2,}
+    > random(1000)
+    < 882.4784
+    ~ \d{2,3}\.\d{2,}
     > sum(1..1000, random(5))
-    < 2464.8003929607607
+    < 2464.8004
     ~ 2\d\d\d\.\d+
 
 #### Uniformly distributed random integer number between 0 and `‹number›`: `randomint(‹number›)`

--- a/ref/Arithmetic_Operators.md
+++ b/ref/Arithmetic_Operators.md
@@ -301,19 +301,19 @@ The following operators generate pseudo random numbers.
 
     > random()
     < 0.468
-    ~ 0\.\d{2,}
+    ~ 0\.\d+
     > 1000*random()
     < 278.4083
-    ~ \d{2,3}\.\d{2,}
+    ~ \d+\.\d+
 
 #### (0,1)-normally distributed random number: `randomnormal()`
 
     > randomnormal()
     < 0.1325
-    ~ -?\d+\.\d{2,}
+    ~ -?\d+\.\d+
     > 1000*randomnormal()
     < -1199.8909
-    ~ -?\d+\.\d{2,}
+    ~ -?\d+\.\d+
 
 #### Random boolean value `true` or `false`: `randombool()`
 
@@ -325,10 +325,10 @@ The following operators generate pseudo random numbers.
 
     > random(10)
     < 7.089
-    ~ \d\.\d{2,}
+    ~ \d\.\d+
     > random(1000)
     < 882.4784
-    ~ \d{2,3}\.\d{2,}
+    ~ \d+\.\d+
     > sum(1..1000, random(5))
     < 2464.8004
     ~ 2\d\d\d\.\d+


### PR DESCRIPTION
Since f3b32d9577e085f6907efdf9b11680c73df79d42, numbers will be printed with only 4 decimal places.  But since trailing zeros are omitted, we might in fact get fewer than four decimals.  Requiring only two non-zero decimals will reduce the chance of a random test failure to 1% per test.