### PR TITLE
is operations

### DIFF
--- a/examples/104_isOperations.html
+++ b/examples/104_isOperations.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Konstruktion.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+
+<script id="csdraw" type="text/x-cindyscript">
+println("ispoint: point, line");
+println(ispoint(A));
+println(ispoint(a));
+
+println("isline: point, line");
+println(isline(A));
+println(isline(a));
+
+
+println("iscircle: circle, conic");
+println(iscircle(C0));
+println(iscircle(C1));
+
+
+println("isconic: circle, conic");
+println(isconic(C0));
+println(isconic(C1));
+
+println("isgeometric: circle, conic, line, string, int");
+int = 5;
+println(isgeometric(C0));
+println(isgeometric(C1));
+println(isgeometric(a));
+println(isgeometric("Test"));
+println(isgeometric(int));
+
+println("issun: sun, mass, point");
+println(issun(S));
+println(issun(M));
+println(issun(A));
+
+
+println("ismass: sun, mass, point");
+println(ismass(S));
+println(ismass(M));
+println(ismass(A));
+
+
+println("isspring: spring, bouncer, line");
+println(isspring(spring));
+println(isspring(bounce));
+println(isspring(a));
+
+
+println("isbouncer: spring, bouncer, line");
+println(isbouncer(spring));
+println(isbouncer(bounce));
+println(isbouncer(a));
+
+
+println("isundefined: defined, undefined");
+println(isundefined(a));
+println(isundefined(aaa));
+</script>
+
+    <script type="text/javascript">
+var cdy = createCindy({
+  scripts: "cs*",
+  defaultAppearance: {},
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 335,
+    background: "rgb(168,176,192)",
+    transform: [{visibleRect: [-9.04, 9.32, 18.16, -4.08]}]
+  }],
+  geometry: [
+    {name: "S", type: "Free", pos: [-0.03508771929824561, -7, -0.8771929824561404], color: [1, 1, 0], labeled: true},
+    {name: "M", type: "Free", pos: [-2.0350877192982457, -7, -0.8771929824561404], color: [1, 0, 1], labeled: true},
+    {name: "A", type: "Free", pos: [-0.03508771929824561, -4, -0.8771929824561404], color: [1, 0, 0], labeled: true},
+    {name: "B", type: "Free", pos: [4, 0.6382978723404256, 1.0638297872340425], color: [1, 0, 0], labeled: true},
+    {name: "C", type: "Free", pos: [4, 3.272727272727273, 0.6493506493506493], color: [1, 0, 0], labeled: true},
+    {name: "C0", type: "CircleBy3", args: ["C", "A", "B"], size: 1, color: [0, 0, 1], printname: "$C_{0}$"},
+    {name: "D", type: "Free", pos: [4, -0.9504950495049505, 0.49504950495049505], color: [1, 0, 0], labeled: true},
+    {name: "E", type: "Free", pos: [4, 0.5289256198347108, 0.4132231404958678], color: [1, 0, 0], labeled: true},
+    {name: "C1", type: "ConicBy5", args: ["E", "A", "B", "D", "C"], size: 1, color: [0, 0, 1], printname: "$C_{1}$"},
+    {name: "bounce", type: "Segment", args: ["A", "D"], pos: [0.06884681583476773, -0.8777969018932874, 4], size: 1, labeled: true},
+    {name: "spring", type: "Segment", args: ["A", "E"], pos: [0.06884681583476773, -0.8777969018932874, 4], size: 1, labeled: true},
+    {name: "a", type: "Join", args: ["C", "A"], pos: [0.06884681583476773, -0.8777969018932874, 4], size: 1, color: [0, 0, 1], labeled: true},
+    {name: "G", type: "Free", pos: [4, -1.925925925925926, -0.9259259259259259], color: [1, 0, 0], labeled: true}
+  ],
+  behavior: [
+    {behavior: {type: "Environment", deltat: 0.2, accuracy: 10}},
+    {name: "M", behavior: {type: "Mass", vy: 0.7}},
+    {name: "S", behavior: {type: "Sun"}},
+    {name: "spring", behavior: {type: "Spring"}},
+    {name: "bounce", behavior: {type: "Bouncer"}}
+  ]
+});
+</script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/ref/Boolean_Operators.md
+++ b/ref/Boolean_Operators.md
@@ -446,6 +446,12 @@ This operator tests whether the expression `‹expr›` represents a [CindyLab](
 
 ------
 
+#### Is a bouncer: `isbouncer(‹expr›)`
+
+**Description:**
+This operator tests whether the expression `‹expr›` represents a [CindyLab](CindyLab) bouncer.
+
+------
 #### Is undefined: `isundefined(‹expr›)`
 
 **Description:**

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1419,6 +1419,80 @@ evaluator.ismatrix$1 = function(args, modifs) {
     };
 };
 
+
+evaluator.iscircle$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === "geo" && v0.value.kind === "C" && v0.value.matrix.usage === "Circle") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+
+evaluator.isconic$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === "geo" && v0.value.kind === "C") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+evaluator.isline$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === "geo" && v0.value.kind === "L") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+
+evaluator.ispoint$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === "geo" && v0.value.kind === "P") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+
+evaluator.isgeometric$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === "geo") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
 evaluator.isnumbermatrix$1 = function(args, modifs) {
     var v0 = evaluate(args[0]);
     if ((List.isNumberMatrix(v0)).value) {
@@ -1436,6 +1510,80 @@ evaluator.isnumbermatrix$1 = function(args, modifs) {
 evaluator.isnumbervector$1 = function(args, modifs) {
     var v0 = evaluate(args[0]);
     if ((List.isNumberVector(v0)).value) {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+
+evaluator.issun$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === 'geo' && v0.value.behavior !== undefined && v0.value.behavior.type === "Sun") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+
+evaluator.ismass$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === 'geo' && v0.value.behavior !== undefined && v0.value.behavior.type === "Mass") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+
+evaluator.isspring$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === 'geo' && v0.value.behavior !== undefined && v0.value.behavior.type === "Spring") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+
+evaluator.isbouncer$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === 'geo' && v0.value.behavior !== undefined && v0.value.behavior.type === "Bouncer") {
+        return {
+            'ctype': 'boolean',
+            'value': true
+        };
+    }
+    return {
+        'ctype': 'boolean',
+        'value': false
+    };
+};
+
+evaluator.isundefined$1 = function(args, modifs) {
+    var v0 = evaluate(args[0]);
+    if (v0.ctype === 'undefined') {
         return {
             'ctype': 'boolean',
             'value': true


### PR DESCRIPTION
Hi,

i added the following operations to cindyscript:

iscircle(1)
isconic(1)
isline(1)
ispoint(1)
isgeometric(1)
issun(1)
ismass(1)
isspring(1)
isbouncer(1)
isundefined(1)

the following were already implemented:
isinteger(1)
isreal(1)
iscomplex(1)
iseven(1)
isodd(1)
islist(1)
ismatrix(1)
isnumbervector(1)
isnumbermatrix (1)
isstring(1)

Cinderella has the following according to http://doc.cinderella.de/tiki-index.php?page=Operator+Index

isinteger (1) test for integer
isreal (1) test for real number
iscomplex (1) test for complex number
iseven (1) test for even integer
isodd (1) test for odd integer
islist (1) test for list
ismatrix (1) test for nested list in matrix shape
isnumbervector (1) test for list which is a number vector
isnumbermatrix (1) test for list which is a number matrix
isstring (1) test for string
isgeometric (1) test for geometric object
isselected (1) test for being selected
ispoint (1) test for point
isline (1) test for line
iscircle (1) test for circle
isconic (1) test for conic
ismass (1) test for mass
issun (1) test for sun
isspring (1) test for spring
isundefined (1) test for being undefined

Therefor isspring and isbouncer are not backwards compatible.