### PR TITLE
Add write-only access to the printlabel property of a geometric object

### DIFF
--- a/examples/102_Slider.html
+++ b/examples/102_Slider.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Labeled Slider</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+
+C.printlabel = round(C.x);
+
+</script>
+<script type="text/javascript">
+
+var cdy = createCindy({ // See ref/createCindy documentation for details.
+  ports: [{id: "CSCanvas"}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+  },
+  transform: [{scale:1.75},{translate:[-5,-5]}],
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0], pinned:true, visible:false},
+    {name:"B", type:"Free", pos:[10,0], pinned:true, visible:false},
+    {name:"a", type:"Segment", args:["A","B"]},
+    {name:"C", type:"PointOnSegment", args:["a"], pos:[5,0], labeled:true, printname:"5"}
+  ]
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas" width="500" height="100"
+          style="border:2px solid black"></canvas>
+</body>
+
+</html>

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -160,6 +160,9 @@ Accessor.setField = function(geo, field, value) {
             geo.pinned = value.value;
         }
     }
+    if (field === "printlabel") {
+        geo.printname = niceprint(value);
+    }
 
     if (field === "xy" && geo.kind === "P" && geo.movable && List._helper.isNumberVecN(value, 2)) {
         movepointscr(geo, List.turnIntoCSList([value.value[0], value.value[1], CSNumber.real(1)]), "homog");


### PR DESCRIPTION
Note that this is called `printlabel` in CindyScript, but `printname` in JavaScript. The CindyScript name is required for compatibility with Cinderella, while the JavaScript name for backwards compatibility with geometry descriptions in existing CindyJS content.