### PR TITLE
Drop log messages from geometric operators

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -569,7 +569,6 @@ geoOps.Compass.updatePosition = function(el) {
 
     var matrix = geoOps._helper.CircleMP(m, p);
     matrix = List.normalizeMax(matrix);
-    console.log(matrix);
     el.matrix = General.withUsage(matrix, "Circle");
 };
 
@@ -1093,8 +1092,6 @@ geoOps.angleBisector.updatePosition = function(el) {
 
     erg1 = List.normalizeMax(erg1);
     erg2 = List.normalizeMax(erg2);
-
-    console.log(erg1, erg2, "erg1", "erg2");
 
     el.results = tracing2(erg1, erg2);
 };


### PR DESCRIPTION
Logging in geometric operators can lead to excessive amounts of logging data, leading to performance problems and making the log as a whole almost useless.