### PR TITLE
Drop unknown operations and their dependencies

### DIFF
--- a/examples/103_BadElements.html
+++ b/examples/103_BadElements.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script type="text/javascript">
+
+var cdy = createCindy({ // See ref/createCindy documentation for details.
+  ports: [{id: "CSCanvas"}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0]},
+    {name:"X", type:"Foo", comment:"There is no such operation."},
+    {name:"y", type:"Join", args:["A","X"]},
+    {name:"Z", type:"PointOnLine", args:["y"]},
+    {name:"B", type:"Free", pos:[1,0]}
+  ]
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas" width="500" height="500"
+          style="border:2px solid black"></canvas>
+  <p>You should see two free points. Unknown operations should be
+  automatically removed from the construction, and that fact should be
+  logged to the development console.</p>
+</body>
+
+</html>

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -95,6 +95,7 @@ function csinit(gslp) {
     var ctf = 0;
     var ctl = 0;
     var ctc = 0;
+    var dropped = {};
 
     // Das ist für alle gleich
     for (k = 0; k < gslp.length; k++) {
@@ -114,9 +115,24 @@ function csinit(gslp) {
         if (!op) {
             console.error(el);
             console.error("Operation " + el.type + " not implemented yet");
+            dropped[el.name] = true;
             gslp.splice(k, 1);
             k--;
             continue;
+        }
+        if (el.args) {
+            for (l = 0; l < el.args.length; ++l) {
+                if (dropped.hasOwnProperty(el.args[l]))
+                    break;
+            }
+            if (l < el.args.length) { // we did break
+                console.log("Dropping " + el.name +
+                    " due to dropped argument " + el.args[l]);
+                dropped[el.name] = true;
+                gslp.splice(k, 1);
+                k--;
+                continue;
+            }
         }
         el.kind = op.kind;
         el.stateIdx = totalStateSize;

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -114,6 +114,9 @@ function csinit(gslp) {
         if (!op) {
             console.error(el);
             console.error("Operation " + el.type + " not implemented yet");
+            gslp.splice(k, 1);
+            k--;
+            continue;
         }
         el.kind = op.kind;
         el.stateIdx = totalStateSize;


### PR DESCRIPTION
Sometimes Cinderella exports things we cannot handle. In those cases it is probably better to continue with the things we can display, instead of failing completely with mysterious errors printed to the console only.

This commit will remove geometric elements with unknown operations from the gslp. It will also drop things which depend on these. There is an example to verify that this works as advertised.