### PR TITLE
Replace multiple calls to global functions in examples

### DIFF
--- a/examples/31_EventTest.html
+++ b/examples/31_EventTest.html
@@ -95,8 +95,8 @@
         
 
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:650px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:650px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:650px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:650px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:650px;left:170px" >Stop</button>
 
 
 	</body>

--- a/examples/31_EventTest.html
+++ b/examples/31_EventTest.html
@@ -94,9 +94,9 @@
         <button onclick="cdy.evokeCS('smaller()')" type="button" style="position:absolute; top:620px;left:210px" >Smaller</button>
         
 
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:650px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:650px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:650px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:650px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:650px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:650px;left:170px" >Stop</button>
 
 
 	</body>

--- a/examples/34_Suns.html
+++ b/examples/34_Suns.html
@@ -61,9 +61,9 @@
     
         </script>
         
-               <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+               <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/34_Suns.html
+++ b/examples/34_Suns.html
@@ -62,8 +62,8 @@
         </script>
         
                <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/34_SunsT.html
+++ b/examples/34_SunsT.html
@@ -63,8 +63,8 @@
         </script>
         
                <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/34_SunsT.html
+++ b/examples/34_SunsT.html
@@ -62,9 +62,9 @@
     
         </script>
         
-               <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+               <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/35_Springs.html
+++ b/examples/35_Springs.html
@@ -91,8 +91,8 @@
         </script>
         
                <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/35_Springs.html
+++ b/examples/35_Springs.html
@@ -90,9 +90,9 @@
     
         </script>
         
-               <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+               <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/36_Springs2.html
+++ b/examples/36_Springs2.html
@@ -86,8 +86,8 @@
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/36_Springs2.html
+++ b/examples/36_Springs2.html
@@ -85,9 +85,9 @@
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/37_Bouncer.html
+++ b/examples/37_Bouncer.html
@@ -78,9 +78,9 @@
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/37_Bouncer.html
+++ b/examples/37_Bouncer.html
@@ -79,8 +79,8 @@
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/38_ManyParticles.html
+++ b/examples/38_ManyParticles.html
@@ -86,8 +86,8 @@
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/38_ManyParticles.html
+++ b/examples/38_ManyParticles.html
@@ -85,9 +85,9 @@
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBalls.html
+++ b/examples/39_ManyBalls.html
@@ -137,8 +137,8 @@ mat=mmmx*mmmy*mat;
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBalls.html
+++ b/examples/39_ManyBalls.html
@@ -136,9 +136,9 @@ mat=mmmx*mmmy*mat;
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBallsExplorer.html
+++ b/examples/39_ManyBallsExplorer.html
@@ -21,7 +21,7 @@
         blobs=false;
         bondings=true;
         black=true;
-            javascript("cdy.csplay()");
+            javascript("cdy.play()");
 
         </script>
         
@@ -273,9 +273,9 @@ forall(pairs,s,
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
         <button onclick="cdy.evokeCS('blobs=!blobs')" type="button" style="position:absolute; top:610px;left:270px" >Blobs</button>
         <button onclick="cdy.evokeCS('bondings=!bondings')" type="button" style="position:absolute; top:610px;left:370px" >Bondings</button>
         <button onclick="cdy.evokeCS('black=!black')" type="button" style="position:absolute; top:610px;left:470px" >Black/White</button>

--- a/examples/39_ManyBallsExplorer.html
+++ b/examples/39_ManyBallsExplorer.html
@@ -273,9 +273,9 @@ forall(pairs,s,
     
         </script>
         
-        <button onclick="csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
         <button onclick="cdy.evokeCS('blobs=!blobs')" type="button" style="position:absolute; top:610px;left:270px" >Blobs</button>
         <button onclick="cdy.evokeCS('bondings=!bondings')" type="button" style="position:absolute; top:610px;left:370px" >Bondings</button>
         <button onclick="cdy.evokeCS('black=!black')" type="button" style="position:absolute; top:610px;left:470px" >Black/White</button>

--- a/examples/39_ManyBallsX.html
+++ b/examples/39_ManyBallsX.html
@@ -95,8 +95,8 @@ masses=allmasses();
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBallsX.html
+++ b/examples/39_ManyBallsX.html
@@ -94,9 +94,9 @@ masses=allmasses();
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBallsY.html
+++ b/examples/39_ManyBallsY.html
@@ -108,8 +108,8 @@ forall(pairs,s,
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBallsY.html
+++ b/examples/39_ManyBallsY.html
@@ -107,9 +107,9 @@ forall(pairs,s,
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBalls_1_1.html
+++ b/examples/39_ManyBalls_1_1.html
@@ -110,9 +110,9 @@ forall(pairs,s,
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBalls_1_1.html
+++ b/examples/39_ManyBalls_1_1.html
@@ -111,8 +111,8 @@ forall(pairs,s,
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBalls_1_2.html
+++ b/examples/39_ManyBalls_1_2.html
@@ -109,8 +109,8 @@ forall(pairs,s,
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBalls_1_2.html
+++ b/examples/39_ManyBalls_1_2.html
@@ -108,9 +108,9 @@ forall(pairs,s,
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBalls_1_3_a.html
+++ b/examples/39_ManyBalls_1_3_a.html
@@ -110,9 +110,9 @@ forall(pairs,s,
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/39_ManyBalls_1_3_a.html
+++ b/examples/39_ManyBalls_1_3_a.html
@@ -111,8 +111,8 @@ forall(pairs,s,
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/40_Swarm.html
+++ b/examples/40_Swarm.html
@@ -121,9 +121,9 @@ for(var i=0;i<nn;i++){
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/40_Swarm.html
+++ b/examples/40_Swarm.html
@@ -122,8 +122,8 @@ for(var i=0;i<nn;i++){
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/40_SwarmExplorer.html
+++ b/examples/40_SwarmExplorer.html
@@ -210,8 +210,8 @@ for(var i=0;i<nn;i++){
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/40_SwarmExplorer.html
+++ b/examples/40_SwarmExplorer.html
@@ -209,9 +209,9 @@ for(var i=0;i<nn;i++){
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/40_SwarmExplorerX.html
+++ b/examples/40_SwarmExplorerX.html
@@ -173,9 +173,9 @@ for(var i=0;i<nn;i++){
     
         </script>
         
-        <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.play()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
+        <button onclick="cdy.pause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/40_SwarmExplorerX.html
+++ b/examples/40_SwarmExplorerX.html
@@ -174,8 +174,8 @@ for(var i=0;i<nn;i++){
         </script>
         
         <button onclick="cdy.csplay()" type="button" style="position:absolute; top:610px;left:60px" >Play</button>
-        <button onclick="cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
+        <button onclick="cdy.cspause()" type="button" style="position:absolute; top:610px;left:110px" >Pause</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:610px;left:170px" >Stop</button>
 
 	</body>
 </html>

--- a/examples/51_Archimedean.html
+++ b/examples/51_Archimedean.html
@@ -439,7 +439,7 @@ mat=mmmx*mmmy*mat;
             
             </script>
              <button onclick="cdy.csplay()" type="button" style="position:absolute; top:640px;left:60px" >Play</button>
-        <button onclick="csstop()" type="button" style="position:absolute; top:640px;left:150px" >Stop</button>
+        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:640px;left:150px" >Stop</button>
 
        	</body>
 </html>

--- a/examples/51_Archimedean.html
+++ b/examples/51_Archimedean.html
@@ -438,8 +438,8 @@ mat=mmmx*mmmy*mat;
 
             
             </script>
-             <button onclick="cdy.csplay()" type="button" style="position:absolute; top:640px;left:60px" >Play</button>
-        <button onclick="cdy.csstop()" type="button" style="position:absolute; top:640px;left:150px" >Stop</button>
+             <button onclick="cdy.play()" type="button" style="position:absolute; top:640px;left:60px" >Play</button>
+        <button onclick="cdy.stop()" type="button" style="position:absolute; top:640px;left:150px" >Stop</button>
 
        	</body>
 </html>

--- a/examples/59_Equilibrium.html
+++ b/examples/59_Equilibrium.html
@@ -190,9 +190,9 @@ if(or(or(oa~!=inpa,ob~!=inpb),oc~!=inpc) ,
     
         </script>
        <div style="position:absolute; top:630px;left:10px">
-        <button onclick="cdy.csplay()" type="button" >Play</button>
-        <button onclick="cdy.cspause()" type="button" >Pause</button>
-        <button onclick="cdy.csstop()" type="button">Stop</button>&nbsp;&nbsp;&nbsp;
+        <button onclick="cdy.play()" type="button" >Play</button>
+        <button onclick="cdy.pause()" type="button" >Pause</button>
+        <button onclick="cdy.stop()" type="button">Stop</button>&nbsp;&nbsp;&nbsp;
         <input onclick="cdy.evokeCS('togglebr()')" type="checkbox" >Brüche Raten<br>
         </div>
 	</body>

--- a/examples/59_Equilibrium.html
+++ b/examples/59_Equilibrium.html
@@ -191,8 +191,8 @@ if(or(or(oa~!=inpa,ob~!=inpb),oc~!=inpc) ,
         </script>
        <div style="position:absolute; top:630px;left:10px">
         <button onclick="cdy.csplay()" type="button" >Play</button>
-        <button onclick="cspause()" type="button" >Pause</button>
-        <button onclick="csstop()" type="button">Stop</button>&nbsp;&nbsp;&nbsp;
+        <button onclick="cdy.cspause()" type="button" >Pause</button>
+        <button onclick="cdy.csstop()" type="button">Stop</button>&nbsp;&nbsp;&nbsp;
         <input onclick="cdy.evokeCS('togglebr()')" type="checkbox" >Brüche Raten<br>
         </div>
 	</body>

--- a/examples/68a_MixedSurfaces.html
+++ b/examples/68a_MixedSurfaces.html
@@ -1122,7 +1122,7 @@ if((choice!=newchoice) & (animstate==1),
   animstate=-1;
   errc(animstate);
 
-  javascript("csplay()");
+  javascript("cdy.csplay()");
 
 );
 

--- a/examples/68a_MixedSurfaces.html
+++ b/examples/68a_MixedSurfaces.html
@@ -1107,7 +1107,7 @@ animstate=animstate+0.1
 errc(animstate);
 if(animstate>=1,
  animstate=1;
- javascript("cdy.csstop()");
+ javascript("cdy.stop()");
 );
 if(animstate>=0,
   choice=newchoice
@@ -1122,7 +1122,7 @@ if((choice!=newchoice) & (animstate==1),
   animstate=-1;
   errc(animstate);
 
-  javascript("cdy.csplay()");
+  javascript("cdy.play()");
 
 );
 

--- a/examples/68b_MixedSurfaces.html
+++ b/examples/68b_MixedSurfaces.html
@@ -2481,7 +2481,7 @@ animstate=animstate+0.1
 errc(animstate);
 if(animstate>=1,
  animstate=1;
- javascript("cdy.csstop()");
+ javascript("cdy.stop()");
 );
 if(animstate>=0,
   choice=newchoice
@@ -2496,7 +2496,7 @@ if((choice!=newchoice) & (animstate==1),
   animstate=-1;
   errc(animstate);
 
-  javascript("cdy.csplay()");
+  javascript("cdy.play()");
 
 );
 

--- a/examples/68b_MixedSurfaces.html
+++ b/examples/68b_MixedSurfaces.html
@@ -2496,7 +2496,7 @@ if((choice!=newchoice) & (animstate==1),
   animstate=-1;
   errc(animstate);
 
-  javascript("csplay()");
+  javascript("cdy.csplay()");
 
 );
 

--- a/examples/70_DownClock.html
+++ b/examples/70_DownClock.html
@@ -33,7 +33,7 @@ last=seconds(););
 </script>
 
         <script id='firstDrawing' type='cindyscript'>
-        javascript("cdy.csplay()");
+        javascript("cdy.play()");
         measured=seconds();
         if(!running,now=now+measured-last);
         last=measured;

--- a/tools/updateSyntax.js
+++ b/tools/updateSyntax.js
@@ -61,7 +61,7 @@ function updateDefaultAppearance(path, str) {
     return str;
 }
 
-var reMethods = /([^.])(evokeCS|cs(?:play|pause|stop))/g;
+var reMethods = /([^.])(?:(evokeCS)|cs(play|pause|stop))/g;
 
 function updateEvokeCS(path, str) {
     var orig = str;
@@ -75,7 +75,7 @@ function updateEvokeCS(path, str) {
         str = str.substr(0, match.index) + "var cdy = " + str.substr(match.index);
         v = "cdy";
     }
-    str = str.replace(reMethods, "$1" + v + ".$2");
+    str = str.replace(reMethods, "$1" + v + ".$2$3");
     if (str !== orig)
         return str;
 }

--- a/tools/updateSyntax.js
+++ b/tools/updateSyntax.js
@@ -61,7 +61,7 @@ function updateDefaultAppearance(path, str) {
     return str;
 }
 
-var reMethods = /([^.])(evokeCS|cs(?:play|pause|stop))/;
+var reMethods = /([^.])(evokeCS|cs(?:play|pause|stop))/g;
 
 function updateEvokeCS(path, str) {
     var orig = str;


### PR DESCRIPTION
The tool was missing a global flag for one RegExp, causing only the first occurrence to be replaced.  This should be better now. Fixes #18.