### PR TITLE
Implement 4-ary form of mesh3d providing normals

### DIFF
--- a/examples/cindy3d/16_MeshNormals.html
+++ b/examples/cindy3d/16_MeshNormals.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>WebGL testing</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/Cindy3D.js"></script>
+<script id="csinit" type="text/x-cindyscript">use("Cindy3D")</script>
+<script id="csdraw" type="text/x-cindyscript">
+m = 50;
+n = 20;
+r1 = 1;
+r2 = 0.3;
+begin3d();
+coords = apply(1..(m+1), i, apply(1..(n+1), j, (
+  a = i/m*360°;
+  b = j/n*360°;
+  p = [cos(a), sin(a), 0];
+  q = cos(b)*[0,0,1] + sin(b)*p;
+  pos = r1*p + r2*q;
+  dp = [-sin(a), cos(a), 0];
+  dq = -sin(b)*[0,0,1] + cos(b)*p;
+  normal = cross(dp, dq);
+  [pos, normal]
+)));
+err("x");
+err(coords);
+err("y");
+forall(1..m, i, forall(1..n, j, (
+  corners = [coords_i_j, coords_i_(j+1), coords_(i+1)_j, coords_(i+1)_(j+1)];
+  cpos = apply(corners, #_1);
+  cnorm = apply(corners, #_2);
+  mesh3d(2, 2, cpos, cnorm, color->0.25*sum(cpos))
+)));
+end3d();
+</script>
+<script type="text/javascript">
+createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+</script>
+</head>
+
+<body>
+  <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
+  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+</body>
+
+</html>

--- a/examples/cindy3d/17_ColorsMesh.html
+++ b/examples/cindy3d/17_ColorsMesh.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>WebGL testing</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/Cindy3D.js"></script>
+<script id="csinit" type="text/x-cindyscript">use("Cindy3D")</script>
+<script id="csdraw" type="text/x-cindyscript">
+m = 50;
+n = 20;
+r1 = 1;
+r2 = 0.3;
+begin3d();
+coords = flatten(apply(1..m, i, apply(1..n, j, (
+  a = i/m*360°;
+  b = j/n*360°;
+  p = [cos(a), sin(a), 0];
+  q = cos(b)*[0,0,1] + sin(b)*p;
+  r1*p + r2*q
+))));
+mesh3d(m, n, coords, colors->coords, topology->"closeBoth", normaltype->"perVertex");
+end3d();
+</script>
+<script type="text/javascript">
+createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+</script>
+</head>
+
+<body>
+  <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
+  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+</body>
+
+</html>

--- a/src/js/cindy3d/Ops3D.js
+++ b/src/js/cindy3d/Ops3D.js
@@ -358,20 +358,61 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
     }
   }
 
+  function meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance) {
+    for (let i = 1, k = 0; i < m; ++i) {
+      for (let j = 1; j < n; ++j) {
+        currentInstance.triangles.addPolygonWithNormalsAndColors(
+          [pos[k], pos[k + 1], pos[k + n + 1], pos[k + n]],
+          [normals[k], normals[k + 1], normals[k + n + 1], normals[k + n]],
+          [colors[k], colors[k + 1], colors[k + n + 1], colors[k + n]],
+          appearance);
+        ++k;
+      }
+      if (tcr) {
+        currentInstance.triangles.addPolygonWithNormalsAndColors(
+          [pos[k], pos[k + 1 - n], pos[k + 1], pos[k + n]],
+          [normals[k], normals[k + 1 - n], normals[k + 1], normals[k + n]],
+          [colors[k], colors[k + 1 - n], colors[k + 1], colors[k + n]],
+          appearance);
+      }
+      ++k;
+    }
+    if (tcc) {
+      for (let j = 1; j < n; ++j) {
+        currentInstance.triangles.addPolygonWithNormalsAndColors(
+          [pos[k], pos[k + 1], pos[j], pos[j - 1]],
+          [normals[k], normals[k + 1], normals[j], normals[j - 1]],
+          [colors[k], colors[k + 1], colors[j], colors[j - 1]],
+          appearance);
+        ++k;
+      }
+      if (tcr) {
+        currentInstance.triangles.addPolygonWithNormalsAndColors(
+          [pos[k], pos[k + 1 - n], pos[0], pos[n - 1]],
+          [normals[k], normals[k + 1 - n], normals[0], normals[n - 1]],
+          [colors[k], colors[k + 1 - n], colors[0], colors[n - 1]],
+          appearance);
+      }
+    }
+  }
+
   function mesh3dImpl(args, modifs) {
     let m = coerce.toInt(evaluate(args[0]));
     let n = coerce.toInt(evaluate(args[1]));
     let pos = coerce.toList(evaluate(args[2])).map(elt => coerce.toHomog(elt));
     let normaltype = "perface";
     let topology = "open";
+    let colors = null;
     let appearance = handleModifsAppearance(
       currentInstance.surfaceAppearance, modifs, {
         "normaltype": (a => normaltype =
                        coerce.toString(a, normaltype).toLowerCase()),
         "topology": (a => topology =
                        coerce.toString(a, normaltype).toLowerCase()),
+        "colors": (a => colors = coerce.toList(a).map(elt => coerce.toColor(elt))),
       });
     if (pos.length !== m*n) return nada;
+    if (colors !== null && colors.length !== m*n) return nada;
     let tcr = (topology === "closerows" || topology === "closeboth");
     let tcc = (topology === "closecolumns" || topology === "closeboth");
     let pc = null, normal = null, normalcnt = 0;
@@ -385,8 +426,11 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
     if (args.length === 4) {
       let normals = coerce.toList(evaluate(args[3]))
         .map(elt => coerce.toDirection(elt));
-      if (args.length !== m*n) return nada;
-      meshWithNormals(m, n, tcr, tcc, pos, normals, appearance);
+      if (normals.length !== m*n) return nada;
+      if (colors !== null)
+        meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
+      else
+        meshWithNormals(m, n, tcr, tcc, pos, normals, appearance);
     } else if (normaltype === "pervertex") {
       let normals = Array(m*n);
       let mn = m*n, p = pos.map(dehom3);
@@ -405,7 +449,10 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
           normals[k++] = scale3(4./normalcnt, normal);
         }
       }
-      meshWithNormals(m, n, tcr, tcc, pos, normals, appearance);
+      if (colors !== null)
+        meshWithNormalsAndColors(m, n, tcr, tcc, pos, normals, colors, appearance);
+      else
+        meshWithNormals(m, n, tcr, tcc, pos, normals, appearance);
     } else {
       meshAutoNormals(m, n, tcr, tcc, pos, appearance);
     }

--- a/src/js/cindy3d/Triangles.js
+++ b/src/js/cindy3d/Triangles.js
@@ -42,6 +42,31 @@ Triangles.prototype.addWithNormals = function(
 };
 
 /**
+ * @param {Array.<number>} p1
+ * @param {Array.<number>} p2
+ * @param {Array.<number>} p3
+ * @param {Array.<number>} n1
+ * @param {Array.<number>} n2
+ * @param {Array.<number>} n3
+ * @param {Array.<number>} c1
+ * @param {Array.<number>} c2
+ * @param {Array.<number>} c3
+ * @param {Appearance} appearance
+ */
+Triangles.prototype.addWithNormalsAndColors = function(
+  p1, p2, p3, n1, n2, n3, c1, c2, c3, appearance)
+{
+  let s = appearance.shininess, a = appearance.alpha;
+  if (a < 1.0)
+    this.opaque = false;
+  this.addPrimitive([
+    p1[0], p1[1], p1[2], p1[3], n1[0], n1[1], n1[2], s, c1[0], c1[1], c1[2], a,
+    p2[0], p2[1], p2[2], p2[3], n2[0], n2[1], n2[2], s, c2[0], c2[1], c2[2], a,
+    p3[0], p3[1], p3[2], p3[3], n3[0], n3[1], n3[2], s, c3[0], c3[1], c3[2], a,
+  ]);
+};
+
+/**
  * @param {Array.<number>} pos1
  * @param {Array.<number>} pos2
  * @param {Array.<number>} pos3
@@ -106,6 +131,24 @@ Triangles.prototype.addPolygonWithNormals = function(pos, n, appearance) {
     pp = pos[i];
     pn = n[i];
   }
+};
+
+/**
+ * @param {Array.<Array.<number>>} pos
+ * @param {Array.<Array.<number>>} n
+ * @param {Array.<Array.<number>>} c
+ * @param {Appearance} appearance
+ */
+Triangles.prototype.addPolygonWithNormalsAndColors = function(pos, n, c, appearance) {
+  if (pos.length == 3)
+    return this.addWithNormalsAndColors(
+      pos[0], pos[1], pos[2], n[0], n[1], n[2], c[0], c[1], c[2], appearance);
+  if (pos.length == 4) {
+    this.addWithNormalsAndColors(pos[0], pos[1], pos[3], n[0], n[1], n[3], c[0], c[1], c[3], appearance);
+    this.addWithNormalsAndColors(pos[3], pos[1], pos[2], n[3], n[1], n[2], c[3], c[1], c[2], appearance);
+    return;
+  }
+  console.error("addPolygonWithNormalsAndColors not supported for more than 4 corners");
 };
 
 /**


### PR DESCRIPTION
The example shows how these can be used to make a multi-colored surface appear smooth.  However, the colors are still per-face, not per-vertex, so the result doesn't look as smooth as could be hoped.

@richter-gebert: You can add `git@github.com:gagern/CindyJS.git` as a remote to your repository, and check out this branch from there to give it a try. If you agree with these changes, feel free to merge this request using the GitHub interface. Otherwise comment and/or assign the request to someone else.
