### PR TITLE
Disable console by default, remove popup console completely

### DIFF
--- a/ref/createCindy.md
+++ b/ref/createCindy.md
@@ -124,11 +124,15 @@ Any parameter which stays at this default value doesn't have to be specified at 
 
 ### csconsole
 
-This should be either `null`, set to `true` or a suitable `DOMElement`.
-If it is an element, then messages (in particular those created by the `err` function) will be appended to that element.
+This should be either `null`, set to `true` or a suitable `DOMElement` or its id string.
+If it is an element (passed directly or identified via its id),
+then messages (in particular those created by the `err` function) will be appended to that element.
 If it is `true` a simple console with a command line will be created automatically.
-If it is `null`, error output will be suppressed.
-If this parameter is absent, then error messages will cause a popup window.
+If it is `null`, error output will be suppressed except for output to the web developer console.
+If this parameter is absent, then it will be handled like `null`.
+
+In the past, the absence of this parameter would cause a popup window,
+but that was more annyoing than useful in most environments.
 
 ### grid
 

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -422,20 +422,15 @@ if (instanceInvocationArguments.use) {
 // CONSOLE
 //
 function setupConsole() {
-    if (typeof csconsole === "object" && csconsole === null) {
+    if (csconsole === null) {
         csconsole = new NullConsoleHandler();
-
-    } else if (typeof csconsole === "boolean" && csconsole === true) {
+    } else if (csconsole === true) {
         csconsole = new CindyConsoleHandler();
-
     } else if (typeof csconsole === "string") {
-        var id = csconsole;
-        csconsole = new ElementConsoleHandler(id);
-    }
-
-    // Fallback
-    if (typeof csconsole === "undefined") {
-        csconsole = new PopupConsoleHandler();
+        csconsole = new ElementConsoleHandler(csconsole);
+    } else {
+        // Default
+        csconsole = new NullConsoleHandler();
     }
 }
 

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -546,30 +546,6 @@ function ElementConsoleHandler(idOrElement) {
 
 ElementConsoleHandler.prototype = new GenericConsoleHandler();
 
-function PopupConsoleHandler() {
-
-    var popup = window.open('', '', 'width=200,height=100');
-    var body;
-
-    if (popup) {
-        body = popup.document.getElementsByTagName("body")[0];
-    }
-
-    this.append = function(s) {
-        if (body) {
-            body.appendChild(s);
-        }
-    };
-
-    this.clear = function() {
-        if (body) {
-            body.innerHTML = "";
-        }
-    };
-}
-
-PopupConsoleHandler.prototype = new GenericConsoleHandler();
-
 function NullConsoleHandler() {
 
     this.append = function(s) {

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -428,6 +428,8 @@ function setupConsole() {
         csconsole = new CindyConsoleHandler();
     } else if (typeof csconsole === "string") {
         csconsole = new ElementConsoleHandler(csconsole);
+    } else if (typeof csconsole === "object" && typeof csconsole.appendChild === "function") {
+        csconsole = new ElementConsoleHandler(csconsole);
     } else {
         // Default
         csconsole = new NullConsoleHandler();
@@ -526,9 +528,12 @@ function CindyConsoleHandler() {
 
 CindyConsoleHandler.prototype = new GenericConsoleHandler();
 
-function ElementConsoleHandler(id) {
+function ElementConsoleHandler(idOrElement) {
 
-    var element = document.getElementById(id);
+    var element = idOrElement;
+    if (typeof idOrElement === "string") {
+        element = document.getElementById(idOrElement);
+    }
 
     this.append = function(s) {
         element.appendChild(s);


### PR DESCRIPTION
These commits
* change the default from popup console to no console (i.e. only web developer console)
* make documentation and implementation agree better
* remove the popup console since it's dead code unless someone requests an API to activate it

This should fix #20.