### PR TITLE
Make sure that writing accessors only operate on geometric elements

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -450,7 +450,7 @@ evaluator._helper.assigntake = function(data, what) { //TODO: Bin nicht ganz sic
 evaluator._helper.assigndot = function(data, what) {
     var where = evaluate(data.obj);
     var field = data.key;
-    if (where && field) {
+    if (where.ctype === 'geo' && field) {
         Accessor.setField(where.value, field, what);
     }
 


### PR DESCRIPTION
This avoids exceptions in cases where the left hand side of the operation evaluates to something other than a geometric element.  In particular, if it is `nada`, then its value is undefined and accessing the kind of that will throw an exception.