### PR TITLE
Avoid exception when drawing undefined images

### DIFF
--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -207,7 +207,7 @@ evaluator.drawimage$2 = function(args, modifs) {
             return nada;
         }
         // console.lof(JSON.stringify(images));
-        if (images === undefined || images[img.value] === 'undefined')
+        if (images === undefined || images[img.value] === undefined)
             return;
         var w = images[img.value].width;
         var h = images[img.value].height;


### PR DESCRIPTION
This was likely a mixup, since either `foo === undefined` or `typeof foo === 'undefined'` could be used here.