### PR TITLE
Improve sourcemaps support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ closure_args_common = \
 closure_args_wrapper = \
 	$(closure_args_common)
 closure_args = \
-	--create_source_map $@.map \
+	--create_source_map $@.tmp.map \
 	--source_map_format V3 \
 	--source_map_location_mapping "build/js/|" \
 	--source_map_location_mapping "src/js/|../../src/js/" \
@@ -139,11 +139,14 @@ build/js/Cindy.plain.js build/js/ours.js build/js/exposed.js: \
 
 build/js/Cindy.closure.js: tools/compiler.jar build/js/Cindy.plain.js src/js/Cindy.js.wrapper tools/apply-source-map.js
 	$(CLOSURE) $(closure_args)
-	$(NODE_CMD) $(filter %tools/apply-source-map.js,$^) -f Cindy.js build/js/Cindy.plain.js.map build/js/Cindy.closure.js.map > build/js/Cindy.js.map
+	$(NODE_CMD) $(filter %tools/apply-source-map.js,$^) -f $(@F) \
+		build/js/Cindy.plain.js.map build/js/Cindy.closure.js.tmp.map \
+		> $@.map
 
 build/js/Cindy.js: build/js/Cindy.$(js_compiler).js
 	@echo 'last_js_compiler=$(js_compiler)' > build/js_compiler.mk
-	cp $< $@
+	sed 's,sourceMappingURL=$(<F).map,sourceMappingURL=$(@F).map,g' < $< > $@
+	sed 's,\("file": *\)"$(<F)",\1"$(@F)",g' < $<.map > $@.map
 
 -include build/js_compiler.mk
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "devDependencies": {
+    "concat-with-sourcemaps": "^1.0.4",
     "expect": "^1.9.0",
     "http-proxy": "^1.11.2",
     "js-beautify": "^1.5.10",
@@ -15,7 +16,8 @@
     "mocha": "^2.3.2",
     "rewire": "^2.3.4",
     "should": "^7.1.0",
-    "source-map": "^0.4.4"
+    "source-map": "^0.4.4",
+    "source-map-dummy": "^1.0.0"
   },
   "scripts": {
     "prepublish": "test -n \"$CINDYJS_BUILDING\" || { make clean && make && make alltests; }",

--- a/src/js/Cindy.js.wrapper
+++ b/src/js/Cindy.js.wrapper
@@ -4,4 +4,4 @@
  * for corresponding sources and their respective licensing conditions.
  */
 %output%
-//# sourceMappingURL=Cindy.js.map
+//# sourceMappingURL=Cindy.closure.js.map

--- a/tools/apply-source-map.js
+++ b/tools/apply-source-map.js
@@ -30,42 +30,10 @@ function open(path) {
   });
 }
 
-function myApplySourceMap(gen, con) {
-  gen._mappings.unsortedForEach(function (m) {
-    if (!m.originalLine) return;
-    console.log(m);
-    var orig = con.originalPositionFor(
-      {line: m.originalLine, column: 0});
-    if (orig.source == null) {
-      console.log(["Not found: ", m]);
-      return;
-    }
-    m.source = orig.source;
-    m.originalLine = orig.line;
-    m.originalColumn = orig.column;
-    if (orig.name != null)
-      m.name = orig.name;
-  });
-}
-
-function onlyLookupColumnZero(con) {
-  var original = con.originalPositionFor;
-  con.originalPositionFor = function(pos) {
-    var res = original.call(this, {line: pos.line, column: 0});
-    return {
-      source: res.source,
-      line: res.line,
-      column: pos.column,
-      name: null
-    };
-  };
-}
-
 function done() {
   var i = maps.length - 1;
   var generator = Generator.fromSourceMap(maps[i]);
   while (i-- > 0) {
-    onlyLookupColumnZero(maps[i]);
     generator.applySourceMap(maps[i]);
   }
   var map = generator.toJSON();

--- a/tools/prepare-deploy.js
+++ b/tools/prepare-deploy.js
@@ -11,9 +11,10 @@ var outDir = "build/deploy";
 var head = null;
 
 var handlers = {
-    "Cindy.closure.js": renameMain,
+    "Cindy.closure.js": false,
     "Cindy.closure.js.map": false,
-    "Cindy.js": false,
+    "Cindy.closure.js.tmp.map": false,
+    "Cindy.js": subst,
     "Cindy.js.map": map,
     "Cindy.plain.js": false,
     "Cindy.plain.js.map": false,
@@ -58,11 +59,11 @@ function lsDir(err, files) {
     });
 }
 
-function renameMain(name, err, content) {
+function subst(name, err, content) {
     if (err) throw err;
     content = content.toString();
     content = content.replace(/\$gitid\$/, head);
-    fs.writeFile(path.join(outDir, "Cindy.js"), content);
+    fs.writeFile(path.join(outDir, name), content);
 }
 
 var mapKeys = ["version", "file", "sourceRoot", "sources", "names", "mappings"];


### PR DESCRIPTION
Lately I've been somewhat disappointed by the fact that Chrome doesn't seem to be using our sourcemaps any more. Today I identified the main reasons for this, and set out to address them. The problem is caused by me usually using `make plain=1` when developing.