### PR TITLE
Check preinstalled version of Node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ DOWNLOAD=$(if $(CURL_CMD),$(CURL_CMD),$(if $(WGET_CMD),$(WGET_CMD),$(error curl 
 ######################################################################
 
 NODE_OS:=$(subst Darwin,darwin,$(subst Linux,linux,$(shell uname -s)))
-NODE_ARCH:=$(subst x86_64,x86,$(subst i386,x86,$(subst i686,x86,$(shell uname -m))))
+NODE_ARCH:=$(subst x86_64,x64,$(subst i386,x86,$(subst i686,x86,$(shell uname -m))))
 NODE_VERSION:=0.12.6
 NODE_URLBASE:=http://nodejs.org/dist
 NODE_TAR:=node-v$(NODE_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,15 @@ NODE_VERSION:=0.12.6
 NODE_URLBASE:=http://nodejs.org/dist
 NODE_TAR:=node-v$(NODE_VERSION)-$(NODE_OS)-$(NODE_ARCH).tar.gz
 NODE_URL:=$(NODE_URLBASE)/v$(NODE_VERSION)/$(NODE_TAR)
+
+NODE:=node
 NPM:=npm
-NPM_DEP:=$(shell $(NPM) -version > /dev/null 2>&1 || echo download/node/bin/npm)
+cmd_needed=$(shell $(1) >/dev/null 2>&1 || echo needed)
+NODE_NEEDED:=$(call cmd_needed,$(NODE) tools/check-node-version.js)
+NPM_NEEDED:=$(call cmd_needed,$(NPM) -version)
+NPM_DEP:=$(if $(NODE_NEEDED)$(NPM_NEEDED),download/node/bin/npm,)
 NODE_PATH:=PATH=node_modules/.bin:$(if $(NPM_DEP),$(dir $(NPM_DEP)):,)$$PATH
 NPM_CMD:=$(if $(NPM_DEP),$(NODE_PATH) npm,$(NPM))
-NODE:=node
 NODE_CMD:=$(if $(NPM_DEP),$(NODE_PATH) node,$(NODE))
 
 download/arch/$(NODE_TAR):

--- a/tools/check-node-version.js
+++ b/tools/check-node-version.js
@@ -1,0 +1,11 @@
+var v = process.version;
+v = v.replace(/^v/,"");
+v = v.split(".");
+v = v.map(function(s){
+  return parseInt(s);
+});
+if (v[0] > 0 || v[1] >= 12)
+  process.exit(0);
+
+console.error("Node 0.12 or later required. Version " + process.version + " found");
+process.exit(1);


### PR DESCRIPTION
This should address #43. It might also be more useful if we ever start using more advanced node features and have to raise our version requirements.

@strobelm, can you please test this with your Fedora? Preferably from a clean working tree, i.e. `git clean -idx`.