### PR TITLE
Detect degenerate situations

### DIFF
--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -535,6 +535,11 @@ List.maxIndex = function(lst, fun, startIdx) {
 List.normalizeMax = function(a) {
     var s = CSNumber.inv(List.maxval(a));
     if (!CSNumber._helper.isFinite(s)) return a;
+    var r = s.value.real, i = s.value.imag;
+    if (r * r + i * i > 1e17) {
+        degenerateSituationDetected();
+        s = CSNumber.zero;
+    }
     return List.scalmult(s, a);
 };
 

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -452,6 +452,20 @@ List._helper.isNaN = function(a1) {
     return erg;
 };
 
+List._helper.isFinite = function(a1) {
+    var erg = true;
+    for (var i = 0; i < a1.value.length; i++) {
+        var av1 = a1.value[i];
+
+        if (av1.ctype === 'list') {
+            erg = erg && List._helper.isFinite(av1);
+        } else {
+            erg = erg && CSNumber._helper.isFinite(av1);
+        }
+    }
+    return erg;
+};
+
 
 List.set = function(a1) {
     var erg = [];

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -535,7 +535,8 @@ List.maxIndex = function(lst, fun, startIdx) {
 List.normalizeMax = function(a) {
     var s = CSNumber.inv(List.maxval(a));
     if (!CSNumber._helper.isFinite(s)) return a;
-    var r = s.value.real, i = s.value.imag;
+    var r = s.value.real;
+    var i = s.value.imag;
     if (r * r + i * i > 1e17) {
         degenerateSituationDetected();
         s = CSNumber.zero;

--- a/src/js/libgeo/Tracing.js
+++ b/src/js/libgeo/Tracing.js
@@ -399,11 +399,11 @@ function tracing2core(n1, n2, o1, o2) {
             // Evil: modify can break copy on write! But it's safe here.
         };
     }
-    if (List._helper.isNaN(n1) || List._helper.isNaN(n2)) {
+    if (!(List._helper.isFinite(n1) && List._helper.isFinite(n2))) {
         // Something went very wrong, numerically speaking. We have no
         // clue whether refining will make things any better, so we
         // assume it won't and give up.
-        debug("Tracing failed due to NaNs.");
+        debug("Tracing failed due to NaNs or Infinity.");
         tracingFailed = true;
     } else if (do1o2 > cost * safety && dn1n2 > cost * safety) {
         // Distance within matching considerably smaller than distance
@@ -522,11 +522,11 @@ function tracing4core(n1, n2, n3, n4, o1, o2, o3, o4) {
 
     for (i = 0; i < 4; i++) {
         if (need_refine) break;
-        if (List._helper.isNaN(new_el[i])) {
+        if (!List._helper.isFinite(new_el[i])) {
             // Something went very wrong, numerically speaking. We have no
             // clue whether refining will make things any better, so we
             // assume it won't and give up.
-            debug("Tracing failed due to NaNs.");
+            debug("Tracing failed due to NaNs or Infinity.");
             tracingFailed = true;
             return res;
         }


### PR DESCRIPTION
_(Manually migrated from GitLab merge request 12 reported by @gagern)_

This here is an attempt to detect degenerate situations while tracing, in order to abort tracing and not end up with excessive amounts of refinements. It should fix #61.

This solution still feels slightly hackish, so I'll welcome any input on how to make it cleaner while still achieving its designated goal. @kranich, @strobelm: any ideas?

---

_(Comment originally by @gagern)_

I should have pointed out that @kanich already did contribute to this approach, so the idea of detecting degenerate situations right where they occur and throwing an exception was his. Still, I hope for some ideas on how to make this cleaner. If we don't come up with anything soon, we might still merge this as is, as long as we are convinced that it doesn't hurt. Are we?

---

_(Comment originally by @strobelm)_

If we follow this approach: Shouldn't we also check in `normalizeMax` whether we normalize by a maximum which is almost zero?

---

_(Comment by @kortenkamp removed since it might contain copyright-protected material)_

---

_(Comment originally by @strobelm)_

@kortenkamp Martin and i had a look on tracing4 and we were not quite sure how an object which was marked invalid is handled in the context of tracing. Could you give us a hint where the magic happens? ;-)
