### PR TITLE
Shift default origin by half a pixel

### DIFF
--- a/ref/Control_Operators.md
+++ b/ref/Control_Operators.md
@@ -201,76 +201,76 @@ This code fragment will draw a 3 × 3 array of points.
     > );
     D lineWidth = 1.2
     D beginPath()
-    D arc(275, 205, 4, 0, 6.283185307179586)
+    D arc(275.5, 204.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(275, 205, 4.6, 0, 6.283185307179586)
+    D arc(275.5, 204.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D strokeStyle = "rgb(0,0,0)"
     D stroke()
     D beginPath()
-    D arc(275, 180, 4, 0, 6.283185307179586)
+    D arc(275.5, 179.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(275, 180, 4.6, 0, 6.283185307179586)
+    D arc(275.5, 179.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D stroke()
     D beginPath()
-    D arc(275, 155, 4, 0, 6.283185307179586)
+    D arc(275.5, 154.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(275, 155, 4.6, 0, 6.283185307179586)
+    D arc(275.5, 154.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D stroke()
     D beginPath()
-    D arc(300, 205, 4, 0, 6.283185307179586)
+    D arc(300.5, 204.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(300, 205, 4.6, 0, 6.283185307179586)
+    D arc(300.5, 204.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D stroke()
     D beginPath()
-    D arc(300, 180, 4, 0, 6.283185307179586)
+    D arc(300.5, 179.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(300, 180, 4.6, 0, 6.283185307179586)
+    D arc(300.5, 179.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D stroke()
     D beginPath()
-    D arc(300, 155, 4, 0, 6.283185307179586)
+    D arc(300.5, 154.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(300, 155, 4.6, 0, 6.283185307179586)
+    D arc(300.5, 154.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D stroke()
     D beginPath()
-    D arc(325, 205, 4, 0, 6.283185307179586)
+    D arc(325.5, 204.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(325, 205, 4.6, 0, 6.283185307179586)
+    D arc(325.5, 204.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D stroke()
     D beginPath()
-    D arc(325, 180, 4, 0, 6.283185307179586)
+    D arc(325.5, 179.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(325, 180, 4.6, 0, 6.283185307179586)
+    D arc(325.5, 179.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D stroke()
     D beginPath()
-    D arc(325, 155, 4, 0, 6.283185307179586)
+    D arc(325.5, 154.5, 4, 0, 6.283185307179586)
     D fillStyle = "rgb(255,200,0)"
     D fill()
     D beginPath()
-    D arc(325, 155, 4.6, 0, 6.283185307179586)
+    D arc(325.5, 154.5, 4.6, 0, 6.283185307179586)
     D fillStyle = "rgb(0,0,0)"
     D stroke()
 

--- a/ref/Texts_and_Tables.md
+++ b/ref/Texts_and_Tables.md
@@ -46,34 +46,34 @@ The code
     > )
     D fillStyle = "rgba(229,0,25,1)"
     D font = "bold 17px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 275.5, 229.5)
     D fillStyle = "rgba(204,0,51,1)"
     D font = "bold 19px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 300.5, 229.5)
     D fillStyle = "rgba(178,0,76,1)"
     D font = "bold 21px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 325.5, 229.5)
     D fillStyle = "rgba(153,0,102,1)"
     D font = "bold 23px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 350.5, 229.5)
     D fillStyle = "rgba(127,0,127,1)"
     D font = "bold 25px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 375.5, 229.5)
     D fillStyle = "rgba(101,0,153,1)"
     D font = "bold 27px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 400.5, 229.5)
     D fillStyle = "rgba(76,0,178,1)"
     D font = "bold 29px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 425.5, 229.5)
     D fillStyle = "rgba(50,0,204,1)"
     D font = "bold 31px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 450.5, 229.5)
     D fillStyle = "rgba(25,0,229,1)"
     D font = "bold 33px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 475.5, 229.5)
     D fillStyle = "rgba(0,0,255,1)"
     D font = "bold 35px Arial"
-    D fillText("Text", null, 229.5)
+    D fillText("Text", 500.5, 229.5)
 
 produces the picture below.
 
@@ -91,7 +91,7 @@ By this it is easy to produce multilined text, as the following piece of code sh
     > multilined text.")
     D fillStyle = "rgb(0,0,0)"
     D font = "18px Arial"
-    D fillText("In Cinderella 'newlines' in Text\nare really used as line terminators.\nSo this text will appear as a\nmultilined text.", null, 229.5)
+    D fillText("In Cinderella 'newlines' in Text\nare really used as line terminators.\nSo this text will appear as a\nmultilined text.", 250.5, 229.5)
 
 | ![Image](img/Newlines.png) |
 | -------------------------- |

--- a/ref/Texts_and_Tables.md
+++ b/ref/Texts_and_Tables.md
@@ -46,34 +46,34 @@ The code
     > )
     D fillStyle = "rgba(229,0,25,1)"
     D font = "bold 17px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(204,0,51,1)"
     D font = "bold 19px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(178,0,76,1)"
     D font = "bold 21px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(153,0,102,1)"
     D font = "bold 23px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(127,0,127,1)"
     D font = "bold 25px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(101,0,153,1)"
     D font = "bold 27px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(76,0,178,1)"
     D font = "bold 29px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(50,0,204,1)"
     D font = "bold 31px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(25,0,229,1)"
     D font = "bold 33px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
     D fillStyle = "rgba(0,0,255,1)"
     D font = "bold 35px Arial"
-    D fillText("Text", null, 230)
+    D fillText("Text", null, 229.5)
 
 produces the picture below.
 
@@ -91,7 +91,7 @@ By this it is easy to produce multilined text, as the following piece of code sh
     > multilined text.")
     D fillStyle = "rgb(0,0,0)"
     D font = "18px Arial"
-    D fillText("In Cinderella 'newlines' in Text\nare really used as line terminators.\nSo this text will appear as a\nmultilined text.", null, 230)
+    D fillText("In Cinderella 'newlines' in Text\nare really used as line terminators.\nSo this text will appear as a\nmultilined text.", null, 229.5)
 
 | ![Image](img/Newlines.png) |
 | -------------------------- |

--- a/ref/js/runtests.js
+++ b/ref/js/runtests.js
@@ -271,7 +271,9 @@ FakeCanvas.prototype.writeLog = function(methodName, args) {
                  map.call(args, JSON.stringify).join(", ") + ")");
 };
 FakeCanvas.prototype.measureText = function(txt) {
-  return 8*txt.length;
+  return {
+      width: 8*txt.length,
+  };
 };
 [ "arc",
   "beginPath",

--- a/src/js/libgeo/GeoState.js
+++ b/src/js/libgeo/GeoState.js
@@ -18,8 +18,8 @@ csport.drawingstate.matrix.a = 25;
 csport.drawingstate.matrix.b = 0;
 csport.drawingstate.matrix.c = 0;
 csport.drawingstate.matrix.d = 25;
-csport.drawingstate.matrix.tx = 250;
-csport.drawingstate.matrix.ty = 250;
+csport.drawingstate.matrix.tx = 250.5;
+csport.drawingstate.matrix.ty = 250.5;
 csport.drawingstate.matrix.det = csport.drawingstate.matrix.a * csport.drawingstate.matrix.d - csport.drawingstate.matrix.b * csport.drawingstate.matrix.c;
 
 csport.drawingstate.matrix.sdet = Math.sqrt(csport.drawingstate.matrix.det);


### PR DESCRIPTION
By shifting the default position of the origin, integer user coordinates have a higher chance of ending up at the center of a pixel, as opposed to the corner of a pixel.

This will affect constructions which use the default coordinate system, as well as those which apply relative transformations to that default, like `scale` and `translate`.  Absolute transformations like `scaleAndOrigin` and `visibleRect` are not affected.

This addresses #31.

Since this is an *incompatible* change, I'd like an OK from Jürgen @richter-gebert on this. Can we just change the default, adjusting any existing content which relies on pixel-exact positioning using the old defaults?