### PR TITLE
Shift mouse position by half a pixel

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -114,8 +114,8 @@ function setuplisteners(canvas, data) {
 
     function updatePostition(event) {
         var rect = canvas.getBoundingClientRect();
-        var x = event.clientX - rect.left - canvas.clientLeft;
-        var y = event.clientY - rect.top - canvas.clientTop;
+        var x = event.clientX - rect.left - canvas.clientLeft + 0.5;
+        var y = event.clientY - rect.top - canvas.clientTop + 0.5;
         var pos = csport.to(x, y);
         mouse.prevx = mouse.x;
         mouse.prevy = mouse.y;


### PR DESCRIPTION
Compared to the drawing coordinate system, where integer coordinates represent corners of pixels, the input coordinate system is shifted by half a pixel so that integer coordinates represent centers of pixels.  Here we make this shift explicit, transforming input coordinates to the drawing coordinate system.

The need for this modification was first discussed in #31. This complements the shift in origin position introduced in #59.