### PR TITLE
Format angles as degrees by default

### DIFF
--- a/ref/Arithmetic_Operators.md
+++ b/ref/Arithmetic_Operators.md
@@ -121,9 +121,18 @@ For noninteger values of `b` only one principal value of `a^b` will be returned.
 
 This operator multiplies any number by the constant `pi/180` .
 This makes possible angle conversion from degrees to radians.
+Note that angles will be printed in degrees by default.
 
     > 180°
+    < 180°
+    > 180° + 0
     < 3.1416
+    > 180° / 3
+    < 60°
+    > 0.5 * 180°
+    < 90°
+    > 20° + 30°
+    < 50°
     > cos(180°)
     < -1
 
@@ -246,13 +255,7 @@ However, the operator returns only one principal value, for which the real value
     > sin(pi) // almost zero except for numerics
     < 0
     > arccos(-1)
-    < 3.1416
-    > arctan2(1,1) ~= 45°
-    < true
-    > arctan2(-1,-1) ~= -135°
-    < true
-
-    - skip test: printing of angles in degrees not implemented.
+    < 180°
     > arctan2(1,1)
     < 45°
     > arctan2(-1,-1)

--- a/src/js/libcs/CSNumber.js
+++ b/src/js/libcs/CSNumber.js
@@ -11,6 +11,9 @@ CSNumber._helper.niceround = function(a) {
 };
 
 CSNumber.niceprint = function(a) {
+    if (a.usage === "Angle") {
+        return CSNumber._helper.niceangle(a);
+    }
     var real = CSNumber._helper.niceround(a.value.real);
     var imag = CSNumber._helper.niceround(a.value.imag);
     if (imag === 0) {
@@ -22,6 +25,38 @@ CSNumber.niceprint = function(a) {
     } else {
         return "" + real + " - i*" + (-imag);
     }
+};
+
+var angleUnit = instanceInvocationArguments.angleUnit || "°";
+var angleUnitName = angleUnit.replace(/\s+/g, ""); // unit may contain space
+var TWOPI = Math.PI * 2;
+var PERTWOPI = 1 / TWOPI;
+var angleUnits = {
+    "rad": TWOPI,
+    "°": 360,
+    "deg": 360,
+    "degree": 360,
+    "gra": 400,
+    "grad": 400,
+    "turn": 1,
+    "cyc": 1,
+    "rev": 1,
+    "rot": 1,
+    "π": 2,
+    "pi": 2,
+    "quad": 4,
+};
+
+CSNumber._helper.niceangle = function(a) {
+    var unit = angleUnits[angleUnitName];
+    if (!unit)
+        return CSNumber.niceprint(General.withUsage(a, null));
+    if (typeof unit === "function")
+        return unit(a);
+    var num = CSNumber.niceprint(CSNumber.realmult(unit * PERTWOPI, a));
+    if (num.indexOf("i*") === -1)
+        return num + angleUnit;
+    return "(" + num + ")" + angleUnit;
 };
 
 CSNumber.complex = function(r, i) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -717,7 +717,7 @@ function postfix_numb_degree(args, modifs) {
     var v1 = evaluateAndVal(args[1]);
 
     if (v0.ctype === 'number' && v1.ctype === 'void') {
-        return CSNumber.mult(v0, CSNumber.real(Math.PI / 180));
+        return General.withUsage(CSNumber.realmult(Math.PI / 180, v0), "Angle");
     }
 
     return nada;
@@ -947,7 +947,10 @@ evaluator.add$2 = infix_add;
 function infix_add(args, modifs) {
     var v0 = evaluateAndVal(args[0]);
     var v1 = evaluateAndVal(args[1]);
-    return General.add(v0, v1);
+    var erg = General.add(v0, v1);
+    if (v0.usage === "Angle" && v1.usage === "Angle")
+        erg = General.withUsage(erg, "Angle");
+    return erg;
 }
 
 evaluator.sub$2 = infix_sub;
@@ -955,7 +958,10 @@ evaluator.sub$2 = infix_sub;
 function infix_sub(args, modifs) {
     var v0 = evaluateAndVal(args[0]);
     var v1 = evaluateAndVal(args[1]);
-    return General.sub(v0, v1);
+    var erg = General.sub(v0, v1);
+    if (v0.usage === "Angle" && v1.usage === "Angle")
+        erg = General.withUsage(erg, "Angle");
+    return erg;
 }
 
 evaluator.mult$2 = infix_mult;
@@ -963,7 +969,12 @@ evaluator.mult$2 = infix_mult;
 function infix_mult(args, modifs) {
     var v0 = evaluateAndVal(args[0]);
     var v1 = evaluateAndVal(args[1]);
-    return General.mult(v0, v1);
+    var erg = General.mult(v0, v1);
+    if (v0.usage === "Angle" && !v1.usage)
+        erg = General.withUsage(erg, "Angle");
+    else if (v1.usage === "Angle" && !v0.usage)
+        erg = General.withUsage(erg, "Angle");
+    return erg;
 }
 
 evaluator.div$2 = infix_div;
@@ -971,7 +982,12 @@ evaluator.div$2 = infix_div;
 function infix_div(args, modifs) {
     var v0 = evaluateAndVal(args[0]);
     var v1 = evaluateAndVal(args[1]);
-    return General.div(v0, v1);
+    var erg = General.div(v0, v1);
+    if (v0.usage === "Angle" && !v1.usage)
+        erg = General.withUsage(erg, "Angle");
+    else if (v1.usage === "Angle" && !v0.usage)
+        erg = General.withUsage(erg, "Angle");
+    return erg;
 }
 
 


### PR DESCRIPTION
Now we're making use of the `usage: "Angle"` setting which might have been applied to some numbers, and format the resulting numbers using degrees instead of radians by default.  There is an instance argument called `angleUnit` which might be used to override that default.  Various units are already defined, using the turn as the unit of reference.

For future extensions, it's already possible to enter a special formatting function into that list.  Such a function could conceivably be used to e.g. format a number as degrees, minutes and seconds.  That isn't supported yet, though, at the time of this writing. Depending on how long the review takes on this, I might add additional commits to take care of that, but if I do I'd also like to extend the testing framework so we can actually unit-test such things.

This fixes #17.