### PR TITLE
Only update content when mouse actually moved

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -123,6 +123,7 @@ function setuplisteners(canvas, data) {
         mouse.y = pos[1];
         csmouse[0] = mouse.x;
         csmouse[1] = mouse.y;
+        mouse.moved = true;
     }
 
     if (data.keylistener === true) {
@@ -236,7 +237,10 @@ function doit() { //Callback for d3-timer
     if (csanimating) {
         cs_tick();
     }
-    updateCindy();
+    if (csanimating || mouse.moved) {
+        mouse.moved = false;
+        updateCindy();
+    }
     csticking = csanimating || mouse.down;
     return !csticking;
 }


### PR DESCRIPTION
So far we run `updateCindy` continuously as long as the mouse button is held down.  This can e.g. lead to traces decaying faster than they would in Cinderella.  With these modifications, we only update the content if the mouse actually moved, leading to improved compatibility and more efficient use of resources.  The timer is still ticking all the time while the button is down, which might be addressed at a later point.

This fixes #38.