### PR TITLE
Treat strings as literals when calling the replace operator

### DIFF
--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -144,6 +144,10 @@ This operator is extremely useful for creating text replacement systems of the k
     < "F+F"
     > replace("F+F", "F", "F+F")
     < "F+F+F+F"
+    > replace("3*$ + 4", "$", "x")
+    < "3*x + 4"
+    > replace("1\2", "\", "$&")
+    < "1$&2"
 
 ------
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -2322,8 +2322,8 @@ evaluator.replace$3 = function(args, modifs) {
     var v2 = evaluate(args[2]);
     if (v0.ctype === 'string' && v1.ctype === 'string' && v2.ctype === 'string') {
         var str0 = v0.value;
-        var str1 = v1.value;
-        var str2 = v2.value;
+        var str1 = v1.value.replace(/[^A-Za-z0-9]/g, "\\$&");
+        var str2 = v2.value.replace(/\$/g, "$$$$");
         var regex = new RegExp(str1, "g");
         str0 = str0.replace(regex, str2);
         return {


### PR DESCRIPTION
We have to call String.prototype.replace with a RegExp as its first argument
because we need the `g` (global) flag.  Otherwise we'd only be replacing the
first occurrence.  But we don't want to interpret the string as a regular
expression, but treat it literally.  So we have to backslash-escape any
characters which might have special meaning in a regular expression.  Which
means any non-alphanumeric character, just to be on the safe side.

We also have to make sure that the replacement string is interpreted
literally, without the special meaning of sequences starting in `$`.  We
achieve this by doubling any `$` encountered in that string.