### PR TITLE
Publish snapshots to cinderella.de

### DIFF
--- a/tools/travis-deploy.sh
+++ b/tools/travis-deploy.sh
@@ -9,6 +9,10 @@ set -x
 eval "$(ssh-agent -s)"
 ssh-add build/travis-ssh
 rm build/travis-ssh
+
+rsync --delete-delay -rci --rsh='ssh -l travis' \
+    build/deploy/ cinderella.de::CindyJS/snapshot/
+
 name=$(git describe --always)
 preserve=(.git README.md LICENSE)
 branch=snapshot


### PR DESCRIPTION
GitHub [doesn't like linking to JavaScript inside repositories](https://github.com/blog/1482-heads-up-nosniff-header-support-coming-to-chrome-and-firefox). So the current approach using the [`deploy` repository](https://github.com/CindyJS/deploy) may still have some use in distributing built versions, quickly bisecting over these, and the likes. But we shouldn't be using it as the main method of linking to CindyJS sources.

Instead we should use some other hosting, and it makes sense to use `cinderella.de` for this purpose. I've set up an `ssh`-enabled user account there with an `rsync` module called `CindyJS`. Pushing to the `snapshot` directory of that module will create a new snapshot, while pushing to a path like `v1.17.5` will create a release of the corresponding name. We'll automatically get redirects like `v1.17` and `v1` for the above. And we'll get a `latest` redirect which will point at the latest (i.e. highest version number) released version but at `snapshots` if there were no releases yet. We can start using that today:

http://cinderella.de/CindyJS/latest/Cindy.js

The pull request at hand should take care of automatically updating the files via rsync, using the same ssh key we use for deployment to the GitHub `deploy` repository. Uploading tagged releases will have to come at a later time.