### PR TITLE
Make drawing of traces more consistent with Cinderella

### DIFF
--- a/examples/106_DrawTrace1.html
+++ b/examples/106_DrawTrace1.html
@@ -22,7 +22,7 @@ var cdy = createCindy({
     transform: [{visibleRect: [-9.04, 9.32, 18.16, -4.12]}]
   }],
   geometry: [
-    {name: "A", type: "Free", pos: [0, 0], trace: true, tracedim: 1, tracelength: 200, traceskip: 1},
+    {name: "A", type: "Free", pos: [0, 0], drawtrace: true, tracedim: 1, tracelength: 200, traceskip: 1},
     {name: "B", type: "Free", pos: [1, 1], size: 8, color: [1, 1, 0]},
     {name: "c", type: "Through", args: ["B"], dir: [1, 0, 0]}
   ]

--- a/examples/106_DrawTrace2.html
+++ b/examples/106_DrawTrace2.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Construction.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="http://cinderella.de/CJS/build/js/Cindy-dev.js"></script>
+
+    <script type="text/javascript">
+createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: { pointSize: 5.0, fontFamily: "sans-serif", lineSize: 1.0 }, 
+	angleUnit: "°", 
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ 4.0, 0.8403361344537815, 0.8403361344537815 ], color: [ 1.0, 0.0, 0.0 ], drawtrace: true, tracelength: 34, traceskip: 10, tracedim: 0.38461538461538464, labeled: true } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 680, height: 336, transform: [ { visibleRect: [ -9.06, 9.34, 18.14, -4.1 ] } ], background: "rgb(168,176,192)" } ], 
+	cinderella: { build: 1793, version: [ 2, 9, 1793 ] } });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -169,13 +169,13 @@ function pointDefault(el) {
     if (el.alpha === undefined) el.alpha = defaultAppearance.alpha;
     el.alpha = CSNumber.real(el.alpha);
 
-    if (el.trace) {
-        el._traces = [];
-        el._traces_tick = 0;
-
+    if (el.drawtrace) {
         if (typeof el.tracedim === "undefined") el.tracedim = 1;
         if (typeof el.tracelength === "undefined") el.tracelength = 100;
         if (typeof el.traceskip === "undefined") el.traceskip = 1;
+        el._traces = new Array(el.tracelength);
+        el._traces_index = 0;
+        el._traces_tick = 0;
     }
 }
 

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -203,7 +203,7 @@ function draw_traces() {
     }
 
     function drawIt() {
-        var lev = k++ / el._traces.length;
+        var lev = k++/ el._traces.length;
         var pos = el._traces[j];
         if (pos) {
             var alpha = elAlpha * lev * lev * lev;

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -179,29 +179,40 @@ function draw_traces() {
     for (var i = 0; i < csgeo.points.length; i++) {
         var el = csgeo.points[i];
 
-        if (el.trace) {
-            if (el._traces_tick % el.traceskip === 0) {
-                el._traces.push(el.homog);
-            }
-
+        if (!el.drawtrace) continue;
+        if (el._traces_tick === el.traceskip) {
+            el._traces[el._traces_index] = el.homog;
+            el._traces_index = (el._traces_index + 1) % el._traces.length;
+            el._traces_tick = 0;
+        } else {
             el._traces_tick++;
-
-            if (el._traces.length > el.tracelength) {
-                el._traces.shift();
-            }
-
-            var antiDamp = 1.03;
-            var elAlpha = el.alpha.value.real;
-            var alpha = elAlpha * Math.pow(antiDamp, -el._traces.length);
-
-            for (var j = 0; j < el._traces.length; j++) {
-                evaluator.draw$1([el._traces[j]], {
-                    size: el.size,
-                    color: el.color,
-                    alpha: CSNumber.real(alpha)
-                });
-                alpha *= antiDamp;
-            }
         }
+
+        var elAlpha = el.alpha.value.real;
+        var size = el.size.value.real;
+        var dimfactor = 1;
+        if (el.tracedim !== 1) {
+            size *= el.tracedim;
+            dimfactor = Math.pow(el.tracedim, -1 / el._traces.length);
+        }
+        var j, k = 0;
+        for (j = el._traces_index; j < el._traces.length; ++j)
+            drawIt();
+        for (j = 0; j < el._traces_index; ++j)
+            drawIt();
+    }
+
+    function drawIt() {
+        var lev = k++ / el._traces.length;
+        var pos = el._traces[j];
+        if (pos) {
+            var alpha = elAlpha * lev * lev * lev;
+            evaluator.draw$1([pos], {
+                size: CSNumber.real(size),
+                color: el.color,
+                alpha: CSNumber.real(alpha)
+            });
+        }
+        size *= dimfactor;
     }
 }


### PR DESCRIPTION
Now we implement the cubic alpha dimming and the dimension change in the same way `CubicAlphaAgingRenderer` does things in Cinderella.

The property in the geometry list was renamed from `trace` to `drawtrace`. That's what Cinderella exports already, and it's more descriptive and less likely to be confused with the topic of complex tracing around singularities. This name change earned the pull request an “incompatible” lable, though. I hope there is not too much content relying on the old name.

The storage for past trace positions was changed from a list with endpoint modifications to a list of fixed length with cyclical index.  [Tests](http://jsperf.com/shift-register/2) suggests that this should be orders of magnitude better than what we had, and it also avoids trouble due to a varying list length.