### PR TITLE
Restore drawing of clipped lines

### DIFF
--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -80,20 +80,30 @@ function render() {
         if (!el.isshowing || el.visible === false || !List._helper.isAlmostReal(el.homog))
             return;
 
-        if (el.clip.value === "none") {
-            evaluator.draw$1([el.homog], {
-                size: el.size,
-                color: el.color,
-                alpha: el.alpha
-            });
-        } else if (el.clip.value === "end") {
+        if (el.kind === "S") {
+            // Segments always join their endpoints.
             evaluator.draw$2(
                 [el.startpos, el.endpos], {
                     size: el.size,
                     color: el.color,
                     alpha: el.alpha
                 });
-        } else if (el.clip.value === "inci") {
+            return;
+        }
+        if (el.clip.value === "end" && el.type === "Join") {
+            // Lines clipped to their defining points join these.
+            pt1 = csgeo.csnames[el.args[0]];
+            pt2 = csgeo.csnames[el.args[1]];
+            evaluator.draw$2(
+                [pt1.homog, pt2.homog], {
+                    size: el.size,
+                    color: el.color,
+                    alpha: el.alpha
+                });
+            return;
+        }
+        if (el.clip.value === "inci") {
+            // Figuring out incident points here.
             var li = [];
             var xmin = [+1000000, 0];
             var xmax = [-1000000, 0];
@@ -140,18 +150,16 @@ function render() {
                         alpha: el.alpha,
                         overhang: el.overhang
                     });
-            } else {
-                evaluator.draw$1(
-                    [el.homog], {
-                        size: el.size,
-                        color: el.color,
-                        alpha: el.alpha
-                    });
+                return;
             }
-        } else {
-            console.error(["Bad clip: ", el.clip]);
+            // otherwise fall through
         }
-
+        // Default: draw an unclipped line
+        evaluator.draw$1([el.homog], {
+            size: el.size,
+            color: el.color,
+            alpha: el.alpha
+        });
     }
 
     var i;


### PR DESCRIPTION
While we use startpos and endpos to draw segments, we stick to using the defining points when drawing a line clipped to its defining points.

I broke this in ee4954cdd4ac278c12778119ca187c5df585e474 but since 47f4826ca74d38eab7fa404b1ee6c6f2cd338a25 moved code between files since then, there is little point in basing the fix on the former.