### PR TITLE
Remind developer to adjust URL after export from Cinderella

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,7 @@ forbidden:
 	! grep -Ero "<script[^>]*type *= *[\"'][^\"'/]*[\"']" examples
 	! grep -Ero "<script[^>]*type *= *[\"']text/cindyscript[\"']" examples
 	! grep -Er "firstDrawing" examples
+	! grep -Er 'cinderella\.de/.*/Cindy.*\.js' examples
 
 tests: forbidden
 

--- a/examples/108_DashType.html
+++ b/examples/108_DashType.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-    <script type="text/javascript" src="http://cinderella.de/CJS/build/js/Cindy-dev.js"></script>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
 createCindy({ 
 	scripts: "cs*", 


### PR DESCRIPTION
Since I've now for the second time committed an example exported from Cinderella which was still referring to the Cindy.js file on the Cinderella webserver, I feel that I might need some technical help to avoid this in the future.