### PR TITLE
Remove duplicates in List.js issue #88

### DIFF
--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -157,25 +157,6 @@ List.triples = function(a) {
     };
 };
 
-List.triples = function(a) {
-    var erg = [];
-    for (var i = 0; i < a.value.length - 2; i++) {
-        for (var j = i + 1; j < a.value.length - 1; j++) {
-            for (var k = j + 1; k < a.value.length; k++) {
-                erg.push({
-                    'ctype': 'list',
-                    'value': [a.value[i], a.value[j], a.value[k]]
-                });
-            }
-        }
-    }
-    return {
-        'ctype': 'list',
-        'value': erg
-    };
-};
-
-
 List.cycle = function(a) {
     var erg = [];
     for (var i = 0; i < a.value.length - 1; i++) {
@@ -339,14 +320,6 @@ List.remove = function(a, b) {
         'ctype': 'list',
         'value': erg
     };
-};
-
-List._helper.compare = function(a, b) {
-    if (a.ctype === 'number' && b.ctype === 'number') {
-        return a.value.real - b.value.real;
-    }
-    return -1;
-
 };
 
 List.sort1 = function(a) {


### PR DESCRIPTION
This change removes the second occurrence of List.triples which is an exact duplicate. It has been been there since its introduction in @a1ef53ba91e39125def81c14aa2374594b152a00. 

Opportunistically it also removes the first occurrence of List._helper.compare which expects to be passed a number, whereas the second occurrence handles a List which is exactly what the only call to List._helper.compare anywhere (shown here) passes to it:
```javascript
General.compare = function(a, b) {
...
    if (a.ctype === 'list') {
        return List._helper.compare(a, b);
    }
```