### PR TITLE
Implements CSNumber._helper.input

### DIFF
--- a/examples/ConstructionRadicalAxisApart-complex.html
+++ b/examples/ConstructionRadicalAxisApart-complex.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>ConstructionRadicalAxisApart.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+    <script type="text/javascript">
+createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: { dimDependent: 0.7 },
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ 4.0, -3.0, -1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C0", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.0, args: [ "A" ], size: 1, printname: "$C_{0}$" }, 
+		{ name: "B", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C1", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.0, args: [ "B" ], size: 1, printname: "$C_{1}$" }, 
+		{ name: "Collection__1", type: "IntersectionCircleCircle", args: [ "C0", "C1" ] }, 
+		{ name: "C", type: "SelectP", pos: [ -3.0, -4.0, { r: -7.654042494670958E-17, i: 1.25 } ], color: [ 1.0, 0.0, 0.0 ], args: [ "Collection__1" ], labeled: true }, 
+		{ name: "D", type: "SelectP", pos: [ -3.0, -4.0, { r: 7.654042494670958E-17, i: -1.25 } ], color: [ 1.0, 0.0, 0.0 ], args: [ "Collection__1" ], labeled: true }, 
+		{ name: "a", type: "Join", pos: [ 4.0, -3.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "C", "D" ], labeled: true, size: 1 } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 680, height: 350, transform: [ { visibleRect: [ -14.12, 7.0, 13.08, -7.0 ] } ], background: "rgb(168,176,192)" } ] });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/examples/ConstructionRadicalAxisApart-index.html
+++ b/examples/ConstructionRadicalAxisApart-index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>ConstructionRadicalAxisApart.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+    <script type="text/javascript">
+createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: { dimDependent: 0.7 },
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ 4.0, -3.0, -1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C0", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.0, args: [ "A" ], size: 1, printname: "$C_{0}$" }, 
+		{ name: "B", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C1", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.0, args: [ "B" ], size: 1, printname: "$C_{1}$" }, 
+		{ name: "Collection__1", type: "IntersectionCircleCircle", args: [ "C0", "C1" ] }, 
+		{ name: "C", type: "SelectP", index: 1, color: [ 1.0, 0.0, 0.0 ], args: [ "Collection__1" ], labeled: true }, 
+		{ name: "D", type: "SelectP", index: 2, color: [ 1.0, 0.0, 0.0 ], args: [ "Collection__1" ], labeled: true }, 
+		{ name: "a", type: "Join", pos: [ 4.0, -3.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "C", "D" ], labeled: true, size: 1 } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 680, height: 350, transform: [ { visibleRect: [ -14.12, 7.0, 13.08, -7.0 ] } ], background: "rgb(168,176,192)" } ] });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/examples/ConstructionRadicalAxisApart.html
+++ b/examples/ConstructionRadicalAxisApart.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>ConstructionRadicalAxisApart.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+    <script type="text/javascript">
+createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: { dimDependent: 0.7 },
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ 4.0, -3.0, -1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C0", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.0, args: [ "A" ], size: 1, printname: "$C_{0}$" }, 
+		{ name: "B", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C1", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.0, args: [ "B" ], size: 1, printname: "$C_{1}$" }, 
+		{ name: "Collection__1", type: "IntersectionCircleCircle", args: [ "C0", "C1" ] }, 
+		{ name: "C", type: "SelectP", pos: [ -3.0, -4.0, -7.654042494670958E-17 ], color: [ 1.0, 0.0, 0.0 ], args: [ "Collection__1" ], labeled: true }, 
+		{ name: "D", type: "SelectP", pos: [ -3.0, -4.0, 7.654042494670958E-17 ], color: [ 1.0, 0.0, 0.0 ], args: [ "Collection__1" ], labeled: true }, 
+		{ name: "a", type: "Join", pos: [ 4.0, -3.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "C", "D" ], labeled: true, size: 1 } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 680, height: 350, transform: [ { visibleRect: [ -14.12, 7.0, 13.08, -7.0 ] } ], background: "rgb(168,176,192)" } ] });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/src/js/libcs/CSNumber.js
+++ b/src/js/libcs/CSNumber.js
@@ -83,6 +83,17 @@ CSNumber.zero = CSNumber.real(0);
 
 CSNumber.one = CSNumber.real(1);
 
+CSNumber._helper.input = function(a) {
+    var r = 0;
+    var i = 0;
+    if (typeof a === "number") r = a;
+    else if (typeof a === "object") {
+        if (typeof a.r === "number") r = a.r;
+        if (typeof a.i === "number") i = a.i;
+    }
+    return CSNumber.complex(r, i);
+};
+
 CSNumber.argmax = function(a, b) {
     var n1 = a.value.real * a.value.real + a.value.imag * a.value.imag;
     var n2 = b.value.real * b.value.real + b.value.imag * b.value.imag;

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1487,7 +1487,11 @@ geoOps._helper.initializePoint = function(el) {
             sz = el.pos[2];
         }
     }
-    var pos = List.realVector([sx, sy, sz]);
+    var pos = List.turnIntoCSList([
+        CSNumber._helper.input(sx),
+        CSNumber._helper.input(sy),
+        CSNumber._helper.input(sz)
+    ]);
     pos = List.normalizeMax(pos);
     return pos;
 };


### PR DESCRIPTION
CSNumber._helper.input(a) can be used to convert a plain real number or an object of the form `{ r: number, i: number }` to a CSNumber. Intended for use in allowing pos and other values to be input as complex numbers as well as real numbers. For example:
` pos: [ -3.0, -4.0, { r: -7.654042494670958E-17, i: 1.25 } ]`