### PR TITLE
Implementation of LineByFixedAngle type

### DIFF
--- a/examples/ConstructionLineByFixedAngle.html
+++ b/examples/ConstructionLineByFixedAngle.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>ConstructionLineByFixedAngle.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+    <script type="text/javascript">
+createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: {}, angle: 10 * Math.PI / 180,
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ -2.0, -4.0, 2.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "a", type: "Through", pos: [ -2.4, 3.2, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "A" ], labeled: true, size: 1 }, 
+		{ name: "B", type: "PointOnLine", pos: [ 4.0, 2.285714285714285, 0.5714285714285714 ], color: [ 1.0, 0.0, 0.0 ], args: [ "a" ], labeled: true }, 
+		{ name: "b", type: "LineByFixedAngle", pos: [ -1.2296635084326417, 1.1519111397571236, 4.0 ], angle: 10 * Math.PI / 180, color: [ 1.0, 1.0, 0.0 ], args: [ "a", "B" ], labeled: true, size: 1 }, 
+		{ name: "c", type: "LineByFixedAngle", pos: [ -0.7148945654344956, 2.3574472827172475, 4.0 ], angle: -20 * Math.PI / 180, color: [ 0.0, 1.0, 1.0 ], args: [ "a", "A" ], labeled: true, size: 1 } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 680, height: 350, transform: [ { visibleRect: [ -9.04, 9.32, 18.16, -4.68 ] } ], background: "rgb(168,176,192)" } ] });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -176,17 +176,18 @@ geoOps.LineByFixedAngle.initialize = function(el) {
     var a = CSNumber._helper.input(el.angle);
     var c = CSNumber.cos(a);
     var s = CSNumber.sin(a);
+    // Setup matrix for applying the angle rotation
     el.rot = List.turnIntoCSList([
-        List.turnIntoCSList([s, c]),
-        List.turnIntoCSList([CSNumber.neg(c), s])
+        List.turnIntoCSList([c, CSNumber.neg(s), CSNumber.zero]),
+        List.turnIntoCSList([s, c, CSNumber.zero]),
+        List.turnIntoCSList([CSNumber.zero, CSNumber.zero, CSNumber.zero])
     ]);
 };
 geoOps.LineByFixedAngle.updatePosition = function(el) {
     var l = csgeo.csnames[(el.args[0])];
     var p = csgeo.csnames[(el.args[1])];
-    var dir = List.turnIntoCSList([l.homog.value[0], l.homog.value[1]]);
-    dir = List.append(List.productMV(el.rot, dir), CSNumber.zero);
-    dir = List.normalizeMax(dir);
+    var dir = List.cross(l.homog, List.linfty);
+    dir = List.productMV(el.rot, dir);
     el.homog = List.cross(p.homog, dir);
     el.homog = List.normalizeMax(el.homog);
     el.homog = General.withUsage(el.homog, "Line");

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -170,6 +170,29 @@ geoOps.Vertical.updatePosition = function(el) {
 };
 
 
+geoOps.LineByFixedAngle = {};
+geoOps.LineByFixedAngle.kind = "L";
+geoOps.LineByFixedAngle.initialize = function(el) {
+    var a = CSNumber._helper.input(el.angle);
+    var c = CSNumber.cos(a);
+    var s = CSNumber.sin(a);
+    el.rot = List.turnIntoCSList([
+        List.turnIntoCSList([s, c]),
+        List.turnIntoCSList([CSNumber.neg(c), s])
+    ]);
+};
+geoOps.LineByFixedAngle.updatePosition = function(el) {
+    var l = csgeo.csnames[(el.args[0])];
+    var p = csgeo.csnames[(el.args[1])];
+    var dir = List.turnIntoCSList([l.homog.value[0], l.homog.value[1]]);
+    dir = List.append(List.productMV(el.rot, dir), CSNumber.zero);
+    dir = List.normalizeMax(dir);
+    el.homog = List.cross(p.homog, dir);
+    el.homog = List.normalizeMax(el.homog);
+    el.homog = General.withUsage(el.homog, "Line");
+};
+
+
 geoOps.Through = {};
 geoOps.Through.kind = "L";
 geoOps.Through.isMovable = true;


### PR DESCRIPTION
This proposal implements the LineByFixedAngle type referenced by the "Export to CindyJS..." html file from Cinderella.

In Cinderella, to draw a line at an angle with respect to another line:

1. Draw line `a` through point `A`.![linethrupoint](https://cloud.githubusercontent.com/assets/15895776/11374748/e3d89cc0-9294-11e5-88ad-7a1b200f9068.png)
2. Then draw line `b` on line `a` through point `B` at 10&deg;.
 * Click the "Draw Line With Fixed Angle" tile.![linebyfixedangle](https://cloud.githubusercontent.com/assets/15895776/11374841/598b0688-9295-11e5-8594-f3a48d9d223e.png)
 * Change the Line angle to 10&deg; in the Info (i) dialog which appears.
 * Click and release near line `a` creating point`B` and line `b`.
 * Change line `b` color to yellow.
2. Now draw line `c` on line `a` through point `A`.
 * Change the Line angle to -20&deg; in the Info (i) dialog which appears.
 * Click near line `a`, drag the pointer over to `A` and release creating line `c`.
 * Change line `c` color to cyan.
3. "Export to CindyJS..." as [ConstructionLineByFixedAngle.html](@162c20edf797994bcd0b7faf92844891e3b3c096).

Note that there appears to be no way to change the angle after creating line `b` and `c` from the Cinderella UI.

Also the proposal expects that the angle will exported as radians not degrees as shown in the "Construction Text" window.

The [ConstructionLineByFixedAngle.html](@162c20edf797994bcd0b7faf92844891e3b3c096)  test file has had the values `angle: -20 * Math.PI / 180` and `angle: 10 * Math.PI / 180` added.