### PR TITLE
Initialize SelectConic from coordinates

### DIFF
--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -1034,6 +1034,28 @@ List.projectiveDistMinScal = function(a, b) {
 
 };
 
+function conicMat2Vec(m) {
+    var v = m.value;
+    var r0 = v[0].value;
+    var r1 = v[1].value;
+    var r2 = v[2].value;
+    return List.turnIntoCSList([
+        r0[0],
+        CSNumber.add(r0[1], r1[0]),
+        CSNumber.add(r0[2], r2[0]),
+        r1[1],
+        CSNumber.add(r1[2], r2[1]),
+        r2[2]
+    ]);
+}
+
+List.conicDist = function(mat1, mat2) {
+    var vec1 = conicMat2Vec(mat1);
+    var vec2 = conicMat2Vec(mat2);
+    console.log(niceprint(vec1), niceprint(vec2));
+    return List.projectiveDistMinScal(vec1, vec2);
+};
+
 List.crossOperator = function(a) {
 
     var x = a.value[0];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -766,11 +766,37 @@ geoOps._helper.splitDegenConic = function(mat) {
 
 geoOps.SelectConic = {};
 geoOps.SelectConic.kind = "C";
+geoOps.SelectConic.initialize = function(el) {
+    if (el.index !== undefined)
+        return el.index - 1;
+    var xx = CSNumber._helper.input(el.pos.xx);
+    var yy = CSNumber._helper.input(el.pos.yy);
+    var zz = CSNumber._helper.input(el.pos.zz);
+    var xy = CSNumber.realmult(0.5, CSNumber._helper.input(el.pos.xy));
+    var xz = CSNumber.realmult(0.5, CSNumber._helper.input(el.pos.xz));
+    var yz = CSNumber.realmult(0.5, CSNumber._helper.input(el.pos.yz));
+    var pos = List.turnIntoCSList([
+        List.turnIntoCSList([xx, xy, xz]),
+        List.turnIntoCSList([xy, yy, yz]),
+        List.turnIntoCSList([xz, yz, zz])
+    ]);
+    var set = csgeo.csnames[(el.args[0])].results;
+    var d1 = List.conicDist(pos, set[0]);
+    console.log("d1=", d1);
+    var best = 0;
+    for (var i = 1; i < set.length; ++i) {
+        var d2 = List.conicDist(pos, set[i]);
+        console.log("d2=", d2);
+        if (d2 < d1) {
+            d1 = d2;
+            best = i;
+        }
+    }
+    return best;
+};
 geoOps.SelectConic.updatePosition = function(el) {
     var set = csgeo.csnames[(el.args[0])];
-    el.matrix = set.results[el.index - 1];
-    el.matrix = List.normalizeMax(el.matrix);
-    el.matrix = General.withUsage(el.matrix, "Conic");
+    el.matrix = set.results[el.param];
 };
 
 // conic by 4 Points and 1 line

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -782,11 +782,9 @@ geoOps.SelectConic.initialize = function(el) {
     ]);
     var set = csgeo.csnames[(el.args[0])].results;
     var d1 = List.conicDist(pos, set[0]);
-    console.log("d1=", d1);
     var best = 0;
     for (var i = 1; i < set.length; ++i) {
         var d2 = List.conicDist(pos, set[i]);
-        console.log("d2=", d2);
         if (d2 < d1) {
             d1 = d2;
             best = i;
@@ -797,6 +795,8 @@ geoOps.SelectConic.initialize = function(el) {
 geoOps.SelectConic.updatePosition = function(el) {
     var set = csgeo.csnames[(el.args[0])];
     el.matrix = set.results[el.param];
+    el.matrix = List.normalizeMax(el.matrix);
+    el.matrix = General.withUsage(el.matrix, "Conic");
 };
 
 // conic by 4 Points and 1 line


### PR DESCRIPTION
The SelectConic element now accepts a description of a conic using 6 variables, corresponding to the equation

> xx⋅x² + yy⋅y² + zz⋅z² + xy⋅x⋅y + xz⋅x⋅z + yz⋅y⋅z = 0

Currently the distance measurement is based on projectiveDistMinScal.  It might make sense to try out something along the lines of tracingSesq for this as well.