### PR TITLE
Fix Render2D.drawline to correctly clip

### DIFF
--- a/examples/LineClippingTest.html
+++ b/examples/LineClippingTest.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>LineClippingTest.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+    <script type="text/javascript">
+createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
+	angleUnit: "°", grid: 10,
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ 4.0, -4.0, -0.13333333333333333 ], color: [ 1.0, 1.0, 0.0 ], pinned: true, size: 1.0, border: false }, 
+		{ name: "B", type: "Free", pos: [ 4.0, 4.0, 0.13333333333333333 ], color: [ 1.0, 1.0, 0.0 ], pinned: true, size: 1.0, border: false }, 
+		{ name: "C", type: "Free", pos: [ 4.0, -4.0, 0.13333333333333333 ], color: [ 1.0, 1.0, 0.0 ], pinned: true, size: 1.0, border: false }, 
+		{ name: "a", type: "Segment", pos: [ 0.0, -0.13333333333333333, 4.0 ], color: [ 1.0, 1.0, 0.0 ], args: [ "A", "B" ] }, 
+		{ name: "b", type: "Segment", pos: [ -0.13333333333333333, -0.0, 4.0 ], color: [ 1.0, 1.0, 0.0 ], args: [ "B", "C" ] }, 
+		{ name: "D", type: "Free", pos: [ 4.0, 4.0, -0.13333333333333333 ], color: [ 1.0, 1.0, 0.0 ], pinned: true, size: 1.0, border: false }, 
+		{ name: "c", type: "Segment", pos: [ -0.0, 0.13333333333333333, 4.0 ], color: [ 1.0, 1.0, 0.0 ], args: [ "C", "D" ] }, 
+		{ name: "d", type: "Segment", pos: [ 0.13333333333333333, -0.0, 4.0 ], color: [ 1.0, 1.0, 0.0 ], args: [ "D", "A" ] }, 
+		{ name: "E", type: "Free", pos: [ 0.0, -0.0, 4.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "e", type: "Through", pos: [ 0.0, -4.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "f", type: "Through", pos: [ 1.3333333333333333, -4.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "g", type: "Through", pos: [ 2.6666666666666665, -4.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "h", type: "Through", pos: [ 4.0, -4.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "k", type: "Through", pos: [ 4.0, -2.6666666666666665, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "l", type: "Through", pos: [ 4.0, -1.3333333333333333, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "m", type: "Through", pos: [ 4.0, -0.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "n", type: "Through", pos: [ 4.0, 1.3333333333333333, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "o", type: "Through", pos: [ 4.0, 2.6666666666666665, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "p", type: "Through", pos: [ 4.0, 4.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "q", type: "Through", pos: [ -2.6666666666666665, -4.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true }, 
+		{ name: "r", type: "Through", pos: [ -1.3333333333333333, -4.0, 0.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "E" ], labeled: true } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 935, height: 739, transform: [ { visibleRect: [ -57.55877642906321, 45.25613719231687, 59.81844486030233, -47.51580562355599 ] } ], background: "rgb(168,176,192)" } ], 
+	cinderella: { build: 1798, version: [ 2, 9, 1798 ] } });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas><p>The yellow segments represent the built-in clipping limits of CindyJS (the visibleRect value is ignored). Move point A everywhere to see the how differently the lines clip.</p>
+</body>
+</html>

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -453,7 +453,7 @@ Render2D.drawline = function(homog) {
     var xMax = 30;
     var yMin = -30;
     var yMax = 30;
-    
+
     var ul = distNeg(xMin, yMax);
     var ur = distNeg(xMax, yMax);
     var ll = distNeg(xMin, yMin);

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -448,8 +448,12 @@ Render2D.drawline = function(homog) {
     var distNeg = function(x, y) {
         return x * a + y * b + c < 0;
     };
-    // This visibleRect value remains hardcoded as before
-    var xMin = -30, xMax = 30, yMin = -30, yMax = 30;
+    // The visibleRect value remains hardcoded as before
+    var xMin = -30;
+    var xMax = 30;
+    var yMin = -30;
+    var yMax = 30;
+    
     var ul = distNeg(xMin, yMax);
     var ur = distNeg(xMax, yMax);
     var ll = distNeg(xMin, yMin);
@@ -457,10 +461,22 @@ Render2D.drawline = function(homog) {
 
     var erg = [];
 
-    if (ul !== ur) erg.push({ x: (-c - b * yMax) / a, y: yMax });
-    if (ur !== lr) erg.push({ x: xMax, y: (-c - a * xMax) / b });
-    if (ll !== lr) erg.push({ x: (-c - b * yMin) / a, y: yMin });
-    if (ul !== ll) erg.push({ x: xMin, y: (-c - a * xMin) / b });
+    if (ul !== ur) erg.push({
+        x: (-c - b * yMax) / a,
+        y: yMax
+    });
+    if (ur !== lr) erg.push({
+        x: xMax,
+        y: (-c - a * xMax) / b
+    });
+    if (ll !== lr) erg.push({
+        x: (-c - b * yMin) / a,
+        y: yMin
+    });
+    if (ul !== ll) erg.push({
+        x: xMin,
+        y: (-c - a * xMin) / b
+    });
     if (erg.length === 2) Render2D.drawsegcore(erg[0], erg[1]);
 };
 

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -440,59 +440,28 @@ Render2D.drawpoint = function(pt) {
 };
 
 Render2D.drawline = function(homog) {
-    var na = CSNumber.abs(homog.value[0]).value.real;
-    var nb = CSNumber.abs(homog.value[1]).value.real;
-    var nc = CSNumber.abs(homog.value[2]).value.real;
-    var divi;
+    var n = List.normalizeMax(homog);
+    var a = n.value[0].value.real;
+    var b = n.value[1].value.real;
+    var c = n.value[2].value.real;
 
-    if (na >= nb && na >= nc) {
-        divi = homog.value[0];
-    }
-    if (nb >= na && nb >= nc) {
-        divi = homog.value[1];
-    }
-    if (nc >= nb && nc >= na) {
-        divi = homog.value[2];
-    }
-    var a = CSNumber.div(homog.value[0], divi);
-    var b = CSNumber.div(homog.value[1], divi);
-    var c = CSNumber.div(homog.value[2], divi); //TODO Realitycheck einbauen
-
-    var l = [
-        a.value.real,
-        b.value.real,
-        c.value.real
-    ];
-    var b1, b2;
-    if (Math.abs(l[0]) < Math.abs(l[1])) {
-        b1 = [1, 0, 30];
-        b2 = [-1, 0, 30];
-    } else {
-        b1 = [0, 1, 30];
-        b2 = [0, -1, 30];
-    }
-    var erg1 = [
-        l[1] * b1[2] - l[2] * b1[1],
-        l[2] * b1[0] - l[0] * b1[2],
-        l[0] * b1[1] - l[1] * b1[0]
-    ];
-    var erg2 = [
-        l[1] * b2[2] - l[2] * b2[1],
-        l[2] * b2[0] - l[0] * b2[2],
-        l[0] * b2[1] - l[1] * b2[0]
-    ];
-
-    var pt1 = {
-        x: erg1[0] / erg1[2],
-        y: erg1[1] / erg1[2]
+    var distNeg = function(x, y) {
+        return x * a + y * b + c < 0;
     };
-    var pt2 = {
-        x: erg2[0] / erg2[2],
-        y: erg2[1] / erg2[2]
+    // This visibleRect value remains hardcoded as before
+    var xMin = -30, xMax = 30, yMin = -30, yMax = 30;
+    var ul = distNeg(xMin, yMax);
+    var ur = distNeg(xMax, yMax);
+    var ll = distNeg(xMin, yMin);
+    var lr = distNeg(xMax, yMin);
 
-    };
+    var erg = [];
 
-    Render2D.drawsegcore(pt1, pt2);
+    if (ul != ur) erg.push({ x: (-c - b * yMax) / a, y: yMax });
+    if (ur != lr) erg.push({ x: xMax, y: (-c - a * xMax) / b });
+    if (ll != lr) erg.push({ x: (-c - b * yMin) / a, y: yMin });
+    if (ul != ll) erg.push({ x: xMin, y: (-c - a * xMin) / b });
+    if (erg.length === 2) Render2D.drawsegcore(erg[0], erg[1]);
 };
 
 Render2D.dashTypes = {

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -457,10 +457,10 @@ Render2D.drawline = function(homog) {
 
     var erg = [];
 
-    if (ul != ur) erg.push({ x: (-c - b * yMax) / a, y: yMax });
-    if (ur != lr) erg.push({ x: xMax, y: (-c - a * xMax) / b });
-    if (ll != lr) erg.push({ x: (-c - b * yMin) / a, y: yMin });
-    if (ul != ll) erg.push({ x: xMin, y: (-c - a * xMin) / b });
+    if (ul !== ur) erg.push({ x: (-c - b * yMax) / a, y: yMax });
+    if (ur !== lr) erg.push({ x: xMax, y: (-c - a * xMax) / b });
+    if (ll !== lr) erg.push({ x: (-c - b * yMin) / a, y: yMin });
+    if (ul !== ll) erg.push({ x: xMin, y: (-c - a * xMin) / b });
     if (erg.length === 2) Render2D.drawsegcore(erg[0], erg[1]);
 };
 


### PR DESCRIPTION
The test file demonstrates the problems. The clipping is not correct as currently implemented by Render2D.drawline. Depending on the angle of a line and where it is drawn it may be drawn outside the clipping rectangle and not within even though it clearly should be.