### PR TITLE
Clean up Pole and Polar, breaking compatibility

### DIFF
--- a/examples/101_PolarOperations.html
+++ b/examples/101_PolarOperations.html
@@ -39,11 +39,11 @@ var cdy = createCindy({
     {name: "A", type: "Free", pos: [3.714285714285714, -4, -1.7857142857142856], color: [1, 0, 0], labeled: true},
     {name: "C0", type: "CircleByRadius", args: ["A"], radius: 4.216918306061904, size: 1, color: [0, 0, 1], printname: "$C_{0}$"},
     {name: "B", type: "Free", pos: [0.6333333333333333, -4, -0.8333333333333334], color: [1, 0, 0], labeled: true},
-    {name: "a", type: "Polar", args: ["B", "C0"], pos: [-0.25419812047450324, -0.4929902942535819, 4], size: 1, color: [1, 0, 0], labeled: true},
+    {name: "a", type: "PolarOfPoint", args: ["B", "C0"], pos: [-0.25419812047450324, -0.4929902942535819, 4], size: 1, color: [1, 0, 0], labeled: true},
     {name: "C", type: "Free", pos: [-2.4347826086956523, -4, -0.8695652173913044], color: [1, 0, 0], labeled: true},
     {name: "D", type: "Free", pos: [4, 0.6666666666666669, 1.1904761904761907], color: [1, 0, 0], labeled: true},
     {name: "b", type: "Join", args: ["C", "D"], pos: [-1.1635944700460832, -0.16129032258064502, 4], size: 1, color: [0.098039225, 0.61960787, 0.30588236], labeled: true},
-    {name: "E", type: "Pole", args: ["b", "C0"], pos: [-1.968049656681811, -4, -1.474182741253347], color: [0, 1, 0], labeled: true}
+    {name: "E", type: "PolarOfLine", args: ["b", "C0"], pos: [-1.968049656681811, -4, -1.474182741253347], color: [0, 1, 0], labeled: true}
   ]
 });
 </script>

--- a/examples/101_PolarOperations.html
+++ b/examples/101_PolarOperations.html
@@ -25,165 +25,28 @@
 </script>
 
     <script type="text/javascript">
-createCindy({
-  "scripts": "cs*",
-  "defaultAppearance": {},
-  "geometry": [
-    {
-      "name": "A",
-      "type": "Free",
-      "pos": [
-        3.714285714285714,
-        -4.0,
-        -1.7857142857142856
-      ],
-      "color": [
-        1.0,
-        0.0,
-        0.0
-      ],
-      "labeled": true
-    },
-    {
-      "name": "C0",
-      "type": "CircleByRadius",
-      "color": [
-        0.0,
-        0.0,
-        1.0
-      ],
-      "radius": 4.216918306061904,
-      "args": [
-        "A"
-      ],
-      "size": 1,
-      "printname": "$C_{0}$"
-    },
-    {
-      "name": "B",
-      "type": "Free",
-      "pos": [
-        0.6333333333333333,
-        -4.0,
-        -0.8333333333333334
-      ],
-      "color": [
-        1.0,
-        0.0,
-        0.0
-      ],
-      "labeled": true
-    },
-    {
-      "name": "a",
-      "type": "PolarPoint",
-      "pos": [
-        -0.25419812047450324,
-        -0.4929902942535819,
-        4.0
-      ],
-      "color": [
-        1.0,
-        0.0,
-        0.0
-      ],
-      "args": [
-        "B",
-        "C0"
-      ],
-      "labeled": true,
-      "size": 1
-    },
-    {
-      "name": "C",
-      "type": "Free",
-      "pos": [
-        -2.4347826086956523,
-        -4.0,
-        -0.8695652173913044
-      ],
-      "color": [
-        1.0,
-        0.0,
-        0.0
-      ],
-      "labeled": true
-    },
-    {
-      "name": "D",
-      "type": "Free",
-      "pos": [
-        4.0,
-        0.6666666666666669,
-        1.1904761904761907
-      ],
-      "color": [
-        1.0,
-        0.0,
-        0.0
-      ],
-      "labeled": true
-    },
-    {
-      "name": "b",
-      "type": "Join",
-      "pos": [
-        -1.1635944700460832,
-        -0.16129032258064502,
-        4.0
-      ],
-      "color": [
-        0.098039225,
-        0.61960787,
-        0.30588236
-      ],
-      "args": [
-        "C",
-        "D"
-      ],
-      "labeled": true,
-      "size": 1
-    },
-    {
-      "name": "E",
-      "type": "PolarLine",
-      "pos": [
-        -1.968049656681811,
-        -4.0,
-        -1.474182741253347
-      ],
-      "color": [
-        0.0,
-        1.0,
-        0.0
-      ],
-      "args": [
-        "b",
-        "C0"
-      ],
-      "labeled": true
-    }
-  ],
-  "ports": [
-    {
-      "id": "CSCanvas",
-      "width": 680,
-      "height": 336,
-      "transform": [
-        {
-          "visibleRect": [
-            -9.04,
-            9.32,
-            18.16,
-            -4.12
-          ]
-        }
-      ],
-      "background": "rgb(168,176,192)"
-    }
+var cdy = createCindy({
+  scripts: "cs*",
+  defaultAppearance: {},
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 336,
+    background: "rgb(168,176,192)",
+    transform: [{visibleRect: [-9.04, 9.32, 18.16, -4.12]}]
+  }],
+  geometry: [
+    {name: "A", type: "Free", pos: [3.714285714285714, -4, -1.7857142857142856], color: [1, 0, 0], labeled: true},
+    {name: "C0", type: "CircleByRadius", args: ["A"], radius: 4.216918306061904, size: 1, color: [0, 0, 1], printname: "$C_{0}$"},
+    {name: "B", type: "Free", pos: [0.6333333333333333, -4, -0.8333333333333334], color: [1, 0, 0], labeled: true},
+    {name: "a", type: "Polar", args: ["B", "C0"], pos: [-0.25419812047450324, -0.4929902942535819, 4], size: 1, color: [1, 0, 0], labeled: true},
+    {name: "C", type: "Free", pos: [-2.4347826086956523, -4, -0.8695652173913044], color: [1, 0, 0], labeled: true},
+    {name: "D", type: "Free", pos: [4, 0.6666666666666669, 1.1904761904761907], color: [1, 0, 0], labeled: true},
+    {name: "b", type: "Join", args: ["C", "D"], pos: [-1.1635944700460832, -0.16129032258064502, 4], size: 1, color: [0.098039225, 0.61960787, 0.30588236], labeled: true},
+    {name: "E", type: "Pole", args: ["b", "C0"], pos: [-1.968049656681811, -4, -1.474182741253347], color: [0, 1, 0], labeled: true}
   ]
 });
-    </script>
+</script>
 </head>
 <body>
     <canvas id="CSCanvas"></canvas>

--- a/examples/109_CenterOfConic.html
+++ b/examples/109_CenterOfConic.html
@@ -31,8 +31,8 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
     {name:"Fs", type:"IntersectionConicLine", args:["Q","linf"]},
     {name:"F1", type:"SelectP", args:["Fs"], index:1},
     {name:"F2", type:"SelectP", args:["Fs"], index:2},
-    {name:"g1", type:"Polar", args:["F1", "Q"], color:[0.7,0.3,0]},
-    {name:"g2", type:"Polar", args:["F2", "Q"], color:[0.7,0.3,0]},
+    {name:"g1", type:"PolarOfPoint", args:["F1", "Q"], color:[0.7,0.3,0]},
+    {name:"g2", type:"PolarOfPoint", args:["F2", "Q"], color:[0.7,0.3,0]},
     {name:"hs", type:"angleBisector", args:["g1", "g2"]},
     {name:"h1", type:"SelectL", args:["hs"], index:1, color:[1,1,0]},
     {name:"h2", type:"SelectL", args:["hs"], index:2, color:[1,1,0]}

--- a/examples/81_Polar.html
+++ b/examples/81_Polar.html
@@ -31,7 +31,7 @@
                       {name:"E", type:"Free", pos:[-6,0]},
                       {name:"P", type:"Free", pos:[6,8],color:[0,1,1]},
 		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,size:1},
-		              {name:"l", type:"Polar", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
+		              {name:"l", type:"PolarOfPoint", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
                       ];
             createCindy({canvasname:"CSCanvas",
                         movescript:"csmove",

--- a/examples/81_Polar.html
+++ b/examples/81_Polar.html
@@ -31,7 +31,7 @@
                       {name:"E", type:"Free", pos:[-6,0]},
                       {name:"P", type:"Free", pos:[6,8],color:[0,1,1]},
 		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,size:1},
-		              {name:"l", type:"PolarPoint", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
+		              {name:"l", type:"Polar", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
                       ];
             createCindy({canvasname:"CSCanvas",
                         movescript:"csmove",

--- a/examples/81_Polar_angular_bisect.html
+++ b/examples/81_Polar_angular_bisect.html
@@ -31,7 +31,7 @@
                       {name:"E", type:"Free", pos:[-6,-1]},
                       {name:"P", type:"Free", pos:[10000000,0],color:[0,1,1]},
 		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,size:1},
-		              {name:"l", type:"Polar", args:["Co","P"],color:[0,1,0],alpha:1,size:2},
+		              {name:"l", type:"Polar", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
                       ];
             createCindy({canvasname:"CSCanvas",
                         movescript:"csmove",

--- a/examples/81_Polar_angular_bisect.html
+++ b/examples/81_Polar_angular_bisect.html
@@ -31,7 +31,7 @@
                       {name:"E", type:"Free", pos:[-6,-1]},
                       {name:"P", type:"Free", pos:[10000000,0],color:[0,1,1]},
 		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,size:1},
-		              {name:"l", type:"Polar", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
+		              {name:"l", type:"PolarOfPoint", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
                       ];
             createCindy({canvasname:"CSCanvas",
                         movescript:"csmove",

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1120,9 +1120,9 @@ geoOps.ArcBy3 = {};
 geoOps.ArcBy3.kind = "C";
 geoOps.ArcBy3.updatePosition = geoOps.CircleBy3.updatePosition;
 
-geoOps.Polar = {};
-geoOps.Polar.kind = "L";
-geoOps.Polar.updatePosition = function(el) {
+geoOps.PolarOfPoint = {};
+geoOps.PolarOfPoint.kind = "L";
+geoOps.PolarOfPoint.updatePosition = function(el) {
     var point = csgeo.csnames[(el.args[0])];
     var conic = csgeo.csnames[(el.args[1])];
     var homog = General.mult(conic.matrix, point.homog);
@@ -1130,9 +1130,9 @@ geoOps.Polar.updatePosition = function(el) {
     el.homog = General.withUsage(homog, "Line");
 };
 
-geoOps.Pole = {};
-geoOps.Pole.kind = "P";
-geoOps.Pole.updatePosition = function(el) {
+geoOps.PolarOfLine = {};
+geoOps.PolarOfLine.kind = "P";
+geoOps.PolarOfLine.updatePosition = function(el) {
     var line = csgeo.csnames[(el.args[0])];
     var conic = csgeo.csnames[(el.args[1])];
     var dualMatrix = List.adjoint3(conic.matrix);
@@ -1633,6 +1633,16 @@ geoMacros.IntersectionCircleCircle = function(el) {
 
 geoMacros.Parallel = function(el) {
     el.type = "Para";
+    return [el];
+};
+
+geoMacros.Pole = function(el) {
+    el.type = "PolarOfLine";
+    return [el];
+};
+
+geoMacros.Polar = function(el) {
+    el.type = "PolarOfPoint";
     return [el];
 };
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1123,23 +1123,22 @@ geoOps.ArcBy3.updatePosition = geoOps.CircleBy3.updatePosition;
 geoOps.Polar = {};
 geoOps.Polar.kind = "L";
 geoOps.Polar.updatePosition = function(el) {
-    var Conic = csgeo.csnames[(el.args[0])];
-    var Point = csgeo.csnames[(el.args[1])];
-    var iMatrix = List.inverse(Conic.matrix);
-    el.homog = General.mult(iMatrix, Point.homog);
-
-    el.homog = List.normalizeMax(el.homog);
-    el.homog = General.withUsage(el.homog, "Point");
+    var point = csgeo.csnames[(el.args[0])];
+    var conic = csgeo.csnames[(el.args[1])];
+    var homog = General.mult(conic.matrix, point.homog);
+    homog = List.normalizeMax(homog);
+    el.homog = General.withUsage(homog, "Line");
 };
 
-geoOps.PolarPoint = {};
-geoOps.PolarPoint.kind = "P";
-geoOps.PolarPoint.updatePosition = function(el) {
-    var Conic = csgeo.csnames[(el.args[1])];
-    var Line = csgeo.csnames[(el.args[0])];
-    el.homog = General.mult(Conic.matrix, Line.homog);
-    el.homog = List.normalizeMax(el.homog);
-    el.homog = General.withUsage(el.homog, "Line");
+geoOps.Pole = {};
+geoOps.Pole.kind = "P";
+geoOps.Pole.updatePosition = function(el) {
+    var line = csgeo.csnames[(el.args[0])];
+    var conic = csgeo.csnames[(el.args[1])];
+    var dualMatrix = List.adjoint3(conic.matrix);
+    var homog = General.mult(dualMatrix, line.homog);
+    homog = List.normalizeMax(homog);
+    el.homog = General.withUsage(homog, "Point");
 };
 
 
@@ -1629,12 +1628,6 @@ geoMacros.IntersectionConicLine = function(el) {
 
 geoMacros.IntersectionCircleCircle = function(el) {
     el.type = "IntersectCirCir";
-    return [el];
-};
-
-geoMacros.PolarLine = function(el) {
-    el.args = [el.args[1], el.args[0]];
-    el.type = "Polar";
     return [el];
 };
 


### PR DESCRIPTION
With `PolarPoint` and `PolarLine`, there was a horrible mess about which is which, mostly because Cinderella uses them in an intuitive way: `PolarPoint` is a line, `PolarLine` a point.  To avoid any such confusions in the future, this commit introduces a new pair of nouns, namely `Pole` (which is a point
defined by a line and a conic) and `Polar` (which is a line defined by a point and a conic).  The order was unifies so that the conic always comes last.

Since the state of affairs so far was such a mess, the commit deliberately does not try to preserve backwards compatibility.

This pull request fixes #86. For those interested in the history of the issue: bf59f449655737739b30723e6098ae0d28d16c04 implemented `Polar` as we are now using it. 2664a18c8f3f50e34c38f72f2829c7d9900220f8 added `PolarPoint` and `PolarLine`, modified the existing code and thus created the current inconsistent situation.