### PR TITLE
Simplify center of conic

### DIFF
--- a/examples/109_CenterOfConic.html
+++ b/examples/109_CenterOfConic.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script type="text/javascript">
+
+var cdy = createCindy({ // See ref/createCindy documentation for details.
+  ports: [{id: "CSCanvas"}],
+  scripts: "cs*",
+  language: "en",
+  grid: 5,
+  snap: true,
+  csconsole: true,
+  defaultAppearance: {
+    lineSize: 2
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[3,0]},
+    {name:"B", type:"Free", pos:[0,2]},
+    {name:"C", type:"Free", pos:[0,-2]},
+    {name:"D", type:"Free", pos:[-1,1]},
+    {name:"E", type:"Free", pos:[-1,-1]},
+    {name:"Q", type:"ConicBy5", args:["A", "B", "C", "D", "E"]},
+    {name:"X", type:"CenterOfConic", args:["Q"], color:[0,1,0]},
+
+    // Code below only for verification
+    {name:"linf", type:"FreeLine", pos:[0,0,1], pinned:true},
+    {name:"Fs", type:"IntersectionConicLine", args:["Q","linf"]},
+    {name:"F1", type:"SelectP", args:["Fs"], index:1},
+    {name:"F2", type:"SelectP", args:["Fs"], index:2},
+    {name:"g1", type:"Polar", args:["F1", "Q"], color:[0.7,0.3,0]},
+    {name:"g2", type:"Polar", args:["F2", "Q"], color:[0.7,0.3,0]},
+    {name:"hs", type:"angleBisector", args:["g1", "g2"]},
+    {name:"h1", type:"SelectL", args:["hs"], index:1, color:[1,1,0]},
+    {name:"h2", type:"SelectL", args:["hs"], index:2, color:[1,1,0]}
+  ]
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas" width="500" height="500"
+          style="border:2px solid black"></canvas>
+</body>
+
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -569,13 +569,8 @@ geoOps.PointOnSegment.stateSize = 2;
 
 
 geoOps._helper.CenterOfConic = function(c) {
-    var pts = geoOps._helper.IntersectLC(List.linfty, c);
-    var ln1 = General.mult(c, pts[0]);
-    var ln2 = General.mult(c, pts[1]);
-
-    var erg = List.cross(ln1, ln2);
-
-    return erg;
+    // The center is the pole of the line at infinity.
+    return General.mult(List.adjoint3(c), List.linfty);
 };
 
 geoOps.CenterOfConic = {};


### PR DESCRIPTION
The center of a conic is simply the pole of the line at infinity.
This is easier to compute than performing a line-conic intersection.
The test case demonstrates that this is indeed the correct point. It builds on #104.