### PR TITLE
Implementation of ConicParabolaPL

### DIFF
--- a/examples/ConstructionParabolaPL.html
+++ b/examples/ConstructionParabolaPL.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>ConstructionParabolaPL.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+    <script type="text/javascript">
+createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
+	angleUnit: "°", 
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ -2.5954198473282437, -4.0, -0.7633587786259541 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "a", type: "FreeLine", pos: [ -0.5192878338278932, -1.85459940652819, 4.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C0", type: "ConicParabolaPL", color: [ 0.0, 0.0, 1.0 ], args: [ "A", "a" ], printname: "$C_{0}$" } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 680, height: 350, transform: [ { visibleRect: [ -9.06, 9.34, 18.14, -4.66 ] } ], background: "rgb(168,176,192)" } ], 
+	cinderella: { build: 1798, version: [ 2, 9, 1798 ] } });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1007,6 +1007,37 @@ geoOps.ConicBy1p4l.updatePosition = function(el) {
 
 };
 
+geoOps.ConicParabolaPL = {};
+geoOps.ConicParabolaPL.kind = "C";
+geoOps.ConicParabolaPL.updatePosition = function(el) {
+    var A = csgeo.csnames[(el.args[0])].homog; // focus point
+    var a = csgeo.csnames[(el.args[1])].homog; // directrix line
+    // The direction of the directrix line
+    var dd = List.cross(a, List.linfty);
+    // The perpendicular direction of the directrix line
+    var dp = List.cross(dd, List.linfty);
+    // Parallel line through focus point in the direction of the directrix line
+    // forms both lines of one degenerate conic
+    var e = List.cross(A, dd);
+    // Line through focus point in the perpendicular direction of directrix line
+    var b = List.cross(A, dp);
+    // Point B is the projection of the focus point onto the directrix line
+    var B = List.cross(a, b);
+    // Create both both angle bisector lines through point B from the
+    // direction of the directrix and its perpendicular direction
+    var c = List.cross(B, List.sub(dd, dp));
+    var d = List.cross(B, List.add(dd, dp));
+    // Midpoint of point A and point B
+    var C = List.add(List.normalizeZ(A), List.normalizeZ(B));
+    // Line c and line d make up the other degenerate conic
+    var vc = List.turnIntoCSList([c]);
+    var vd = List.turnIntoCSList([d]);
+    var ve = List.turnIntoCSList([e]);
+    el.matrix = geoOps._helper.conicFromTwoDegenerates(vc, vd, ve, ve, C);
+    el.matrix = List.normalizeMax(el.matrix);
+    el.matrix = General.withUsage(el.matrix, "Conic");
+};
+
 geoOps.ConicBy2Foci1P = {};
 geoOps.ConicBy2Foci1P.kind = "Cs";
 geoOps.ConicBy2Foci1P.updatePosition = function(el) {


### PR DESCRIPTION
Adds support for the algorithm "ConicParabolaPL" type referenced by the html produced by "Export to CindyJS" from Cinderella. This is one of the items on the #24 list.

The code makes use geoOps._helper.conicFromTwoDegenerates and just like geoOps.ConicFromPrincipalDirections and geoOps.ConicInSquare has one of the degenerate conics comprised of a doubled up line.