### PR TITLE
Create hopefully persistent anchor names

### DIFF
--- a/ref/js/md2html.js
+++ b/ref/js/md2html.js
@@ -79,8 +79,8 @@ MyRenderer.prototype.heading = function(text, level, raw) {
   }
   if (!id && (match = /`‹\w*›\s*(\S+)\s*‹\w*›`/.exec(raw))) {
     // infix operators
-    id = "$" + match[1].replace(/./g, function(char) {
-      return "u" + char.charCodeAt(0).toString(16);
+    id = match[1].replace(/./g, function(char) {
+      return "$" + char.charCodeAt(0).toString(16) + "u";
     });
   }
   if (!id && (match = /`([^`]*)`/.exec(raw))) {
@@ -88,10 +88,11 @@ MyRenderer.prototype.heading = function(text, level, raw) {
     match = match[1];
     id = match
       .replace(/\s+/g, "")
-      .replace(/_/g, "\\$u5f")
+      .replace(/\$/g, "\\$24u")
+      .replace(/_/g, "\\$5fu")
       .replace(/‹[^‹›]*›/g, "_")
       .replace(/\W/g, function(char) {
-        return "$u" + char.charCodeAt(0).toString(16);
+        return "$" + char.charCodeAt(0).toString(16) + "u";
       });
   }
   if (!id && (match = /([\w.]+)\s*=.*‹/.exec(raw))) {

--- a/ref/ref.css
+++ b/ref/ref.css
@@ -12,3 +12,6 @@ code { background: #ddddff; }
 table { border-collapse:collapse; }
 table td, table th { padding: 0.5ex 1em;  border: 1px solid black; }
 table td, table th, table code { background: #ffffff; }
+a.hlink { margin-left: 0.5em; opacity: 0.1; text-decoration: none; }
+a.hlink::after { content: "¶"; }
+a.hlink:hover { opacity: 0.8; }


### PR DESCRIPTION
While marked tries to provide anchor names for all its headings, these names
tend to focus on the word parts of the heading, ignoring symbolic content.
Changing the descriptive part of a heading line will change the anchor.  So
we override that, and try to come up with a scheme which will hopefully make
our anchors remain unaffected by many common forms of edits.

In particular, a normal CindyScript command has an anchor composed from the
name of the command and its arity.  An infix operator has its command
derived from the codepoint of its symbol(s).  Some other constructs like the
one for absolute value use `_` as a placeholder for arguments and unicode
codepoints for the non-argument symbols.  Only the first of these is really
easily readable by humans, but all of these should remain pretty unaffected
by changes to the non-essential parts of the headline.