### PR TITLE
Provide aliases for operations

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1739,6 +1739,16 @@ geoMacros.IntersectionConicConic = function(el) {
     return [el];
 };
 
+geoMacros.FreePoint = function(el) {
+    el.type = "Free";
+    return [el];
+};
+
+geoMacros.Orthogonal = function(el) {
+    el.type = "Perp";
+    return [el];
+};
+
 geoMacros.Parallel = function(el) {
     el.type = "Para";
     return [el];


### PR DESCRIPTION
… where Cinderella has the more descriptive name

Currently Cinderella adapts to CindyJS naming upon export, but since the names used by Cinderella are more descriptive, we should eventually export those, so make sure we understand them.