### PR TITLE
Remove normalizeZ from geoOps.Compass

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -656,12 +656,17 @@ geoOps.Compass.updatePosition = function(el) {
     var m = csgeo.csnames[(el.args[2])].homog;
     var b = csgeo.csnames[(el.args[1])].homog;
     var c = csgeo.csnames[(el.args[0])].homog;
-    m = List.normalizeZ(m);
-    b = List.normalizeZ(b);
-    c = List.normalizeZ(c);
+    // Scale each point's homogeneous coordinates by the other two
+    // point's z-value to allow addtion and subtraction to be valid.
+    var mZ = m.value[2];
+    var bZ = b.value[2];
+    var cZ = c.value[2];
+    m = List.scalmult(CSNumber.mult(bZ, cZ), m);
+    b = List.scalmult(CSNumber.mult(mZ, cZ), b);
+    c = List.scalmult(CSNumber.mult(mZ, bZ), c);
     var diff = List.sub(b, c);
     var p = List.add(diff, m);
-    p = List.normalizeZ(p);
+    p = List.normalizeMax(p);
 
     var matrix = geoOps._helper.CircleMP(m, p);
     matrix = List.normalizeMax(matrix);

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -648,8 +648,6 @@ geoOps.CircleMr.updatePosition = function(el) {
 geoOps.CircleMr.stateSize = 2;
 
 
-//TODO Must be redone for Points at infinity
-//Original Cindy Implementation is not correct either
 geoOps.Compass = {};
 geoOps.Compass.kind = "C";
 geoOps.Compass.updatePosition = function(el) {
@@ -670,8 +668,11 @@ geoOps.Compass.updatePosition = function(el) {
     var z2 = CSNumber.abs2(cZ);
     var xz = CSNumber.neg(CSNumber.mult(cX, cZ));
     var yz = CSNumber.neg(CSNumber.mult(cY, cZ));
-    var sqR = List.abs2(List.sub(b, m));
-    var zz = CSNumber.sub(List.abs2(List.turnIntoCSList([cX, cY])), sqR);
+    var dXY = List.turnIntoCSList([cX, cY]);
+    var sqXY = List.scalproduct(dXY, dXY);
+    var dR = List.sub(b, m);
+    var sqR = List.scalproduct(dR, dR);
+    var zz = CSNumber.sub(sqXY, sqR);
     var matrix = geoOps._helper.buildConicMatrix([z2, CSNumber.zero, z2, xz, yz, zz]);
     matrix = List.normalizeMax(matrix);
     el.matrix = General.withUsage(matrix, "Circle");

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -637,8 +637,11 @@ geoOps.CircleMr.updatePosition = function(el) {
     var r = getStateComplexNumber();
     putStateComplexNumber(r); // copy param
     var m = csgeo.csnames[(el.args[0])].homog;
-    var rs = CSNumber.mult(m.value[2], r); // scale the radius
-    var matrix = geoOps._helper.ScaledCircleMrr(m, CSNumber.mult(rs, rs));
+    m = List.normalizeZ(m);
+    var p = List.turnIntoCSList([r, CSNumber.zero, CSNumber.zero]);
+    p = List.add(p, m);
+    var matrix = geoOps._helper.CircleMP(m, p);
+    matrix = List.normalizeMax(matrix);
     el.matrix = General.withUsage(matrix, "Circle");
     el.radius = r;
 };

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -637,11 +637,17 @@ geoOps.CircleMr.updatePosition = function(el) {
     var r = getStateComplexNumber();
     putStateComplexNumber(r); // copy param
     var m = csgeo.csnames[(el.args[0])].homog;
-    m = List.normalizeZ(m);
-    var p = List.turnIntoCSList([r, CSNumber.zero, CSNumber.zero]);
-    p = List.add(p, m);
-    var matrix = geoOps._helper.CircleMP(m, p);
-    matrix = List.normalizeMax(matrix);
+    var rabs2 = CSNumber.abs2(r).value.real;
+    var rs = m.value[2]; // Already scaled when r/r=1 is scaled by m
+    if (rabs2 > 1) {
+        // Like homog [1=r/r, 0, 1/r]; Scale m by 1/r; rs already scaled
+        // Note: CSNumber.inv(CSNumber.real(Infinity)) produces NaN - i*NaN
+        m = List.scalmult(isFinite(rabs2) ? CSNumber.inv(r) : CSNumber.zero, m);
+    } else {
+        // Like homog [r, 0, 1]; Scale r by m.value[2]; m already scaled by 1
+        rs = CSNumber.mult(rs, r);
+    }
+    var matrix = geoOps._helper.ScaledCircleMrr(m, CSNumber.mult(rs, rs));
     el.matrix = General.withUsage(matrix, "Circle");
     el.radius = r;
 };

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -641,14 +641,14 @@ geoOps.CircleMr.updatePosition = function(el) {
     The circle's radius value may take on values from zero to infinity.
     However since the squared radius value appears in the circle's matrix,
     a radius value of 2E+154 or more could also end up as an infinite value.
-    The use of List.normalizeMax everywhere limits coordinate values of m to
-    no more 1.0, so scaling the radius value by m's z-coordinate first will
-    not make the radius value any larger. Then by squaring the radius value,
-    any infinity value produced can be caught here.
+    Using List.normalizeMax elsewhere will limit the coordinate values of m
+    to no more than 1.0, so that scaling the radius value by m's z-coordinate
+    first here will not make the radius value any larger. Then by squaring the
+    radius value, any infinity value produced can be caught here.
     */
     var sr = CSNumber.mult(m.value[2], r);
     var sr2 = CSNumber.mult(sr, sr);
-    if (!CSNumber._helper.isFinite(sr2)) return List.fund;
+    if (!CSNumber._helper.isFinite(sr2) && !CSNumber._helper.isNaN(sr2)) return List.fund;
     var matrix = geoOps._helper.ScaledCircleMrr(m, sr2);
     el.matrix = General.withUsage(matrix, "Circle");
     el.radius = r;
@@ -656,7 +656,6 @@ geoOps.CircleMr.updatePosition = function(el) {
 geoOps.CircleMr.stateSize = 2;
 
 
-// M is center and rr is radius squared; both must be pre-scaled
 geoOps._helper.ScaledCircleMrr = function(M, rr) {
     /*
     Given M as the circle's homogeneous center point coordinates [x, y, z] and

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -653,9 +653,9 @@ geoOps.CircleMr.stateSize = 2;
 geoOps.Compass = {};
 geoOps.Compass.kind = "C";
 geoOps.Compass.updatePosition = function(el) {
-    var m = csgeo.csnames[(el.args[2])].homog;
+    var m = csgeo.csnames[(el.args[0])].homog;
     var b = csgeo.csnames[(el.args[1])].homog;
-    var c = csgeo.csnames[(el.args[0])].homog;
+    var c = csgeo.csnames[(el.args[2])].homog;
     // Scale each point's homogeneous coordinates by the other two
     // point's z-value to allow addtion and subtraction to be valid.
     var mZ = m.value[2];
@@ -664,11 +664,15 @@ geoOps.Compass.updatePosition = function(el) {
     m = List.scalmult(CSNumber.mult(bZ, cZ), m);
     b = List.scalmult(CSNumber.mult(mZ, cZ), b);
     c = List.scalmult(CSNumber.mult(mZ, bZ), c);
-    var diff = List.sub(b, c);
-    var p = List.add(diff, m);
-    p = List.normalizeMax(p);
-
-    var matrix = geoOps._helper.CircleMP(m, p);
+    var cX = c.value[0]; // bZ*cX*mZ
+    var cY = c.value[1]; // bZ*cY*mZ
+    cZ = c.value[2]; // bZ*cZ*mZ
+    var z2 = CSNumber.abs2(cZ);
+    var xz = CSNumber.neg(CSNumber.mult(cX, cZ));
+    var yz = CSNumber.neg(CSNumber.mult(cY, cZ));
+    var sqR = List.abs2(List.sub(b, m));
+    var zz = CSNumber.sub(List.abs2(List.turnIntoCSList([cX, cY])), sqR);
+    var matrix = geoOps._helper.buildConicMatrix([z2, CSNumber.zero, z2, xz, yz, zz]);
     matrix = List.normalizeMax(matrix);
     el.matrix = General.withUsage(matrix, "Circle");
 };


### PR DESCRIPTION
Using normalizeZ on the homogeneous coordinates of the three points produces `(m/mZ, b/bZ, c/cZ)`, scaling these by `mZ * bZ * cZ` leaves `(bZ * cZ * m, mZ * cZ * b, mZ * bZ * c)` instead and removes the possiblity of a divide_by-zero.