### PR TITLE
Simplify geoOps._helper.pointReflection

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1646,7 +1646,7 @@ geoOps._helper.pointReflection = function(center, point) {
     // If center is at infinity, the result will be center unless point
     // is also at infinity, then the result is the ideal point [0, 0, 0].
     return List.normalizeMax(List.sub(
-        List.scalmult(CSNumber.mult(CSNumber.real(2), point.value[2]), center),
+        List.scalmult(CSNumber.realmult(2, point.value[2]), center),
         List.scalmult(center.value[2], point)));
 };
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1643,9 +1643,11 @@ geoOps.TransformS.updatePosition = function(el) {
 };
 
 geoOps._helper.pointReflection = function(center, point) {
-    // if center is at infinity, the result should always be center.
-    var circle = geoOps._helper.CircleMP(center, point);
-    return geoOps._helper.conicOtherIntersection(circle, point, center);
+    // If center is at infinity, the result will be center unless point
+    // is also at infinity, then the result is the ideal point [0, 0, 0].
+    return List.normalizeMax(List.sub(
+        List.scalmult(CSNumber.mult(CSNumber.real(2), point.value[2]), center),
+        List.scalmult(center.value[2], point)));
 };
 
 geoOps._helper.conicOtherIntersection = function(conic, a, b) {


### PR DESCRIPTION
As implemented geoOps._helper.pointReflection literally uses a circuitous method to achieve what in its simplest form is just `center - (point - center)`.

If the center and point homogeneous coordinates are `(Cx, Cy, Cz)` and `(Px, Py, Pz)` respectively, then normalized this becomes `center/cZ - (point/pZ - center/cZ)` and thus `2 * center/cZ - point/pZ`.

To avoid dividing by zero this is scaled by `cZ * pZ` giving `2 * pZ * center - cZ * point` which is then `2 * pZ * (Cx, Cy, Cz) - cZ * (Px, Py, Pz)`.

The current implementation produces the same result symbolically along with a scale factor of `2Cz(CxPx+CyPy)Pz-(Cx²+Cy²)Pz²-Cz²(Px²+Py²)`.