### PR TITLE
Have splitDegenConic return a pair of null vectors instead of nada

### DIFF
--- a/examples/111_VeryDegenerateICC.html
+++ b/examples/111_VeryDegenerateICC.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script type="text/javascript">
+
+var cdy = createCindy({ // See ref/createCindy documentation for details.
+  ports: [{id: "CSCanvas"}],
+  language: "en",
+  geometry: [ 
+    { name: "A", type: "Free", pos: [5,5,1], color: [0,0,1], labeled: true }, 
+    { name: "B", type: "Free", pos: [5,5,1], color: [0,0,1], labeled: true }, 
+    { name: "C", type: "Free", pos: [5,5,1], color: [0,0,1], labeled: true }, 
+    { name: "D", type: "Free", pos: [3,-4,1], color: [1,0,0], labeled: true }, 
+    { name: "E", type: "Free", pos: [3,-4,1], color: [1,0,0], labeled: true }, 
+    { name: "F", type: "Free", pos: [3,-4,1], color: [1,0,0], labeled: true }, 
+    { name: "C0", type: "ConicFromPrincipalDirections", args: ["A", "B", "C"], color: [0,0,1] },
+    { name: "C1", type: "ConicFromPrincipalDirections", args: ["D", "E", "F"], color: [1,0,0] },
+    { name: "Is", type: "IntersectionConicConic", args: ["C0", "C1"] },
+    { name: "I1", type: "SelectP", args: ["Is"], index: 1, color: [0,.7,0] },
+    { name: "I2", type: "SelectP", args: ["Is"], index: 2, color: [0,.7,0] },
+    { name: "I3", type: "SelectP", args: ["Is"], index: 3, color: [0,.7,0] },
+    { name: "I4", type: "SelectP", args: ["Is"], index: 4, color: [0,.7,0] }
+  ]
+});
+</script>
+</head>
+
+<body style="font-family:Arial;">
+    <canvas id="CSCanvas" width="500" height="500"
+            style="border:2px solid black"></canvas>
+    <p>
+      The initial situation shows some <em>very</em> degenerate situation
+      for the intersection of two conics, where both the conics involved are
+      in fact undefined. This exposes a problem discussed in
+      <a href="https://github.com/CindyJS/CindyJS/issues/132">issue #132</a>
+      which would lead to an exception during initialization.
+    </p>
+    <p>
+      Moving from that situation is non-trivial as well, since it may
+      lead to extremely slow responses due to tracing problems. See
+      <a href="https://github.com/CindyJS/CindyJS/issues/136"> issue #136</a>.
+    </p>
+</body>
+
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -766,11 +766,14 @@ geoOps._helper.splitDegenConic = function(mat) {
     }
 
     var beta = CSNumber.sqrt(CSNumber.mult(CSNumber.real(-1), adj_mat.value[idx].value[idx]));
+    if (CSNumber.abs2(beta).value.real < 1e-16) {
+        var zeros = List.turnIntoCSList([
+            CSNumber.zero, CSNumber.zero, CSNumber.zero
+        ]);
+        return [zeros, zeros];
+    }
     idx = CSNumber.real(idx + 1);
     var p = List.column(adj_mat, idx);
-    if (CSNumber.abs2(beta).value.real < 1e-16) {
-        return nada;
-    }
 
     p = List.scaldiv(beta, p);
 


### PR DESCRIPTION
While `nada` would be appropriate for CindyScript operations, in the geometry core we expect to continue with any intermediate result without further type checking.  So we should always return a pair of vectors, even if we make them null vectors to indicate undefined geometric elements.

This fixes #132.