### PR TITLE
implemented indicator for non-degenerate circles

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -400,7 +400,7 @@ eval_helper.drawconic = function(conicMatrix, modifs, isNotDegenCircle) {
         return;
     Render2D.preDrawCurve();
 
-    var eps = 1e-14; //JRG Hab ih von 1e-16 runtergesetzt
+    var eps = 1e-16; //JRG Hab ih von 1e-16 runtergesetzt
     var mat = List.normalizeMax(conicMatrix);
     var origmat = mat;
 

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -393,7 +393,7 @@ evaluator.drawconic$1 = function(args, modifs) {
     return eval_helper.drawconic(Conic.matrix, modifs);
 };
 
-eval_helper.drawconic = function(conicMatrix, modifs) {
+eval_helper.drawconic = function(conicMatrix, modifs, isNotDegenCircle) {
 
     Render2D.handleModifs(modifs, Render2D.conicModifs);
     if (Render2D.lsize === 0)
@@ -407,7 +407,9 @@ eval_helper.drawconic = function(conicMatrix, modifs) {
     // check for complex values
     for (var i = 0; i < 2; i++)
         for (var j = 0; j < 2; j++) {
-            if (Math.abs(mat.value[i].value[j].value.imag) > eps) return;
+            if (Math.abs(mat.value[i].value[j].value.imag) > CSNumber.eps) {
+                return;
+            }
         }
 
     // transform matrix to canvas coordiantes
@@ -456,7 +458,7 @@ eval_helper.drawconic = function(conicMatrix, modifs) {
 
 
     var det = a * c * f - a * e * e - b * b * f + 2 * b * d * e - c * d * d;
-    var degen = Math.abs(det) < eps;
+    var degen = (Math.abs(det) < eps) && !isNotDegenCircle;
 
     var cswh_max = csw > csh ? csw : csh;
 

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -65,9 +65,10 @@ function render() {
         modifs.alpha = el.alpha;
         modifs.size = el.size;
 
-        eval_helper.drawconic(el.matrix, modifs);
+        // perhaps we are conic now (e.g. projective transform)
+        var nonDegenCir = (el.matrix.usage === 'Circle' && el.isNotDegenCircle);
 
-
+        eval_helper.drawconic(el.matrix, modifs, nonDegenCir);
     }
 
     function drawgeoline(el) {


### PR DESCRIPTION
Hi following up on bug #139 i wrote some routines which fix drawing bugs if circles are getting very small after applying Möbius transforms. 

The key idea is to indicate that known non-degenerate circles will be still circles after the Möbius transform and loop in that property until we reach the conic drawing routine.

On the way i refactored functions using random lines (which is used quite often to generate points on the circles).