### PR TITLE
Declare inputs of the shader resource build step

### DIFF
--- a/make/build.js
+++ b/make/build.js
@@ -249,6 +249,7 @@ module.exports = function build(settings, task) {
     ];
 
     task("c3dres", [], function() {
+        c3d_str_res.forEach(this.input, this);
         this.node(
             "tools/files2json.js",
             "-varname=c3d_resources",


### PR DESCRIPTION
Without this, a change to one of these inputs will not trigger a recreation of the corresponding output.