### PR TITLE
Add getImage function to the Plugin API

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3750,6 +3750,11 @@ evaluator.use$1 = function(args, modifs) {
                 "setTextRenderer": function(handler) {
                     textRenderer = handler;
                 },
+                "getImage": function(name) {
+                    if (images.hasOwnProperty(name))
+                        return images[name];
+                    return null;
+                },
             });
             return {
                 "ctype": "boolean",


### PR DESCRIPTION
Using this function, it becomes possible for plugins to operate on the same collection of images used in CindyJS itself.