### PR TITLE
Angular bisector

### DIFF
--- a/examples/AngularBisectorCdy.html
+++ b/examples/AngularBisectorCdy.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>AngularBisectorCdy.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+    <script type="text/javascript">
+createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
+	angleUnit: "°", 
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ -0.16, 0.16, 4.0 ], color: [ 1.0, 0.0, 0.0 ] }, 
+		{ name: "a", type: "Through", pos: [ -0.8739495798319329, -4.0, 0.1250420168067227 ], color: [ 0.0, 0.0, 1.0 ], args: [ "A" ] }, 
+		{ name: "b", type: "Through", pos: [ 3.2682926829268295, -4.0, 0.2907317073170732 ], color: [ 0.0, 0.0, 1.0 ], args: [ "A" ] }, 
+		{ name: "Collection__1", type: "AngularBisector", args: [ "a", "b", "A" ] }, 
+		{ name: "c", type: "SelectL", pos: [ 0.957605970573069, -4.0, 0.19830423882292275 ], color: [ 1.0, 1.0, 0.0 ], args: [ "Collection__1" ] }, 
+		{ name: "d", type: "SelectL", pos: [ 4.0, 0.9576059705730687, 0.12169576117707727 ], color: [ 0.0, 1.0, 1.0 ], args: [ "Collection__1" ] }, 
+		{ name: "Collection__2", type: "AngularBisector", args: [ "c", "d" ] }, 
+		{ name: "e", type: "SelectL", pos: [ 4.0, -2.454728389053679, 0.2581891355621472 ], color: [ 0.7568628, 0.0, 0.0 ], args: [ "Collection__2" ] }, 
+		{ name: "", type: "SelectL", pos: [ -2.454728389053677, -4.0, 0.061810864437852914 ], color: [ 1.0, 1.0, 1.0 ], args: [ "Collection__2" ], size: 0 } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 590, height: 392, transform: [ { visibleRect: [ -9.06, 9.34, 14.54, -6.34 ] } ], background: "rgb(168,176,192)" } ], 
+	cinderella: { build: 1813, version: [ 2, 9, 1813 ] } });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2247,6 +2247,12 @@ geoMacros.Arc = function(el) {
     return [el];
 };
 
+geoMacros.AngularBisector = function(el) {
+    el.type = "angleBisector";
+    el.args.length = 2; // Drop point of intersection
+    return [el];
+};
+
 geoMacros.Transform = function(el) {
     var arg = csgeo.csnames[el.args[1]];
     var tr = csgeo.csnames[el.args[0]];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1643,9 +1643,25 @@ geoOps.SelectP.updatePosition = function(el) {
 geoOps.SelectL = {};
 geoOps.SelectL.kind = "L";
 geoOps.SelectL.signature = ["Ls"];
+geoOps.SelectL.initialize = function(el) {
+    if (el.index !== undefined)
+        return el.index - 1;
+    var set = csgeo.csnames[(el.args[0])].results.value;
+    var pos = geoOps._helper.initializeLine(el);
+    var d1 = List.projectiveDistMinScal(pos, set[0]);
+    var best = 0;
+    for (var i = 1; i < set.length; ++i) {
+        var d2 = List.projectiveDistMinScal(pos, set[i]);
+        if (d2 < d1) {
+            d1 = d2;
+            best = i;
+        }
+    }
+    return best;
+};
 geoOps.SelectL.updatePosition = function(el) {
     var set = csgeo.csnames[(el.args[0])];
-    el.homog = set.results.value[el.index - 1];
+    el.homog = set.results.value[el.param];
     el.homog = General.withUsage(el.homog, "Line");
 };
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -30,7 +30,7 @@ geoOps.FreeLine.kind = "L";
 geoOps.FreeLine.signature = [];
 geoOps.FreeLine.isMovable = true;
 geoOps.FreeLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     putStateComplexVector(pos);
 };
 geoOps.FreeLine.getParamForInput = function(el, pos, type) {
@@ -176,7 +176,7 @@ geoOps.HorizontalLine.kind = "L";
 geoOps.HorizontalLine.signature = [];
 geoOps.HorizontalLine.isMovable = true;
 geoOps.HorizontalLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     pos = List.turnIntoCSList([CSNumber.zero, pos.value[1], pos.value[2]]);
     pos = List.normalizeMax(pos);
     putStateComplexVector(pos);
@@ -217,7 +217,7 @@ geoOps.VerticalLine.kind = "L";
 geoOps.VerticalLine.signature = [];
 geoOps.VerticalLine.isMovable = true;
 geoOps.VerticalLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     pos = List.turnIntoCSList([pos.value[0], CSNumber.zero, pos.value[2]]);
     pos = List.normalizeMax(pos);
     putStateComplexVector(pos);
@@ -2120,6 +2120,29 @@ geoOps._helper.initializePoint = function(el) {
             sx = el.pos[0];
             sy = el.pos[1];
             sz = 1;
+        }
+        if (el.pos.length === 3) {
+            sx = el.pos[0];
+            sy = el.pos[1];
+            sz = el.pos[2];
+        }
+    }
+    var pos = List.turnIntoCSList([
+        CSNumber._helper.input(sx),
+        CSNumber._helper.input(sy),
+        CSNumber._helper.input(sz)
+    ]);
+    pos = List.normalizeMax(pos);
+    return pos;
+};
+
+geoOps._helper.initializeLine = function(el) {
+    var sx = 0;
+    var sy = 0;
+    var sz = 0;
+    if (el.pos) {
+        if (el.pos.ctype === "list" && List.isNumberVector(el.pos)) {
+            return el.pos;
         }
         if (el.pos.length === 3) {
             sx = el.pos[0];


### PR DESCRIPTION
This makes `AngularBisector` ready to be exported from Cinderella. It requires a version of Cinderella which is recent enough to export `SelectL` not `SelectP`. The implementation of `SelectL` required a rework similar to what I did to `SelectP` in 3eefed8632fb0d7a4584c573137689b77c7d8ec0. For reasons unknown (to me), Cinderella exports the point of intersection as a third argument. Since our internal operation only expects two lines, I'm using the macro step to also ensure that the third argument gets dropped. I will probably file a Cinderella merge request to not export that argument at all.