### PR TITLE
Warn about division by zero only in user-defined script

### DIFF
--- a/ref/Boolean_Operators.md
+++ b/ref/Boolean_Operators.md
@@ -23,7 +23,7 @@ The result of this operator is either `true` or `false`.
 Note that `NaN` (Not a Number) compares not equal even to itself:
 
     > a = 0/0
-    * DIVISION BY ZERO
+    * WARNING: Division by zero!
     > a == a
     < false
 
@@ -56,7 +56,7 @@ It is the logical negation of `‹expr1› == ‹expr2›`.
 Note that `NaN` (Not a Number) compares different from itself:
 
     > a = 0/0
-    * DIVISION BY ZERO
+    * WARNING: Division by zero!
     > a != a
     < true
 

--- a/src/js/libcs/CSNumber.js
+++ b/src/js/libcs/CSNumber.js
@@ -264,14 +264,6 @@ CSNumber.abs = function(a1) {
 
 CSNumber.inv = function(a) {
     var s = a.value.real * a.value.real + a.value.imag * a.value.imag;
-    // BUG?
-    // perhaps we should not only check for 0
-    // if(Math.abs(s) < 1e32) {
-    if (s === 0) {
-        console.error("DIVISION BY ZERO");
-        //        halt=immediately;
-
-    }
     return {
         "ctype": "number",
         "value": {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -985,7 +985,7 @@ function infix_div(args, modifs) {
     var v0 = evaluateAndVal(args[0]);
     var v1 = evaluateAndVal(args[1]);
     if (CSNumber._helper.isZero(v1))
-        console.error("WARNING: Division by zero!");
+        csconsole.err("WARNING: Division by zero!");
     var erg = General.div(v0, v1);
     if (v0.usage === "Angle" && !v1.usage)
         erg = General.withUsage(erg, "Angle");

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -984,6 +984,8 @@ evaluator.div$2 = infix_div;
 function infix_div(args, modifs) {
     var v0 = evaluateAndVal(args[0]);
     var v1 = evaluateAndVal(args[1]);
+    if (CSNumber._helper.isZero(v1))
+        console.error("WARNING: Division by zero!");
     var erg = General.div(v0, v1);
     if (v0.usage === "Angle" && !v1.usage)
         erg = General.withUsage(erg, "Angle");


### PR DESCRIPTION
This should fix #168.

It also changes the error message from "DIVISION BY ZERO" to "WARNING: Division by zero!" as emitted by Cinderella.