### PR TITLE
Circle of small radius should not be drawn as lines

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -407,7 +407,7 @@ eval_helper.drawconic = function(conicMatrix, modifs) {
     // check for complex values
     for (var i = 0; i < 2; i++)
         for (var j = 0; j < 2; j++) {
-            if (Math.abs(mat.value[i].value[j].value.imag) > eps) return;
+            if (Math.abs(mat.value[i].value[j].value.imag) > CSNumber.eps) return;
         }
 
     // transform matrix to canvas coordiantes

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -458,6 +458,14 @@ eval_helper.drawconic = function(conicMatrix, modifs) {
     var det = a * c * f - a * e * e - b * b * f + 2 * b * d * e - c * d * d;
     var degen = Math.abs(det) < eps;
 
+    // check for circles with very large radius 
+    if (degen && conicMatrix.usage === "Circle") {
+        var cen = General.mult(List.adjoint3(origmat), List.linfty);
+        var zabs = CSNumber.abs(cen.value[2]).value.real;
+        // we are not a degenrate circle if our center is finite
+        if (zabs > CSNumber.eps) degen = false;
+    }
+
     var cswh_max = csw > csh ? csw : csh;
 
     var x_zero = -1.5 * cswh_max;


### PR DESCRIPTION
Hi, here is the promised code. It checks if the center of our circle is a finite point, if not we should not draw the circle as line even the radius gets very small (as in 111_Moebius_It.html). The approach is much more lightweight and reliable than the previous pull request. Are there any drawbacks i have not thought of?

@gagern / @kranich: @richter-gebert asked me to merge a fix for the circle problem quickly since he needs this for an applets (or widget or whats the fancy term right now).

This should fix #139 and supersede #155.