### PR TITLE
 Continuation of Angular bisector #172 

### DIFF
--- a/examples/AngularBisectorCdy.html
+++ b/examples/AngularBisectorCdy.html
@@ -21,8 +21,6 @@
     </style>
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
-scale=1;//4 in Cinderella
-drawtext((-9,8),"C"+C.homog/scale,color->(0,0.7,0),size->20);
 draw((-9.06,0),(14.54,0),arrow->true,size->2,color->(128/255,128/255,128/255));//x-axis
 draw((0,-6.34),(0,9.34),arrow->true,size->2,color->(128/255,128/255,128/255));//y-axis
 </script>
@@ -35,10 +33,8 @@ createCindy({
 	geometry: [ 
 		{ name: "A", type: "Free", pos: [ -0.16, 0.16, 4.0 ], color: [ 1.0, 0.0, 0.0 ] }, 
 		{ name: "a", type: "Through", pos: [ -0.8739495798319329, -4.0, 0.1250420168067227 ], color: [ 1.0, 0.0, 0.0 ], args: [ "A" ] }, 
-		{ name: "B", type: "Free", pos: [ -0.16, 0.16, 4.0 ], color: [ 0.0, 0.0, 1.0 ] }, 
-		{ name: "b", type: "Through", pos: [ 3.2682926829268295, -4.0, 0.2907317073170732 ], color: [ 0.0, 0.0, 1.0 ], args: [ "B" ] }, 
-		{ name: "C", type: "Meet", pos: [ -0.16, 0.16, 4.0 ], color: [ 0.0, 1.0, 0.0 ], args: [ "a", "b" ] }, 
-		{ name: "Collection__1", type: "AngularBisector", args: [ "a", "b", "C" ] }, 
+		{ name: "b", type: "Through", pos: [ 3.2682926829268295, -4.0, 0.2907317073170732 ], color: [ 0.0, 0.0, 1.0 ], args: [ "A" ] }, 
+		{ name: "Collection__1", type: "AngularBisector", args: [ "a", "b", "A" ] }, 
 		{ name: "c", type: "SelectL", pos: [ 0.957605970573069, -4.0, 0.19830423882292275 ], color: [ 1.0, 1.0, 0.0 ], args: [ "Collection__1" ] }, 
 		{ name: "d", type: "SelectL", pos: [ 4.0, 0.9576059705730687, 0.12169576117707727 ], color: [ 0.0, 1.0, 1.0 ], args: [ "Collection__1" ] }, 
 		{ name: "Collection__2", type: "AngularBisector", args: [ "c", "d" ] }, 

--- a/examples/AngularBisectorCdy.html
+++ b/examples/AngularBisectorCdy.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>AngularBisectorCdy.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+scale=1;//4 in Cinderella
+drawtext((-9,8),"C"+C.homog/scale,color->(0,0.7,0),size->20);
+draw((-9.06,0),(14.54,0),arrow->true,size->2,color->(128/255,128/255,128/255));//x-axis
+draw((0,-6.34),(0,9.34),arrow->true,size->2,color->(128/255,128/255,128/255));//y-axis
+</script>
+
+    <script type="text/javascript">
+createCindy({
+	scripts: "cs*", grid: 1, snap: true, 
+	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 }, 
+	angleUnit: "°", 
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ -0.16, 0.16, 4.0 ], color: [ 1.0, 0.0, 0.0 ] }, 
+		{ name: "a", type: "Through", pos: [ -0.8739495798319329, -4.0, 0.1250420168067227 ], color: [ 1.0, 0.0, 0.0 ], args: [ "A" ] }, 
+		{ name: "B", type: "Free", pos: [ -0.16, 0.16, 4.0 ], color: [ 0.0, 0.0, 1.0 ] }, 
+		{ name: "b", type: "Through", pos: [ 3.2682926829268295, -4.0, 0.2907317073170732 ], color: [ 0.0, 0.0, 1.0 ], args: [ "B" ] }, 
+		{ name: "C", type: "Meet", pos: [ -0.16, 0.16, 4.0 ], color: [ 0.0, 1.0, 0.0 ], args: [ "a", "b" ] }, 
+		{ name: "Collection__1", type: "AngularBisector", args: [ "a", "b", "C" ] }, 
+		{ name: "c", type: "SelectL", pos: [ 0.957605970573069, -4.0, 0.19830423882292275 ], color: [ 1.0, 1.0, 0.0 ], args: [ "Collection__1" ] }, 
+		{ name: "d", type: "SelectL", pos: [ 4.0, 0.9576059705730687, 0.12169576117707727 ], color: [ 0.0, 1.0, 1.0 ], args: [ "Collection__1" ] }, 
+		{ name: "Collection__2", type: "AngularBisector", args: [ "c", "d" ] }, 
+		{ name: "e", type: "SelectL", pos: [ 4.0, -2.454728389053679, 0.2581891355621472 ], color: [ 0.7, 0.0, 0.0 ], args: [ "Collection__2" ], dashtype: "dashed" }, 
+		{ name: "f", type: "SelectL", pos: [ -2.454728389053677, -4.0, 0.061810864437852914 ], color: [ 0.0, 0.0, 0.7 ], args: [ "Collection__2" ], dashtype: "dashed" } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 590, height: 392, transform: [ { visibleRect: [ -9.06, 9.34, 14.54, -6.34 ] } ], background: "rgb(168,176,192)" } ], 
+	cinderella: { build: 1813, version: [ 2, 9, 1813 ] } });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/examples/FreeAngleBisector.html
+++ b/examples/FreeAngleBisector.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>FreeAngleBisector.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+draw((-9.06,0),(14.54,0),arrow->true,size->2,color->(128/255,128/255,128/255));//x-axis
+draw((0,-6.34),(0,9.34),arrow->true,size->2,color->(128/255,128/255,128/255));//y-axis
+</script>
+
+    <script type="text/javascript">
+createCindy({
+	scripts: "cs*", 
+	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 }, 
+	angleUnit: "°",  grid: 1, snap: true, 
+	geometry: [ 
+    { name: "A", type: "Free", pos: [ -0.16, 0.16, 4.0 ], color: [ 1.0, 0.0, 0.0 ] }, 
+		{ name: "a", type: "Through", pos: [ -0.8739495798319329, -4.0, 0.1250420168067227 ], color: [ 1.0, 0.0, 0.0 ], args: [ "A" ] }, 
+		{ name: "B", type: "Free", pos: [ -0.16, 0.16, 4.0 ], color: [ 0.0, 0.0, 1.0 ] }, 
+		{ name: "b", type: "Through", pos: [ 3.2682926829268295, -4.0, 0.2907317073170732 ], color: [ 0.0, 0.0, 1.0 ], args: [ "B" ] }, 
+		{ name: "Collection__1", type: "AngularBisector", args: [ "a", "b" ] }, 
+		{ name: "c", type: "SelectL", pos: [ 0.957605970573069, -4.0, 0.19830423882292275 ], color: [ 1.0, 1.0, 0.0 ], args: [ "Collection__1" ] }, 
+		{ name: "d", type: "SelectL", pos: [ 4.0, 0.9576059705730687, 0.12169576117707727 ], color: [ 0.0, 1.0, 1.0 ], args: [ "Collection__1" ] } ], 
+	ports: [ 
+		{ id: "CSCanvas", width: 590, height: 392, transform: [ { visibleRect: [ -9.06, 9.34, 14.54, -6.34 ] } ], background: "rgb(168,176,192)" } ], 
+	cinderella: { build: 1813, version: [ 2, 9, 1813 ] } });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2442,6 +2442,12 @@ geoMacros.Arc = function(el) {
     return [el];
 };
 
+geoMacros.AngularBisector = function(el) {
+    el.type = "angleBisector";
+    el.args.length = 2; // Drop point of intersection
+    return [el];
+};
+
 geoMacros.Transform = function(el) {
     var arg = csgeo.csnames[el.args[1]];
     var tr = csgeo.csnames[el.args[0]];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1336,25 +1336,22 @@ geoOps.angleBisector.signature = ["L", "L", "P"];
 geoOps.angleBisector.updatePosition = function(el) {
     var a = csgeo.csnames[el.args[0]].homog;
     var b = csgeo.csnames[el.args[1]].homog;
-    var mult = CSNumber.mult;
-    var scalAbs = function(v, l) {
-        return List.scalmult(CSNumber.sqrt(CSNumber.add(mult(v[0], v[0]), mult(v[1], v[1]))), l);
-    };
-    var as = scalAbs(b.value, a);
-    var bs = scalAbs(a.value, b);
-    var res = [List.sub(as, bs), List.add(as, bs)];
-    var chk = function(which) {
-        // Check for coincident lines
-        var t = res[which];
-        if (List._helper.isAlmostZero(t)) {
-            // Produce a line that is perpendicular to the other line at the point given
-            var l = res[1 - which].value;
-            var p = csgeo.csnames[(el.args[2])].homog;
-            t = List.cross(List.turnIntoCSList([l[0], l[1], CSNumber.zero]), p);
-        }
-        return List.normalizeMax(t);
-    };
-    el.results = tracing2(chk(0), chk(1));
+    var p = csgeo.csnames[el.args[2]].homog;
+    var add = List.add;
+    var sub = List.sub;
+    var abs = List.abs;
+    var cross = List.cross;
+    var sm = List.scalmult;
+    var nm = List.normalizeMax;
+    var isAlmostZero = List._helper.isAlmostZero;
+    var linfty = List.linfty;
+    var na = sm(abs(cross(cross(linfty, b), linfty)), a);
+    var nb = sm(abs(cross(cross(linfty, a), linfty)), b);
+    var res1 = sub(na, nb);
+    var res2 = add(na, nb);
+    if (isAlmostZero(res1)) res1 = cross(cross(cross(linfty, res2), linfty), p);
+    if (isAlmostZero(res2)) res2 = cross(cross(cross(linfty, res1), linfty), p);
+    el.results = tracing2(nm(res1), nm(res2));
 };
 geoOps.angleBisector.stateSize = tracing2.stateSize;
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1332,18 +1332,29 @@ geoOps.PolarOfLine.updatePosition = function(el) {
 
 geoOps.angleBisector = {};
 geoOps.angleBisector.kind = "Ls";
-geoOps.angleBisector.signature = ["L", "L"];
+geoOps.angleBisector.signature = ["L", "L", "P"];
 geoOps.angleBisector.updatePosition = function(el) {
     var a = csgeo.csnames[el.args[0]].homog;
     var b = csgeo.csnames[el.args[1]].homog;
-    var abs = function(v) {
-        return CSNumber.sqrt(CSNumber.add(CSNumber.mult(v[0], v[0]), CSNumber.mult(v[1], v[1])));
+    var mult = CSNumber.mult;
+    var scalAbs = function(v, l) {
+        return List.scalmult(CSNumber.sqrt(CSNumber.add(mult(v[0], v[0]), mult(v[1], v[1]))), l);
     };
-    var as = List.scalmult(abs(b.value), a);
-    var bs = List.scalmult(abs(a.value), b);
-    var erg1 = List.normalizeMax(List.sub(as, bs));
-    var erg2 = List.normalizeMax(List.add(as, bs));
-    el.results = tracing2(erg1, erg2);
+    var as = scalAbs(b.value, a);
+    var bs = scalAbs(a.value, b);
+    var res = [List.sub(as, bs), List.add(as, bs)];
+    var chk = function(which) {
+        // Check for concurrent lines
+        var t = res[which];
+        if (List._helper.isAlmostZero(t)) {
+            // Produce a line that is perpendicular to the other line at the point given
+            var l = res[1-which].value;
+            var p = csgeo.csnames[(el.args[2])].homog;
+            t = List.cross(List.turnIntoCSList([l[0], l[1], CSNumber.zero]), p);
+        }
+        return List.normalizeMax(t);
+    };
+    el.results = tracing2(chk(0), chk(1));
 };
 geoOps.angleBisector.stateSize = tracing2.stateSize;
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -31,7 +31,7 @@ geoOps.FreeLine.kind = "L";
 geoOps.FreeLine.signature = [];
 geoOps.FreeLine.isMovable = true;
 geoOps.FreeLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     putStateComplexVector(pos);
 };
 geoOps.FreeLine.getParamForInput = function(el, pos, type) {
@@ -177,7 +177,7 @@ geoOps.HorizontalLine.kind = "L";
 geoOps.HorizontalLine.signature = [];
 geoOps.HorizontalLine.isMovable = true;
 geoOps.HorizontalLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     pos = List.turnIntoCSList([CSNumber.zero, pos.value[1], pos.value[2]]);
     pos = List.normalizeMax(pos);
     putStateComplexVector(pos);
@@ -218,7 +218,7 @@ geoOps.VerticalLine.kind = "L";
 geoOps.VerticalLine.signature = [];
 geoOps.VerticalLine.isMovable = true;
 geoOps.VerticalLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     pos = List.turnIntoCSList([pos.value[0], CSNumber.zero, pos.value[2]]);
     pos = List.normalizeMax(pos);
     putStateComplexVector(pos);
@@ -2361,6 +2361,29 @@ geoOps._helper.initializePoint = function(el) {
             sx = el.pos[0];
             sy = el.pos[1];
             sz = 1;
+        }
+        if (el.pos.length === 3) {
+            sx = el.pos[0];
+            sy = el.pos[1];
+            sz = el.pos[2];
+        }
+    }
+    var pos = List.turnIntoCSList([
+        CSNumber._helper.input(sx),
+        CSNumber._helper.input(sy),
+        CSNumber._helper.input(sz)
+    ]);
+    pos = List.normalizeMax(pos);
+    return pos;
+};
+
+geoOps._helper.initializeLine = function(el) {
+    var sx = 0;
+    var sy = 0;
+    var sz = 0;
+    if (el.pos) {
+        if (el.pos.ctype === "list" && List.isNumberVector(el.pos)) {
+            return el.pos;
         }
         if (el.pos.length === 3) {
             sx = el.pos[0];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1334,61 +1334,15 @@ geoOps.angleBisector = {};
 geoOps.angleBisector.kind = "Ls";
 geoOps.angleBisector.signature = ["L", "L"];
 geoOps.angleBisector.updatePosition = function(el) {
-    var xx = csgeo.csnames[(el.args[0])];
-    var yy = csgeo.csnames[(el.args[1])];
-
-    var poi = List.normalizeMax(List.cross(xx.homog, yy.homog));
-
-    var myI = List.normalizeMax(List.cross(List.ii, poi));
-    var myJ = List.normalizeMax(List.cross(List.jj, poi));
-
-    var sqi = CSNumber.sqrt(CSNumber.mult(List.det3(poi, yy.homog, myI), List.det3(poi, xx.homog, myI)));
-    var sqj = CSNumber.sqrt(CSNumber.mult(List.det3(poi, yy.homog, myJ), List.det3(poi, xx.homog, myJ)));
-
-    var mui = General.mult(myI, sqj);
-    var tauj = General.mult(myJ, sqi);
-
-    var erg1 = List.add(mui, tauj);
-    var erg2 = List.sub(mui, tauj);
-
-    var erg1zero = List.abs(erg1).value.real < CSNumber.eps;
-    var erg2zero = List.abs(erg2).value.real < CSNumber.eps;
-
-    if (!erg1zero && !erg2zero) {
-        erg1 = List.normalizeMax(erg1);
-        erg2 = List.normalizeMax(erg2);
-    } else if (erg1zero) {
-        erg2 = List.normalizeMax(erg2);
-    } else if (erg2zero) {
-        erg1 = List.normalizeMax(erg1);
-    }
-
-    // degenrate case
-    if ((List.almostequals(erg1, List.linfty).value && erg2zero) || (List.almostequals(erg2, List.linfty).value && erg1zero)) {
-        var mu, tau, mux, tauy;
-        if (List.abs(erg1).value.real < List.abs(erg2).value.real) {
-            mu = List.det3(poi, yy.homog, erg2);
-            tau = List.det3(poi, xx.homog, erg2);
-
-            mux = General.mult(xx.homog, mu);
-            tauy = General.mult(yy.homog, tau);
-
-            erg1 = List.add(mux, tauy);
-
-        } else {
-            mu = List.det3(poi, yy.homog, erg1);
-            tau = List.det3(poi, xx.homog, erg1);
-
-            mux = General.mult(xx.homog, mu);
-            tauy = General.mult(yy.homog, tau);
-
-            erg2 = List.add(mux, tauy);
-        }
-    }
-
-    erg1 = List.normalizeMax(erg1);
-    erg2 = List.normalizeMax(erg2);
-
+    var a = csgeo.csnames[el.args[0]].homog;
+    var b = csgeo.csnames[el.args[1]].homog;
+    var abs = function(v) {
+        return CSNumber.sqrt(CSNumber.add(CSNumber.mult(v[0], v[0]), CSNumber.mult(v[1], v[1])));
+    };
+    var as = List.scalmult(abs(b.value), a);
+    var bs = List.scalmult(abs(a.value), b);
+    var erg1 = List.normalizeMax(List.sub(as, bs));
+    var erg2 = List.normalizeMax(List.add(as, bs));
     el.results = tracing2(erg1, erg2);
 };
 geoOps.angleBisector.stateSize = tracing2.stateSize;

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1671,9 +1671,25 @@ geoOps.SelectP.updatePosition = function(el) {
 geoOps.SelectL = {};
 geoOps.SelectL.kind = "L";
 geoOps.SelectL.signature = ["Ls"];
+geoOps.SelectL.initialize = function(el) {
+    if (el.index !== undefined)
+        return el.index - 1;
+    var set = csgeo.csnames[(el.args[0])].results.value;
+    var pos = geoOps._helper.initializeLine(el);
+    var d1 = List.projectiveDistMinScal(pos, set[0]);
+    var best = 0;
+    for (var i = 1; i < set.length; ++i) {
+        var d2 = List.projectiveDistMinScal(pos, set[i]);
+        if (d2 < d1) {
+            d1 = d2;
+            best = i;
+        }
+    }
+    return best;
+};
 geoOps.SelectL.updatePosition = function(el) {
     var set = csgeo.csnames[(el.args[0])];
-    el.homog = set.results.value[el.index - 1];
+    el.homog = set.results.value[el.param];
     el.homog = General.withUsage(el.homog, "Line");
 };
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1344,7 +1344,7 @@ geoOps.angleBisector.updatePosition = function(el) {
     var bs = scalAbs(a.value, b);
     var res = [List.sub(as, bs), List.add(as, bs)];
     var chk = function(which) {
-        // Check for concurrent lines
+        // Check for coincident lines
         var t = res[which];
         if (List._helper.isAlmostZero(t)) {
             // Produce a line that is perpendicular to the other line at the point given
@@ -2455,7 +2455,21 @@ geoMacros.Arc = function(el) {
 
 geoMacros.AngularBisector = function(el) {
     el.type = "angleBisector";
-    el.args.length = 2; // Drop point of intersection
+    if (el.args.length === 2) {
+        el.args.push("$InternalNullPoint$");
+        if (csgeo.csnames[el.args[2]] === undefined) {
+            var el2 = {
+                name: el.args[2],
+                type: "Free",
+                pos: [0, 0, 0],
+                pinned: true,
+                labeled: false,
+                visible: false,
+                size: 0
+            };
+            addElement(el2);
+        }
+    }
     return [el];
 };
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1348,7 +1348,7 @@ geoOps.angleBisector.updatePosition = function(el) {
         var t = res[which];
         if (List._helper.isAlmostZero(t)) {
             // Produce a line that is perpendicular to the other line at the point given
-            var l = res[1-which].value;
+            var l = res[1 - which].value;
             var p = csgeo.csnames[(el.args[2])].homog;
             t = List.cross(List.turnIntoCSList([l[0], l[1], CSNumber.zero]), p);
         }


### PR DESCRIPTION
@gagern wrote:
This makes `AngularBisector` ready to be exported from Cinderella. It requires a version of Cinderella which is recent enough to export `SelectL` not `SelectP`. The implementation of `SelectL` required a rework similar to what I did to `SelectP` in [3eefed8](https://github.com/CindyJS/CindyJS/commit/3eefed8632fb0d7a4584c573137689b77c7d8ec0). For reasons unknown (to me), Cinderella exports the point of intersection as a third argument. Since our internal operation only expects two lines, I'm using the macro step to also ensure that the third argument gets dropped. I will probably file a Cinderella merge request to not export that argument at all.

What I've done is simplify `angleBisector.updatePosition` to not create or make use of the intersection of the two lines. I've also modified @gagern's `AngularBisectorCdy.html` to  to run lines a and b through separated points, create the intersection point of the two lines and  show the coordinates of the intersection point using `CindyScript`. The axes, grid and point snapping are also turned on.

Since Cinderella currently exports the `AngularBisector` name instead of the name @kranich and I prefer  `AngleBisector` I have left that name as is. I would welcome any example of @kortenkamp's that shows where this implementation of `angleBisector.updatePosition` fails. When the lines are identical, this implementation produces one line identical to the other two lines and one ideal line [0,0,0]. When the lines are parallel, this implementation produces a line mid-way and parallel to the other two lines and one line at infinity. 

