### PR TITLE
Allow manipulating lines in CindyJS

### DIFF
--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -181,7 +181,7 @@ Accessor.setField = function(geo, field, value) {
     }
 
 
-    if (field === "homog" && geo.kind === "P" && geo.movable && List._helper.isNumberVecN(value, 3)) {
+    if (field === "homog" && (geo.kind === "P" || geo.kind === "L") && geo.movable && List._helper.isNumberVecN(value, 3)) {
         movepointscr(geo, value, "homog");
     }
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -282,16 +282,17 @@ geoOps.Through.initialize = function(el) {
     putStateComplexVector(dir);
 };
 geoOps.Through.getParamForInput = function(el, pos, type) {
-    var l;
+    var dir;
     if (type === "mouse") {
         var p1 = csgeo.csnames[(el.args[0])].homog;
-        l = List.cross(p1, pos);
-    } else if (type === "homog") {
-        l = pos;
+        dir = List.cross(List.linfty, List.cross(p1, pos));
+    } else if (type === "homog") { // For use by Accessor.setField(geo, "homog", value)
+        dir = List.cross(List.linfty, pos);
+    } else if (type === "dir") { // For use by Accessor.setField(geo, "angle", value)
+        dir = pos;
     } else {
-        l = List.turnIntoCSList([CSNumber.zero, CSNumber.zero, CSNumber.zero]);
+        dir = List.turnIntoCSList([CSNumber.zero, CSNumber.zero, CSNumber.zero]);
     }
-    var dir = List.cross(List.linfty, l);
     // The parameter is the point at infinity, without its last coordinate.
     return List.normalizeMax(dir);
 };


### PR DESCRIPTION
A call to `Accessor.setField(geo, "angle", value)` on a line through a point results in a call `movepointscr(geo, dir, "dir")`. `geoOps.Through.getParamForInput` did not support `"dir"` as a valid type. Also CindyScript couldn't set a line's `homog` value.

I ran into this problem when I was instrumenting an example file for #183. The instrumented example using JavaScript and CindyScript to manipulate lines and points in CindyJS is [AngularBisectorCS.html](https://gist.github.com/elkins0/0baf165f01ff9440c9b4) 