### PR TITLE
Make branch cut of CSNumber.sqrt consistent with Cinderella

### DIFF
--- a/src/js/libcs/CSNumber.js
+++ b/src/js/libcs/CSNumber.js
@@ -400,6 +400,8 @@ CSNumber.sqrt = function(a) {
     var ii = a.value.imag;
     var n = Math.sqrt(Math.sqrt(rr * rr + ii * ii));
     var w = Math.atan2(ii, rr);
+    if (w < 0)
+        w += 2 * Math.PI;
     var i = n * Math.sin(w / 2);
     var r = n * Math.cos(w / 2);
     return {

--- a/tests/CSNumber_tests.js
+++ b/tests/CSNumber_tests.js
@@ -189,7 +189,7 @@ describe("Trigonometry", function() {
   });
 
   it("sqrt", function() {
-    var sqrt_f_a = CSNumber.complex(10.000031249755862,-0.024999921875854481);
+    var sqrt_f_a = CSNumber.complex(-10.000031249755862,0.024999921875854481);
     var sqrt_f_b = CSNumber.complex(0.55589297025142115,0.89945371997393364);
 
     expect(CSNumber._helper.isAlmostEqual(sqrt_f_a, CSNumber.sqrt(f_a))).toBe(true);


### PR DESCRIPTION
This should fix #15.

Note that the result of the test case is now consistent with the output of Cinderella, unlike before.