### PR TITLE
Refer to node executable using the $NODE environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "whole-line-stream": "^0.1.0"
   },
   "scripts": {
-    "prepublish": "node make/index.js call_npm=false parallel=true build=release all",
-    "test": "node make/index.js call_npm=false alltests"
+    "prepublish": "$NODE make/index.js call_npm=false parallel=true build=release all",
+    "test": "$NODE make/index.js call_npm=false alltests"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should help in situations like e.g. Debian, where the node binary is called `nodejs`, but perhaps also Windows, where it is called `node.exe` and may not be included in the `PATH`.

The `$NODE` environment variable has been available in npm since https://github.com/npm/npm/commit/9c63b765a6d125324cf27ae01785e0d13ec62b9f from 2012.

To test, see whether `npm install` and `npm test` work if called from the top level directory.