### PR TITLE
Change default lineJoin to round

### DIFF
--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -294,7 +294,7 @@ Render2D.makeColor = function(colorraw) {
 Render2D.preDrawCurve = function() {
     csctx.lineWidth = Render2D.lsize;
     csctx.lineCap = 'round';
-    csctx.lineJoin = 'miter';
+    csctx.lineJoin = 'round';
     csctx.strokeStyle = Render2D.lineColor;
 };
 


### PR DESCRIPTION
This fixes a regression for drawpoly.  In the long run modifiers to change line join and line cap style would be nice, but this here is just a hot fix.