### PR TITLE
lineCap, lineJoin, and miterLimit modifiers

### DIFF
--- a/examples/134_LineCap.html
+++ b/examples/134_LineCap.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+n = 5;
+pts = apply(0..4, gauss(exp(i*2*pi*#/n)));
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+draw([[-1, 1], [1, 1]], lineCap -> "butt", size->10);
+draw([[-1, 0], [1, 0]], lineCap -> "round", size->10);
+draw([[-1, -1], [1, -1]], lineCap -> "square", size->10);
+</script>
+<script type="text/javascript">
+
+var cdy = createCindy({
+  ports: [{id: "CSCanvas", visibleRect: [-2, 2, 2, -2], width: 500, height: 500 }],
+  scripts: "cs*"
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas" width="500" height="500"
+          style="border:2px solid black"></canvas>
+</body>
+
+</html>
+

--- a/examples/135_LineJoin.html
+++ b/examples/135_LineJoin.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+n = 5;
+pts = apply(0..4, gauss(exp(i*2*pi*#/n)));
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+drawpoly(apply(pts, # + [-3, 0]), lineJoin -> "round", size->7);
+drawpoly(pts, lineJoin -> "bevel", size->7);
+drawpoly(apply(pts, # + [3, 0]), lineJoin -> "miter", size->7);
+</script>
+<script type="text/javascript">
+
+var cdy = createCindy({
+  ports: [{id: "CSCanvas", visibleRect: [-5, 5, 5, -5], width: 500, height: 500 }],
+  scripts: "cs*"
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas" width="500" height="500"
+          style="border:2px solid black"></canvas>
+</body>
+
+</html>
+

--- a/examples/136_MiterLimit.html
+++ b/examples/136_MiterLimit.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+pts = [[-2, 0.2], [0, 0], [-2, -0.2]];
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+connect(pts, lineJoin -> "miter", miterLimit->10, size->7);
+connect(apply(pts, # + [3, 0]), lineJoin -> "miter", miterLimit->20, size->7);
+</script>
+<script type="text/javascript">
+
+var cdy = createCindy({
+  ports: [{id: "CSCanvas", visibleRect: [-5, 5, 5, -5], width: 500, height: 500 }],
+  scripts: "cs*"
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas" width="500" height="500"
+          style="border:2px solid black"></canvas>
+</body>
+
+</html>
+

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1024,6 +1024,9 @@ evaluator.plot$2 = function(args, modifs) {
         "dashpattern": true,
         "dashtype": true,
         "dashing": true,
+        "lineCap": true,
+        "lineJoin": true,
+        "miterLimit": true,
 
         "connect": function(v) {
             if (v.ctype === 'boolean')
@@ -1047,8 +1050,6 @@ evaluator.plot$2 = function(args, modifs) {
     });
     csctx.strokeStyle = Render2D.lineColor;
     csctx.lineWidth = Render2D.lsize;
-    csctx.lineCap = 'round';
-    csctx.lineJoin = 'round';
 
     function canbedrawn(v) {
         return v.ctype === 'number' && CSNumber._helper.isAlmostReal(v);
@@ -1254,7 +1255,9 @@ evaluator.plotX$1 = function(args, modifs) { //OK
     var col = csport.drawingstate.linecolor;
     csctx.fillStyle = col;
     csctx.lineWidth = 1;
-    csctx.lineCap = 'round';
+    csctx.lineCap = Render2D.lineCap;
+    csctx.lineJoin = Render2D.lineJoin;
+    csctx.miterLimit = Render2D.miterLimit;
 
     var stroking = false;
 

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -22,6 +22,9 @@ Render2D.handleModifs = function(modifs, handlers) {
     Render2D.align = 0;
     Render2D.xOffset = 0;
     Render2D.yOffset = 0;
+    Render2D.lineCap = "round";
+    Render2D.lineJoin = "round";
+    Render2D.miterLimit = 10;
 
     // Process handlers
     var key, handler;
@@ -242,6 +245,21 @@ Render2D.modifHandlers = {
         }
     },
 
+    "lineCap": function(v) {
+        if (v.ctype === "string" && (v.value === "round" || v.value === "square" || v.value === "butt"))
+            Render2D.lineCap = v.value;
+    },
+
+    "lineJoin": function(v) {
+        if (v.ctype === "string" && (v.value === "round" || v.value === "bevel" || v.value === "miter"))
+            Render2D.lineJoin = v.value;
+    },
+
+    "miterLimit": function(v) {
+        if (v.ctype === "number" && v.value.real > 0) {
+            Render2D.miterLimit = Math.round(v.value.real);
+        }
+    }
 };
 
 Render2D.lineModifs = {
@@ -257,6 +275,7 @@ Render2D.lineModifs = {
     "arrowsides": true,
     "arrowposition": true,
     "arrowsize": true,
+    "lineCap": true
 };
 
 Render2D.pointModifs = {
@@ -267,7 +286,14 @@ Render2D.pointModifs = {
 
 Render2D.pointAndLineModifs = Render2D.lineModifs;
 
-Render2D.conicModifs = Render2D.pointModifs;
+Render2D.conicModifs = {
+    "size": true,
+    "color": true,
+    "alpha": true,
+    "lineCap": true,
+    "lineJoin": true,
+    "miterLimit": true
+};
 
 Render2D.textModifs = {
     "size": true,
@@ -293,8 +319,9 @@ Render2D.makeColor = function(colorraw) {
 
 Render2D.preDrawCurve = function() {
     csctx.lineWidth = Render2D.lsize;
-    csctx.lineCap = 'round';
-    csctx.lineJoin = 'round';
+    csctx.lineCap = Render2D.lineCap;
+    csctx.lineJoin = Render2D.lineJoin;
+    csctx.miterLimit = Render2D.miterLimit;
     csctx.strokeStyle = Render2D.lineColor;
 };
 
@@ -311,8 +338,9 @@ Render2D.drawsegcore = function(pt1, pt2) {
     var overhang2x = overhang1 * endpoint2x + overhang2 * endpoint1x;
     var overhang2y = overhang1 * endpoint2y + overhang2 * endpoint1y;
     csctx.lineWidth = Render2D.lsize;
-    csctx.lineCap = 'round';
-    csctx.lineJoin = 'round';
+    csctx.lineCap = Render2D.lineCap;
+    csctx.lineJoin = Render2D.lineJoin;
+    csctx.miterLimit = Render2D.miterLimit;
     csctx.strokeStyle = Render2D.lineColor;
 
 


### PR DESCRIPTION
Added `lineCap`, `lineJoin`, and `miterLimit` modifiers to drawing operators. This should fix #197.

`lineCap` should be one of `round`, `square`, and `butt`. Default is `round`.
See examples/134_LineCap.html.

`lineJoin` should be one of `round`, `bevel`, and `miter`. Default is `round`.
See examples/135_LineJoin.html.

`miterLimit` should be a positive number. Default is `10`.
See examples/136_MiterLimit.html.