### PR TITLE
bugfix: colorplot on HiDPI displays was not handled correctly

### DIFF
--- a/examples/cindygl/18_hidpitest.html
+++ b/examples/cindygl/18_hidpitest.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+    <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+    <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: HiDPI-Test</h1>
+    <script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+      
+      createimage("256", 256, 256);
+      createimage("128", 128, 128);
+      createimage("64", 64, 64);
+    </script>
+    <script id="csdraw" type="text/x-cindyscript">
+     L = [0, 0];
+     R = [128, 0];
+     
+     plot(p) := (
+      if(p.y>100, random(),
+      d = abs(p - (64, 64));
+      if(d<20, 1, 
+        if(d<30, 0,
+          floor(sin(.01*(p.x*p.x+p.y*p.y))+1)
+        )
+      )
+     ));
+     
+     colorplot(L, R, "256", plot(#));
+     colorplot(L, R, "128", plot(#));
+     colorplot(L, R, "64", plot(#));
+     
+     colorplot(plot(#)); //This is supposed to be printed in factual screen resolution
+     drawimage([128,0], [256, 0], "256");
+     drawimage([256,0], [384, 0], "128");
+     drawimage([384,0], [512, 0], "64");
+     
+     drawtext([0,100],"colorplot()", color->red(.9));
+     drawtext([128,100],"256x256", color->red(.9));
+     drawtext([256,100],"128x128", color->red(.9));
+     drawtext([386,100],"64x64", color->red(.9));
+    </script>
+    
+    The two leftimages should have a resolution higher than 128x128 on HiDPI-displays.
+    <canvas  id="CSCanvas" style="position:relative; top:0px;"></canvas>
+    
+    <script type="text/javascript">
+        var gslp=[];
+        cdy = createCindy({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    autoplay: true,
+                    geometry: gslp,
+                    images: {image: "image.png"},
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 512,
+                      height: 128,
+                      transform: [ { visibleRect: [0, 0, 512, 128] } ]
+                    }]
+                    }
+        );
+    </script>
+
+
+	</body>
+</html>

--- a/src/js/cindygl/Plugin.js
+++ b/src/js/cindygl/Plugin.js
@@ -48,9 +48,12 @@ createCindy.registerPlugin(1, "CindyGL", function(api) {
 
     var prog = args[0];
 
-    let cw = api.instance['canvas']['clientWidth'];
+    let cw = api.instance['canvas']['clientWidth']; //CSS pixels
     let ch = api.instance['canvas']['clientHeight'];
 
+    let iw = api.instance['canvas']['width']; //internal measures. might be twice as cw on HiDPI-Displays
+    let ih = api.instance['canvas']['height'];
+    
     let m = api.getInitialMatrix();
     let transf = function(px, py) { //copied from Operators.js
       var xx = px - m.tx;
@@ -63,9 +66,9 @@ createCindy.registerPlugin(1, "CindyGL", function(api) {
       };
       return erg;
     };
-    compileAndRender(prog, transf(0, ch), transf(cw, ch), cw, ch, null);
+    compileAndRender(prog, transf(0, ch), transf(cw, ch), iw, ih, null);
     let csctx = api.instance['canvas'].getContext('2d');
-    csctx.drawImage(glcanvas, 0, 0, cw, ch, 0, 0, cw, ch);
+    csctx.drawImage(glcanvas, 0, 0, iw, ih, 0, 0, cw, ch);
     return nada;
   });
 


### PR DESCRIPTION
Now the 1-adic colorplot renders in "real resolution" instead of CSS-resolution. Therefore content looks nicer on HiDPI-displays.