### PR TITLE
Upgrade Google Closure Compiler to latest version (v20160208)

### DIFF
--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20150126",
+        closure_version: "20160201",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",

--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160201",
+        closure_version: "20160208",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",

--- a/make/build.js
+++ b/make/build.js
@@ -269,6 +269,7 @@ module.exports = function build(settings, task) {
         var opts = {
             language_in: "ECMASCRIPT6_STRICT",
             language_out: "ECMASCRIPT5_STRICT",
+            dependency_mode: "LOOSE",
             create_source_map: "build/js/Cindy3D.js.map",
             compilation_level: this.setting("c3d_closure_level"),
             warning_level: this.setting("c3d_closure_warnings"),
@@ -285,7 +286,7 @@ module.exports = function build(settings, task) {
             })),
         };
         if (this.setting("cindy3d-dbg") !== undefined) {
-            opts.transpile_only = true;
+            opts.compilation_level = "WHITESPACE_ONLY";
             opts.formatting = "PRETTY_PRINT";
         }
         this.closureCompiler(closure_jar, opts);
@@ -336,6 +337,7 @@ module.exports = function build(settings, task) {
         var opts = {
             language_in: "ECMASCRIPT6_STRICT",
             language_out: "ECMASCRIPT5_STRICT",
+            dependency_mode: "LOOSE",
             create_source_map: "build/js/CindyGL.js.map",
             compilation_level: this.setting("cgl_closure_level"),
             warning_level: this.setting("cgl_closure_warnings"),
@@ -354,7 +356,7 @@ module.exports = function build(settings, task) {
             })),
         };
         if (this.setting("cindygl-dbg") !== undefined) {
-            opts.transpile_only = true;
+            opts.compilation_level = "WHITESPACE_ONLY";
             opts.formatting = "PRETTY_PRINT";
         }
         this.closureCompiler(closure_jar, opts);

--- a/plugins/cindy3d/src/js/Ops3D.js
+++ b/plugins/cindy3d/src/js/Ops3D.js
@@ -306,7 +306,8 @@ createCindy.registerPlugin(1, "Cindy3D", function(api) {
    * @param {!function(number, number, number, number)} callback  invoked once per mesh face
    */
   function iterMesh(m, n, tcr, tcc, callback) {
-    for (let i = 1, k = 0; i < m; ++i) {
+    let k = 0;
+    for (let i = 1; i < m; ++i) {
       for (let j = 1; j < n; ++j) {
         callback(k, k + 1, k + n + 1, k + n);
         ++k;


### PR DESCRIPTION
This pull request updates Google Closure Compiler to the latest version.

Among the benefits are:

* official support for ECMAScript 6 (since v20151015)
* many ES6 related bug fixes
* support for ES6 modules (opt-in)
* slightly smaller output size