### PR TITLE
CindyGL: clone only relevant cindyjs-expression instead of whole object

### DIFF
--- a/src/js/cindygl/CodeBuilder.js
+++ b/src/js/cindygl/CodeBuilder.js
@@ -470,7 +470,7 @@ CodeBuilder.prototype.determineUniformTypes = function() {
 CodeBuilder.prototype.copyRequiredFunctions = function(expr) {
   if (expr['ctype'] === 'function' && !this.myfunctions.hasOwnProperty(expr['oper']) && this.api.getMyfunction(expr['oper']) !== null) { //copy and transverse recursively all occuring myfunctions
     let fun = expr['oper'];
-    this.myfunctions[fun] = clone(this.api.getMyfunction(fun));
+    this.myfunctions[fun] = cloneExpression(this.api.getMyfunction(fun));
     this.copyRequiredFunctions(this.myfunctions[fun].body);
   }
   for (let i in expr['args']) {
@@ -851,7 +851,7 @@ CodeBuilder.prototype.generateHeaderOfCompiledFunctions = function() {
 };
 
 CodeBuilder.prototype.generateColorPlotProgram = function(expr) { //TODO add arguments for #
-  expr = clone(expr); //then we can write dirty things on expr...
+  expr = cloneExpression(expr); //then we can write dirty things on expr...
 
   this.precompile(expr); //determine this.variables, types etc.
   let r = this.compile(expr, '', true);

--- a/src/js/cindygl/General.js
+++ b/src/js/cindygl/General.js
@@ -4,18 +4,17 @@
 
 
 /**
- * clone some object while ignoring  pointer-references to the same child
+ * clones expression while ignoring  pointer-references to the same child
  */
-function clone(obj) {
+function cloneExpression(obj) {
   var copy;
-  // Handle the 3 simple types, and null or undefined
   if (null == obj || "object" != typeof obj) return obj;
   // Handle Object
   // Handle Array
   if (obj instanceof Array) {
     copy = [];
     for (var i = 0, len = obj.length; i < len; i++) {
-      copy[i] = clone(obj[i]);
+      copy[i] = cloneExpression(obj[i]);
     }
     return copy;
   }
@@ -23,7 +22,25 @@ function clone(obj) {
   if (obj instanceof Object) {
     copy = {};
     for (var attr in obj) {
-      if (obj.hasOwnProperty(attr)) copy[attr] = clone(obj[attr]);
+      if (obj.hasOwnProperty(attr)) {
+        if(['oper',
+          'impl',
+          'args',
+          'ctype',
+          'stack',
+          'name',
+          'modifs',
+          'arglist',
+          'value',
+          'real',
+          'imag',
+          'key',
+          'obj',
+          'body'
+        ].indexOf(attr)>=0)
+          copy[attr] = cloneExpression(obj[attr]);
+        else console.log("Did not copy " + attr);
+      }
     }
     return copy;
   }


### PR DESCRIPTION
This fixes some problem on Safari. Also required for #182 to work with Safari.