### PR TITLE
Rudementary saving of geometric state

### DIFF
--- a/make/sources.js
+++ b/make/sources.js
@@ -23,6 +23,7 @@ exports.libgeo = [
     "src/js/libgeo/Tracing.js",
     "src/js/libgeo/GeoOps.js",
     "src/js/libgeo/GeoScripts.js",
+    "src/js/libgeo/StateIO.js",
 ];
 
 exports.liblab = [

--- a/src/js/libcs/General.js
+++ b/src/js/libcs/General.js
@@ -199,6 +199,31 @@ General.wrap = function(v) {
     return nada;
 };
 
+General.unwrap = function(v) {
+    if (typeof v !== "object" || v === null) {
+        return v;
+    }
+    if (Array.isArray(v)) {
+        return v.map(General.unwrap);
+    }
+    switch (v.ctype) {
+        case "string":
+        case "boolean":
+            return v.value;
+        case "number":
+            if (v.value.imag === 0)
+                return v.value.real;
+            return {
+                r: v.value.real,
+                i: v.value.imag
+            };
+        case "list":
+            return v.value.map(General.unwrap);
+        default:
+            return null;
+    }
+};
+
 General.withUsage = function(v, usage) {
     // shallow copy with possibly new usage
     return {

--- a/src/js/libgeo/StateIO.js
+++ b/src/js/libgeo/StateIO.js
@@ -1,0 +1,117 @@
+// Functions to save and restore geometric state
+
+var attributesToClone = [
+    //"_traces", // internal
+    //"_traces_index", // internal
+    //"_traces_tick", // internal
+    "alpha",
+    "angle", // LineByFixedAngle, may need update once we have inspect
+    //"antipodalPoint", // internal, PointOnCircle to OtherPointOnCircle
+    "args",
+    "arrow",
+    "arrowposition",
+    "arrowshape",
+    "arrowsides",
+    "arrowsize",
+    //"behavior", // needs dedicated code
+    "clip",
+    "color",
+    "dashtype",
+    //"dir", // Through, not needed if we export pos
+    "drawtrace",
+    //"dualMatrix", // output for conic
+    //"endPoint", // output for arc
+    //"endpos", // output for segment
+    //"farpoint", // output for segment
+    "filled", // drawgeoarc
+    //"homog", // save as pos
+    //"incidences", // internal
+    //"index", // should not be used, select by pos
+    //"isArc", // internal
+    //"isshowing", // internal
+    //"kind", // internal
+    "labeled",
+    "labelpos",
+    //"mat1", // output of Möbius transformations
+    //"mat2", // output of Möbius transformations
+    //"matrix", // output of conic or transform
+    //"movable", // internal
+    "name",
+    "overhang",
+    //"param", // internal
+    "pinned",
+    //"pos", // needs dedicated code
+    "printname",
+    "radius", // CircleMr, does seem to update this
+    //"results", // output of multi-valued operations
+    //"rot", // internal, LineByFixedAngle
+    //"sclRsq", // internal, TrReflectionC
+    "size",
+    //"startPoint", // output for arc
+    //"startpos", // output for segment
+    //"stateIdx", // internal
+    "text_fontfamily",
+    "textbold",
+    "textitalics",
+    "textsize",
+    //"tooClose", // internal
+    "tracedim",
+    "tracelength",
+    "traceskip",
+    "tracing",
+    "type",
+    //"viaPoint", // output for arc
+    "visible",
+];
+
+function savePos(el) {
+    if (!(/^Select/.test(el.type) || geoOps[el.type].isMovable))
+        return null; // Fully determined by arguments, no position needed
+    var unwrap = General.unwrap;
+    var sum = CSNumber.sum;
+    switch (el.kind) {
+        case "P":
+        case "L":
+            return unwrap(el.homog);
+        case "C":
+            var mat = el.mat.value;
+            return {
+                xx: unwrap(mat[0].value[0]),
+                yy: unwrap(mat[1].value[1]),
+                zz: unwrap(mat[2].value[2]),
+                xy: unwrap(sum(mat[0].value[1], mat[1].value[0])),
+                xz: unwrap(sum(mat[0].value[2], mat[2].value[0])),
+                yz: unwrap(sum(mat[1].value[2], mat[2].value[1])),
+            };
+        default:
+            return null;
+    }
+}
+
+function saveGeoElement(el) {
+    var res = {};
+    attributesToClone.forEach(function(key) {
+        if (!el.hasOwnProperty(key)) return;
+        var val = General.unwrap(el[key]);
+        if (val !== null && val !== undefined)
+            res[key] = val;
+    });
+    var pos = savePos(el);
+    if (pos) res.pos = pos;
+    return res;
+}
+
+function saveGeoState() {
+    var res = [];
+    csgeo.gslp.forEach(function(el) {
+        if (el.tmp) return;
+        res.push(saveGeoElement(el));
+    });
+    return res;
+}
+
+globalInstance.saveState = function() {
+    return {
+        geometry: saveGeoState(),
+    };
+};


### PR DESCRIPTION
This only saves the geometry portion of the current state, not the current assignment of variables or the properties of a physics simulation. So it's a first step. Since the API hasn't stabilized yet, there intentionally is no documentation. The idea is that the object returned from `cdy.saveState()` will gain properties as we learn how to store more and more aspects of internal state; at the moment there is only a `geometry` object which can be used in place of the original `geometry` component of the `createCindy` options object. One day we may have an accompanying `cdy.restoreState(savedState)` call to reinsert a saved state into a running instance.