### PR TITLE
Arrow heads empty and jet

### DIFF
--- a/examples/07_Feldlinien_newarrows.html
+++ b/examples/07_Feldlinien_newarrows.html
@@ -33,8 +33,8 @@
                           col=(c1,c2,0);
                           col=col/abs(col)*.7;
                           linesize(sqrt(s)*3);
-			  //draw(p-f*1.5,p+f*.5, arrow->true, arrowshape->"default", arrowsides->"==>", arrowsize->0.7, color->(0,0,1),color->col);
-			  draw(p-f*1.5,p+f*.5,arrow->true, arrowshape->"default" ,color->col);
+			  //draw(p-f*1.5,p+f*.5, arrow->true, arrowshape->"line", arrowsides->"==>", arrowsize->0.7, color->(0,0,1),color->col);
+			  draw(p-f*1.5,p+f*.5,arrow->true, arrowshape->"line" ,color->col);
                           //draw(p+f*.5,p+nn*.8,color->(0,0,1),alpha->0.9,color->col);
                           //draw(p+f*.5,p-nn*.8,color->(0,0,1),alpha->0.9,color->col);
                           )

--- a/examples/arrow_playground.html
+++ b/examples/arrow_playground.html
@@ -117,6 +117,12 @@ draw(H,K,size->2,alpha->0.5, arrow->true, arrowshape->"full", arrowsides->"==>",
                       {name:"XX1", type:"Free", pos:[8,-6],color:[1,0,0],size:3},
                       {name:"YY1", type:"Free", pos:[12,-6],color:[1,0,0],size:3},
 		      {name:"GSLP2", type:"Segment", args:["XX1","YY1"], arrow:true, arrowsides: "<==", arrowshape: "default", arrowsize: 3, arrowposition: 0.8, color: [0,1,0], },
+                      {name:"XX2", type:"Free", pos:[8,-4],color:[1,0,0],size:3},
+                      {name:"YY2", type:"Free", pos:[12,-4],color:[1,0,0],size:3},
+		      {name:"GSLP3", type:"Segment", args:["XX2","YY2"], arrow:true, arrowsides: "<==", arrowshape: "empty", arrowsize: 3, arrowposition: 0.8, color: [1,0,1], },
+                      {name:"XX3", type:"Free", pos:[8,-3],color:[1,0,0],size:3},
+                      {name:"YY3", type:"Free", pos:[12,-3],color:[1,0,0],size:3},
+		      {name:"GSLP4", type:"Segment", args:["XX3","YY3"], arrow:true, arrowsides: "<==", arrowshape: "jet", arrowsize: 3, arrowposition: 0.8, color: [0,0.8,0.8], },
 
 
                     ];

--- a/examples/arrow_playground.html
+++ b/examples/arrow_playground.html
@@ -75,7 +75,7 @@ draw(E,F,size->2,alpha->0.5, arrow->true, arrowshape->"full", arrowsides->"==>",
 
 draw(G,H,size->2,alpha->0.5, arrow->true, arrowshape->"full", arrowsides->"<==>", arrowsize->1.5, arrowposition->0.6);
 
-draw(I,J,size->2,alpha->0.5, arrow->true, arrowshape->"default", arrowsides->"<==>", arrowsize->0.7, arrowposition->0.2);
+draw(I,J,size->2,alpha->0.5, arrow->true, arrowshape->"line", arrowsides->"<==>", arrowsize->0.7, arrowposition->0.2);
 param = |X-Y|/6;
 draw(K,L,size->2,alpha->0.5, arrow->true, arrowshape->"full", arrowsides->"<==>", arrowsize->1.5, arrowposition->param);
 draw(L,J,size->2,alpha->0.1, arrow->true, arrowshape->"full", arrowsides->"<==>", arrowsize->param, arrowposition->0.8);
@@ -116,7 +116,7 @@ draw(H,K,size->2,alpha->0.5, arrow->true, arrowshape->"full", arrowsides->"==>",
 
                       {name:"XX1", type:"Free", pos:[8,-6],color:[1,0,0],size:3},
                       {name:"YY1", type:"Free", pos:[12,-6],color:[1,0,0],size:3},
-		      {name:"GSLP2", type:"Segment", args:["XX1","YY1"], arrow:true, arrowsides: "<==", arrowshape: "default", arrowsize: 3, arrowposition: 0.8, color: [0,1,0], },
+		      {name:"GSLP2", type:"Segment", args:["XX1","YY1"], arrow:true, arrowsides: "<==", arrowshape: "line", arrowsize: 3, arrowposition: 0.8, color: [0,1,0], },
                       {name:"XX2", type:"Free", pos:[8,-4],color:[1,0,0],size:3},
                       {name:"YY2", type:"Free", pos:[12,-4],color:[1,0,0],size:3},
 		      {name:"GSLP3", type:"Segment", args:["XX2","YY2"], arrow:true, arrowsides: "<==", arrowshape: "empty", arrowsize: 3, arrowposition: 0.8, color: [1,0,1], },

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -160,6 +160,11 @@ Render2D.modifHandlers = {
         } else {
             Render2D.arrowShape = Render2D.arrowShapes[v.value];
             Render2D.isArrow = true;
+            if (Render2D.arrowShape.deprecated) {
+                console.log("arrowshape " + v.value + " is deprecated, use " +
+                    Render2D.arrowShape.deprecated + " instead.");
+                Render2D.arrowShape.deprecated = null;
+            }
         }
     },
 
@@ -328,13 +333,44 @@ Render2D.preDrawCurve = function() {
 };
 
 Render2D.arrowShapes = {
-    "default": { close: false, fill: false, ratio: 1 },
-    "line": { close: false, fill: false, ratio: 1 },
-    "empty": { close: true, fill: false, ratio: 1 },
-    "hollow": { close: true, fill: false, ratio: 1 },
-    "full": { close: true, fill: true, ratio: 1 },
-    "jet": { close: true, fill: true, ratio: 1.5 },
-    "delta": { close: true, fill: true, ratio: 1.5 },
+    "default": {
+        close: false,
+        fill: false,
+        ratio: 1,
+        deprecated: "line"
+    },
+    "line": {
+        close: false,
+        fill: false,
+        ratio: 1
+    },
+    "empty": {
+        close: true,
+        fill: false,
+        ratio: 1
+    },
+    "hollow": {
+        close: true,
+        fill: false,
+        ratio: 1,
+        deprecated: "empty"
+    },
+    "full": {
+        close: true,
+        fill: true,
+        ratio: 1
+    },
+    "jet": {
+        close: true,
+        fill: true,
+        ratio: 1.5
+    },
+    "delta": {
+        close: true,
+        fill: true,
+        ratio: 1.5,
+        deprecated: "jet"
+    },
 };
 
 Render2D.drawsegcore = function(pt1, pt2) {

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -76,9 +76,6 @@ Render2D.handleModifs = function(modifs, handlers) {
 
 };
 
-Render2D.sin30deg = 0.5;
-Render2D.cos30deg = Math.sqrt(0.75);
-
 Render2D.modifHandlers = {
     "size": function(v) {
         if (v.ctype === "number") {
@@ -357,48 +354,32 @@ Render2D.drawsegcore = function(pt1, pt2) {
 
     var dx = endpoint2x - endpoint1x;
     var dy = endpoint2y - endpoint1y;
-    var norm = Math.sqrt(dx * dx + dy * dy);
-    var cosAngle = dx / norm;
-    var sinAngle = dy / norm;
+    var hs = Render2D.headlen / Math.sqrt(dx * dx + dy * dy);
+    var hx = dx * hs;
+    var hy = dy * hs;
     var pos_fac1 = Render2D.arrowposition;
     var pos_fac2 = 1 - pos_fac1;
     var tip1x = pos_fac1 * overhang1x + pos_fac2 * overhang2x;
     var tip1y = pos_fac1 * overhang1y + pos_fac2 * overhang2y;
     var tip2x = pos_fac1 * overhang2x + pos_fac2 * overhang1x;
     var tip2y = pos_fac1 * overhang2y + pos_fac2 * overhang1y;
-    var headlen = Render2D.headlen;
-    var sin30 = Render2D.sin30deg;
-    var cos30 = Render2D.cos30deg;
-    var x30sub = headlen * (cosAngle * cos30 + sinAngle * sin30);
-    var x30add = headlen * (cosAngle * cos30 - sinAngle * sin30);
-    var y30sub = headlen * (sinAngle * cos30 - cosAngle * sin30);
-    var y30add = headlen * (sinAngle * cos30 + cosAngle * sin30);
     var arrowSides = Render2D.arrowSides;
 
     csctx.beginPath();
 
     // draw line in parts for full arrow
     if (Render2D.arrowShape === "full") {
-        var rx, ry, lx, ly;
         if (arrowSides === "<==>" || arrowSides === "<==") {
-            rx = tip1x + x30sub;
-            ry = tip1y + y30sub;
-            lx = tip1x + x30add;
-            ly = tip1y + y30add;
             if (Render2D.arrowposition < 1.0) {
                 csctx.moveTo(overhang1x, overhang1y);
                 csctx.lineTo(tip1x, tip1y);
             }
-            csctx.moveTo((rx + lx) / 2, (ry + ly) / 2);
+            csctx.moveTo(tip1x + hx, tip1y + hy);
         } else {
             csctx.moveTo(overhang1x, overhang1y);
         }
         if (arrowSides === '==>' || arrowSides === '<==>') {
-            rx = tip2x - x30sub;
-            ry = tip2y - y30sub;
-            lx = tip2x - x30add;
-            ly = tip2y - y30add;
-            csctx.lineTo((rx + lx) / 2, (ry + ly) / 2);
+            csctx.lineTo(tip2x - hx, tip2y - hy);
             if (Render2D.arrowposition < 1.0) {
                 csctx.moveTo(tip2x, tip2y);
                 csctx.lineTo(overhang2x, overhang2y);
@@ -422,15 +403,15 @@ Render2D.drawsegcore = function(pt1, pt2) {
     }
 
     function draw_arrowhead(tipx, tipy, sign) {
-        var rx = tipx - sign * x30sub;
-        var ry = tipy - sign * y30sub;
+        var rx = tipx - sign * hx + 0.5 * hy;
+        var ry = tipy - sign * hy - 0.5 * hx;
+        var lx = tipx - sign * hx - 0.5 * hy;
+        var ly = tipy - sign * hy + 0.5 * hx;
 
         csctx.beginPath();
         if (Render2D.arrowShape === "full") {
             csctx.lineWidth = Render2D.lsize / 2;
         }
-        var lx = tipx - sign * x30add;
-        var ly = tipy - sign * y30add;
         csctx.moveTo(rx, ry);
         csctx.lineTo(tipx, tipy);
         csctx.lineTo(lx, ly);

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -8,13 +8,13 @@ Render2D.handleModifs = function(modifs, handlers) {
     Render2D.size = null;
     if (Render2D.psize <= 0) Render2D.psize = 0;
     if (Render2D.lsize <= 0) Render2D.lsize = 0;
-    Render2D.overhang = 1; //TODO Eventuell dfault setzen
+    Render2D.overhang = 1; //TODO Maybe set default
     Render2D.dashing = false;
     Render2D.isArrow = false;
     Render2D.arrowSides = '==>';
     Render2D.arrowposition = 1.0; // position arrowhead along the line
     Render2D.headlen = 10; // arrow head length - perhaps set this relative to canvas size
-    Render2D.arrowShape = 'default';
+    Render2D.arrowShape = Render2D.arrowShapes.line;
     Render2D.alpha = csport.drawingstate.alpha;
     Render2D.bold = "";
     Render2D.italics = "";
@@ -150,11 +150,16 @@ Render2D.modifHandlers = {
     },
 
     "arrowshape": function(v) {
-        if (v.ctype === 'string') {
-            Render2D.arrowShape = v.value;
-            Render2D.isArrow = true;
-        } else {
+        if (v.ctype !== 'string') {
             console.error("arrowshape needs to be of type string");
+        } else if (!Render2D.arrowShapes.hasOwnProperty(v.value)) {
+            var allowed = Object.keys(Render2D.arrowShapes);
+            allowed.sort();
+            allowed = allowed.join(", ");
+            console.error("arrowshape needs to be one of " + allowed);
+        } else {
+            Render2D.arrowShape = Render2D.arrowShapes[v.value];
+            Render2D.isArrow = true;
         }
     },
 
@@ -322,6 +327,16 @@ Render2D.preDrawCurve = function() {
     csctx.strokeStyle = Render2D.lineColor;
 };
 
+Render2D.arrowShapes = {
+    "default": { close: false, fill: false, ratio: 1 },
+    "line": { close: false, fill: false, ratio: 1 },
+    "empty": { close: true, fill: false, ratio: 1 },
+    "hollow": { close: true, fill: false, ratio: 1 },
+    "full": { close: true, fill: true, ratio: 1 },
+    "jet": { close: true, fill: true, ratio: 1.5 },
+    "delta": { close: true, fill: true, ratio: 1.5 },
+};
+
 Render2D.drawsegcore = function(pt1, pt2) {
     var m = csport.drawingstate.matrix;
     var endpoint1x = pt1.x * m.a - pt1.y * m.b + m.tx;
@@ -368,7 +383,7 @@ Render2D.drawsegcore = function(pt1, pt2) {
     csctx.beginPath();
 
     // draw line in parts for full arrow
-    if (Render2D.arrowShape === "full") {
+    if (Render2D.arrowShape.close) {
         if (arrowSides === "<==>" || arrowSides === "<==") {
             if (Render2D.arrowposition < 1.0) {
                 csctx.moveTo(overhang1x, overhang1y);
@@ -396,31 +411,32 @@ Render2D.drawsegcore = function(pt1, pt2) {
 
     // draw arrow heads at desired positions
     if (arrowSides === '==>' || arrowSides === '<==>') {
-        draw_arrowhead(tip2x, tip2y, 1);
+        draw_arrowhead(tip2x, tip2y, 1, Render2D.arrowShape.ratio);
     }
     if (arrowSides === '<==' || arrowSides === '<==>') {
-        draw_arrowhead(tip1x, tip1y, -1);
+        draw_arrowhead(tip1x, tip1y, -1, -Render2D.arrowShape.ratio);
     }
 
-    function draw_arrowhead(tipx, tipy, sign) {
-        var rx = tipx - sign * hx + 0.5 * hy;
-        var ry = tipy - sign * hy - 0.5 * hx;
-        var lx = tipx - sign * hx - 0.5 * hy;
-        var ly = tipy - sign * hy + 0.5 * hx;
+    function draw_arrowhead(tipx, tipy, sign, ratio) {
+        var rx = tipx - ratio * hx + 0.5 * hy;
+        var ry = tipy - ratio * hy - 0.5 * hx;
+        var lx = tipx - ratio * hx - 0.5 * hy;
+        var ly = tipy - ratio * hy + 0.5 * hx;
 
         csctx.beginPath();
-        if (Render2D.arrowShape === "full") {
+        if (Render2D.arrowShape.fill) {
             csctx.lineWidth = Render2D.lsize / 2;
         }
         csctx.moveTo(rx, ry);
         csctx.lineTo(tipx, tipy);
         csctx.lineTo(lx, ly);
-        if (Render2D.arrowShape === "full") {
+        if (Render2D.arrowShape.close) {
             csctx.fillStyle = Render2D.lineColor;
+            csctx.lineTo(tipx - sign * hx, tipy - sign * hy);
             csctx.closePath();
-            csctx.fill();
-        } else if (Render2D.arrowShape !== "default") {
-            console.error("arrowshape is unknown");
+            if (Render2D.arrowShape.fill) {
+                csctx.fill();
+            }
         }
         csctx.stroke();
     }


### PR DESCRIPTION
This fixes #152. Together with Cinderella merge request 65 it will ensure that arrow shapes exported from Cinderella can be matched by CindyJS. There is a *very* minor backwards incompatibility since the shape of existing arrow heads is slightly modified to match that used by Cinderella. I doubtr any content will have a problem with that.