### PR TITLE
Implement the version function

### DIFF
--- a/make/README.md
+++ b/make/README.md
@@ -275,6 +275,17 @@ Here is a list of important commands.
   In that case, or if `files` is omitted altogether,
   `dst` should name a directory.
 
+### Version determination
+
+The file [`getversion.js`](getversion.js) provides a function
+which launces `git` to build a file called `Version.js`.
+However, unlike a regular command, this operation is not tied to a single task.
+Instead there are multiple tasks which need an up-to-date `Version.js`.
+Creation of that file can't be a task by itself, though, since
+it should only be created if one of the tasks that need it get run.
+So it's a mix between a task (since it is a shared dependency run only once)
+and a command (since it adds a job to the current task).
+
 ### Build logic
 
 Once all tasks have been defined, [`make.js`](make.js)

--- a/make/build.js
+++ b/make/build.js
@@ -4,6 +4,7 @@ var glob = require("glob");
 var path = require("path");
 var Q = require("q");
 
+var getversion = require("./getversion");
 var src = require("./sources");
 
 module.exports = function build(settings, task) {
@@ -36,15 +37,20 @@ module.exports = function build(settings, task) {
     // Build different flavors of Cindy.js
     //////////////////////////////////////////////////////////////////////
 
+    var version = getversion.factory("build/js/Version.js", "var version");
+
     task("plain", [], function() {
+        version(this);
         this.concat(src.srcs, "build/js/Cindy.plain.js");
     });
 
     task("ours", [], function() {
+        version(this);
         this.concat(src.ours, "build/js/ours.js");
     });
 
     task("exposed", [], function() {
+        version(this);
         this.concat(
             src.lib.concat("src/js/expose.js", src.inclosure),
             "build/js/exposed.js");

--- a/make/getversion.js
+++ b/make/getversion.js
@@ -1,0 +1,61 @@
+"use strict";
+
+var cp = require("child_process");
+var Q = require("q");
+var qfs = require("q-io/fs");
+
+exports.factory = function(path, varname) {
+    // Make sure we run this task only once for every instance of this factory
+    var cache = null;
+    return function(task) {
+        task.addJob(function() {
+            return cache || (cache = getVersion(path, varname, task));
+        });
+    }
+}
+
+function getVersion(path, varname, task) {
+    var args = [
+        "describe",
+        "--match", "v[0-9]*.*", // annotated tags looking like a version
+        "--always", // if none found, report abbreviated commit id instead
+        "--long", // always include commit id and commit count since tag
+        "--abbrev=7", // length of commit id to be included
+        "--dirty=!", // append ! to git id if the working tree is unclean
+    ];
+    // git describe returns "v12.34.56-0-g1a2b3c4" or "v1.2.3-45-g6ace7bf!"
+    // which we turn into e.g. [1, 2, 3, 45, "g6ace7bf!"].
+    // The fourth entry indicates the number of commits since the given tag.
+    // So a number of 0 means an official release.  That's the reason why
+    // we use -1 instead of 0 when we don't have a tag to build on.
+    return Q.Promise(function(resolve, reject) {
+        cp.execFile("git", args, function(err, stdout, stderr) {
+            if (stderr) task.log(stderr.replace(/\n$/, ""));
+            if (err) {
+                // Report problem but don't fail build
+                task.log(err);
+                resolve([0, 0, 0, -1, "?!"]);
+            }
+            var ver = stdout.toString().replace(/[\r\n][^]*$/, "");
+            if (ver.charAt(0) === "v") {
+                ver = ver.substring(1);
+                var parts = ver.split(/[.-]/);
+                parts = parts.map(function(part) {
+                    if (/^[0-9]+$/.test(part))
+                        return +part; // convert to number
+                    return part;
+                });
+                resolve(parts);
+            } else {
+                // Commit id but no tag, default to version 0.0.0
+                resolve([0, 0, 0, -1, "g" + ver]);
+            }
+        });
+    }).then(function(parts) {
+        var json = JSON.stringify(parts);
+        task.log("Version: " + json);
+        if (varname)
+            json = varname + " = " + json + ";\n";
+        return qfs.write(path, json);
+    });
+}

--- a/make/sources.js
+++ b/make/sources.js
@@ -39,6 +39,7 @@ exports.inclosure = [
     "src/js/Setup.js",
     "src/js/Events.js",
     "src/js/Timer.js",
+    "build/js/Version.js",
 ].concat(exports.libcs, exports.libgeo, exports.liblab);
 
 exports.ours = ["src/js/Head.js"].concat(exports.inclosure, "src/js/Tail.js");

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -2,6 +2,11 @@
 // and here are the definitions of the operators
 //*******************************************************
 
+evaluator.version$0 = function(args, modifs) {
+    var ver = ["CindyJS"].concat(version);
+    return List.turnIntoCSList(ver.map(General.wrap));
+};
+
 evaluator.timestamp$0 = function(args, modifs) {
     return {
         "ctype": "number",

--- a/tools/prepare-deploy.js
+++ b/tools/prepare-deploy.js
@@ -22,6 +22,7 @@ var handlers = {
     "Cindy3D.js.map": map,
     "CindyGL.js": true,
     "CindyGL.js.map": map,
+    "Version.js": false,
     "WEB-INF": false,
     "c3dres.js": false,
     "cglres.js": false,


### PR DESCRIPTION
This implements a new nullary function called `version()`. At the moment, the version function will return a list

    ["CindyJS", 0, 0, 0, -1, "g‹commit-id›"]

which can be used to distinguish CindyJS from Cinderella, and to identify the commit in question.  The commit id will be terminated by an exclamation mark if the working directory is different from the named commit.

Once we start tagging releases, using annotated tags of the form `v‹major›.‹minor›.‹patch›`, then the second through fourth component will be the version components, and the fifth component the number of commits since that version (and therefore always 0 for official releases). The machinery for this is already in place in the build system.

To test this machinery, try `git tag -a v7.15.3 -m 'Just a test' master~12` or some such, but don't forget to do a matching `git tag -d` right after the test, in order to not accidentially push that tag to GitHub.

I'm not sure where to document this function. Since we want a matching function for Cinderella, I'll probably document it in the Cinderella handbook first, and let [docscrub](https://github.com/CindyJS/CindyJS/tree/docscrub) carry the changes from there to us.