### PR TITLE
CindyGL: used correct coordinates for drawImage

### DIFF
--- a/plugins/cindygl/src/js/CanvasWrapper.js
+++ b/plugins/cindygl/src/js/CanvasWrapper.js
@@ -154,7 +154,7 @@ CanvasWrapper.prototype.drawTo = function(context, x, y) {
   gl.bindFramebuffer(gl.FRAMEBUFFER, null); //renders to glcanvas
   gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
   gl.flush();
-  context.drawImage(glcanvas, 0, 0, this.sizeX, this.sizeY, x, y, this.sizeX, this.sizeY);
+  context.drawImage(glcanvas, 0, glcanvas.height - this.sizeY, this.sizeX, this.sizeY, x, y, this.sizeX, this.sizeY);
 };
 
 


### PR DESCRIPTION
Fixes a problem that occurred as a consequence of #221 that was visible at example 18_hidpitest.html