### PR TITLE
Reduce differences between CindyJS and Cinderella

### DIFF
--- a/ref/Arithmetic_Operators.md
+++ b/ref/Arithmetic_Operators.md
@@ -306,10 +306,10 @@ for which the real part is between −90° = −π/2 and +90° = +π/2.
     > arcsin(-1)
     < -90°
     > arcsin(2) // the sign of the imaginary part is undefined here
-    < (90 - i*75.4561)°
-    ~ \(90 [+\-] i\*75.4561\)°
+    < (90 - i*75.5)°
+    ~ \(90 [+\-] i\*75\.5\)°
     > arcsin(2 + 3*i)
-    < (32.696 + i*113.6397)°
+    < (32.7 + i*113.6)°
     > arcsin(sqrt(3)/2)
     < 60°
 
@@ -333,10 +333,10 @@ for which the real part is between 0° = 0 and +180° = +π.
     > arccos(-1)
     < 180°
     > arccos(2) // the sign of the imaginary part is undefined here
-    < (0 + i*75.4561)°
-    ~ \(0 [+\-] i\*75.4561\)°
+    < (0 + i*75.5)°
+    ~ \(0 [+\-] i\*75\.5\)°
     > arccos(2 + 3*i)
-    < (57.304 - i*113.6397)°
+    < (57.3 - i*113.6)°
     > arccos(sqrt(3)/2)
     < 30°
 
@@ -360,9 +360,9 @@ for which the real part is between −90° = −π/2 and +90° = +π/2.
     > arctan(-1)
     < -45°
     > arctan(2)
-    < 63.4349°
+    < 63.4°
     > arctan(2 + 3*i)
-    < (80.7825 + i*13.1249)°
+    < (80.8 + i*13.1)°
     > arctan(sqrt(3))
     < 60°
 

--- a/ref/Boolean_Operators.md
+++ b/ref/Boolean_Operators.md
@@ -94,12 +94,12 @@ If both expressions are **strings**, then the order is the lexicographic (dictio
     > "aa" > "a" + "a"
     < false
 
-In all other cases (if the values are not comparable) the value `_?_` is returned.
+In all other cases (if the values are not comparable) the value `___` is returned.
 
     > 1 > 1 + i
-    < _?_
+    < ___
     > "2" > 1
-    < _?_
+    < ___
 
 ------
 
@@ -123,9 +123,9 @@ This operator is similar to **&gt;** but tests for **less than**.
     > "aa" < "a" + "a"
     < false
     > 1 < 1 + i
-    < _?_
+    < ___
     > "2" < 1
-    < _?_
+    < ___
 
 ------
 
@@ -149,9 +149,9 @@ This operator is similar to **&gt;** but tests for **greater than or equal to**.
     > "aa" >= "a" + "a"
     < true
     > 1 >= 1 + i
-    < _?_
+    < ___
     > "2" >= 1
-    < _?_
+    < ___
 
 ------
 
@@ -175,9 +175,9 @@ This operator is similar to **&gt;** but tests for **less than or equal to**.
     > "aa" <= "a" + "a"
     < true
     > 1 <= 1 + i
-    < _?_
+    < ___
     > "2" <= 1
-    < _?_
+    < ___
 
 ------
 
@@ -209,7 +209,7 @@ Logical **and** of two Boolean values defined by the following truth table:
 | `true`  | `false` | `false` |
 | `true`  | `true`  | `true`  |
 
-If one of the two arguments is not a Boolean expression, the operator returns `_?_`.
+If one of the two arguments is not a Boolean expression, the operator returns `___`.
 
 ------
 
@@ -225,7 +225,7 @@ Logical **or** of two Boolean values defined by the following truth table:
 | `true`  | `false` | `true`  |
 | `true`  | `true`  | `true`  |
 
-If one of the two arguments is not a Boolean expression, the operator returns `_?_`.
+If one of the two arguments is not a Boolean expression, the operator returns `___`.
 
 ------
 
@@ -239,14 +239,14 @@ Logical **not** of one Boolean value defined by the following truth table:
 | `false` | `true`  |
 | `true`  | `false` |
 
-If the argument is not a Boolean expression, the operator returns `_?_`.
+If the argument is not a Boolean expression, the operator returns `___`.
 
     > !(1 < 0)
     < true
     > !(1 > 0)
     < false
     > !1
-    < _?_
+    < ___
 
 ------
 
@@ -278,7 +278,7 @@ If the argument is not a Boolean expression, the operator returns `_?_`.
     > not(1 > 0)
     < false
     > not(1)
-    < _?_
+    < ___
 
 ------
 
@@ -294,7 +294,7 @@ Logical **exclusive or** of two Boolean values defined by the following truth ta
 | `true`  | `false` | `true`     |
 | `true`  | `true`  | `false`    |
 
-If one of the two arguments is not a Boolean expression, the operator returns `_?_`.
+If one of the two arguments is not a Boolean expression, the operator returns `___`.
 
 ------
 
@@ -455,4 +455,4 @@ This operator tests whether the expression `‹expr›` represents a [CindyLab](
 #### Is undefined: `isundefined(‹expr›)`
 
 **Description:**
-This operator tests whether the expression `‹expr›` returns an undefined element (`_?_`).
+This operator tests whether the expression `‹expr›` returns an undefined element (`___`).

--- a/ref/Control_Operators.md
+++ b/ref/Control_Operators.md
@@ -26,10 +26,10 @@ This code fragment prints a message on the console, if `x` has a negative value.
 
 **Return value:**
 In this case the return value of the `if`-function is &lt;expr&gt;.
-Otherwise, `_?_` is returned.
+Otherwise, `___` is returned.
 
     > x = 5; if(x<0, -1);
-    < _?_
+    < ___
     > x = -3; if(x<0, -1);
     < -1
 

--- a/ref/Lists_and_Linear_Algebra.md
+++ b/ref/Lists_and_Linear_Algebra.md
@@ -65,7 +65,7 @@ A three-dimensional vector may then be written as follows:
 **Description:**
 One can access the individual elements of a list either with the infix operator `‹list›_‹int›` or the functional operator `take(‹list›,‹int›)`.
 The indices start with number 1.
-If the index that should be accessed is less than 1 or greater than the number of elements in the list, then the value`_?_`is returned.
+If the index that should be accessed is less than 1 or greater than the number of elements in the list, then the value`___`is returned.
 Also, a warning message is issued on the console.
 
     > [2, 5, 7, 3]_3
@@ -73,7 +73,7 @@ Also, a warning message is issued on the console.
     > take([2, 5, 7, 3], 2)
     < 5
     > [2, 5, 7, 3]_5
-    < _?_
+    < ___
 
 The index can also be an arbitrary calculation.
 Furthermore, indices can access the nested parts of a nested list.
@@ -87,7 +87,7 @@ Furthermore, indices can access the nested parts of a nested list.
     > [[2, [4, 5]], 1]_1_2_2
     < 5
     > [[2, [4, 5]], 1]_1_2_2_2
-    < _?_
+    < ___
 
 If a list is stored in a variable, the individual entries can be set after they are accessed by the `_` operator.
 So for example, after the code fragment

--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -226,13 +226,13 @@ If the argument of format is a list of objects the format statement is applied t
     > format([sin(30°),cos(30°)],3)
     < ["0.5", "0.866"]
 
-If the first argument is neither a number nor a list, then the result is `_?_`.
+If the first argument is neither a number nor a list, then the result is `___`.
 If, however, it is a list, and somewhere nested inside that list is a value which is neither a number nor a list, then that value will be turned into a string representation of itself.
 
     > format("foo",4)
-    < _?_
+    < ___
     > format(1 < 2,4)
-    < _?_
+    < ___
     > format([2.339, "foo", [5.678, 1 < 2]], 2)
     < ["2.34", "foo", ["5.68", "true"]]
 
@@ -293,7 +293,7 @@ Characters can be returned and set with this operator.
     > "CindyScript"_5
     < "y"
     > "CindyScript"_12
-    < _?_
+    < ___
     > a="CindyScript";
     > a_5="erella";
     > a

--- a/ref/Vectors_and_Matrices.md
+++ b/ref/Vectors_and_Matrices.md
@@ -181,7 +181,7 @@ This operator finds the maximum value in a list of entries.
 The maximum of an empty list is not defined.
 
     > max([])
-    < _?_
+    < ___
 
 ------
 
@@ -206,7 +206,7 @@ The two-argument form can however also be used to obtain the maximum of two numb
 The maximum of an empty list is not defined.
 
     > max([], 99)
-    < _?_
+    < ___
 
 ------
 
@@ -224,7 +224,7 @@ This operator is similar to the last one, except that the running variable is lo
 The maximum of an empty list is not defined.
 
     > max([], x, 99)
-    < _?_
+    < ___
 
 ------
 
@@ -239,7 +239,7 @@ This operator finds the minimum of a list of entries.
 The minimum of an empty list is not defined.
 
     > min([])
-    < _?_
+    < ___
 
 ------
 
@@ -263,7 +263,7 @@ The two-argument form can however also be used to obtain the minimum of two numb
 The minimum of an empty list is not defined.
 
     > min([], 99)
-    < _?_
+    < ___
 
 ------
 
@@ -281,7 +281,7 @@ This operator is similar to the last one, except that the running variable is lo
 The minimum of an empty list is not defined.
 
     > min([], x, 99)
-    < _?_
+    < ___
 
 ------
 

--- a/src/js/libcs/CSNumber.js
+++ b/src/js/libcs/CSNumber.js
@@ -4,18 +4,19 @@
 var CSNumber = {};
 CSNumber._helper = {};
 CSNumber._helper.roundingfactor = 1e4;
+CSNumber._helper.angleroundingfactor = 1e1;
 
-CSNumber._helper.niceround = function(a) {
-    return Math.round(a * CSNumber._helper.roundingfactor) /
-        CSNumber._helper.roundingfactor;
+CSNumber._helper.niceround = function(a, roundingfactor) {
+    return Math.round(a * roundingfactor) / roundingfactor;
 };
 
-CSNumber.niceprint = function(a) {
+CSNumber.niceprint = function(a, roundingfactor) {
+    roundingfactor = roundingfactor || CSNumber._helper.roundingfactor;
     if (a.usage === "Angle") {
         return CSNumber._helper.niceangle(a);
     }
-    var real = CSNumber._helper.niceround(a.value.real);
-    var imag = CSNumber._helper.niceround(a.value.imag);
+    var real = CSNumber._helper.niceround(a.value.real, roundingfactor);
+    var imag = CSNumber._helper.niceround(a.value.imag, roundingfactor);
     if (imag === 0) {
         return "" + real;
     }
@@ -53,7 +54,9 @@ CSNumber._helper.niceangle = function(a) {
         return CSNumber.niceprint(General.withUsage(a, null));
     if (typeof unit === "function")
         return unit(a);
-    var num = CSNumber.niceprint(CSNumber.realmult(unit * PERTWOPI, a));
+    var num = CSNumber.niceprint(
+        CSNumber.realmult(unit * PERTWOPI, a),
+        unit > 200 ? CSNumber._helper.angleroundingfactor : null);
     if (num.indexOf("i*") === -1)
         return num + angleUnit;
     return "(" + num + ")" + angleUnit;

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -89,7 +89,7 @@ function niceprint(a) {
         return '_??_';
     }
     if (a.ctype === 'undefined') {
-        return '_?_';
+        return '___';
     }
     if (a.ctype === 'number') {
         return CSNumber.niceprint(a);
@@ -138,7 +138,7 @@ function niceprint(a) {
     }
 
 
-    return "__";
+    return "_?_";
 
 }
 


### PR DESCRIPTION
I've managed to export the CindyJS reftest suite to a JSON file, and hook that up to Cinderella so that it can run the same set of tests, ensuring compatibility for tested features or at least exposing incompatibilities so they can be discussed and dealt with. In the process, I found that

1. Cinderella prints angles with just a single decimal and
2. Cinderella uses `___`  to represent nada where CindyJS uses `_?_`.

The latter is likely an accident. I remember discussing compatibility with @richter-gebert at some point, and he was rather surprised that the string representations did *not* match. Both these points seem like unnecessary divergence, so we might unify behavior instead of catering for such differences in the test suite. I just rebased this onto #233 so it takes those cases of nada into account.