### PR TITLE
Angle bisector take 3

### DIFF
--- a/make/build.js
+++ b/make/build.js
@@ -137,7 +137,7 @@ module.exports = function build(settings, task) {
     // Run separate unit tests to test various interna
     //////////////////////////////////////////////////////////////////////
 
-    task("unittests", ["exposed"], function() {
+    task("unittests", ["exposed", "plain"], function() {
         this.cmdscript("mocha", "tests");
     });
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -31,7 +31,7 @@ geoOps.FreeLine.kind = "L";
 geoOps.FreeLine.signature = [];
 geoOps.FreeLine.isMovable = true;
 geoOps.FreeLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     putStateComplexVector(pos);
 };
 geoOps.FreeLine.getParamForInput = function(el, pos, type) {
@@ -177,7 +177,7 @@ geoOps.HorizontalLine.kind = "L";
 geoOps.HorizontalLine.signature = [];
 geoOps.HorizontalLine.isMovable = true;
 geoOps.HorizontalLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     pos = List.turnIntoCSList([CSNumber.zero, pos.value[1], pos.value[2]]);
     pos = List.normalizeMax(pos);
     putStateComplexVector(pos);
@@ -218,7 +218,7 @@ geoOps.VerticalLine.kind = "L";
 geoOps.VerticalLine.signature = [];
 geoOps.VerticalLine.isMovable = true;
 geoOps.VerticalLine.initialize = function(el) {
-    var pos = geoOps._helper.initializePoint(el);
+    var pos = geoOps._helper.initializeLine(el);
     pos = List.turnIntoCSList([pos.value[0], CSNumber.zero, pos.value[2]]);
     pos = List.normalizeMax(pos);
     putStateComplexVector(pos);
@@ -2361,6 +2361,29 @@ geoOps._helper.initializePoint = function(el) {
             sx = el.pos[0];
             sy = el.pos[1];
             sz = 1;
+        }
+        if (el.pos.length === 3) {
+            sx = el.pos[0];
+            sy = el.pos[1];
+            sz = el.pos[2];
+        }
+    }
+    var pos = List.turnIntoCSList([
+        CSNumber._helper.input(sx),
+        CSNumber._helper.input(sy),
+        CSNumber._helper.input(sz)
+    ]);
+    pos = List.normalizeMax(pos);
+    return pos;
+};
+
+geoOps._helper.initializeLine = function(el) {
+    var sx = 0;
+    var sy = 0;
+    var sz = 0;
+    if (el.pos) {
+        if (el.pos.ctype === "list" && List.isNumberVector(el.pos)) {
+            return el.pos;
         }
         if (el.pos.length === 3) {
             sx = el.pos[0];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1334,61 +1334,15 @@ geoOps.angleBisector = {};
 geoOps.angleBisector.kind = "Ls";
 geoOps.angleBisector.signature = ["L", "L"];
 geoOps.angleBisector.updatePosition = function(el) {
-    var xx = csgeo.csnames[(el.args[0])];
-    var yy = csgeo.csnames[(el.args[1])];
-
-    var poi = List.normalizeMax(List.cross(xx.homog, yy.homog));
-
-    var myI = List.normalizeMax(List.cross(List.ii, poi));
-    var myJ = List.normalizeMax(List.cross(List.jj, poi));
-
-    var sqi = CSNumber.sqrt(CSNumber.mult(List.det3(poi, yy.homog, myI), List.det3(poi, xx.homog, myI)));
-    var sqj = CSNumber.sqrt(CSNumber.mult(List.det3(poi, yy.homog, myJ), List.det3(poi, xx.homog, myJ)));
-
-    var mui = General.mult(myI, sqj);
-    var tauj = General.mult(myJ, sqi);
-
-    var erg1 = List.add(mui, tauj);
-    var erg2 = List.sub(mui, tauj);
-
-    var erg1zero = List.abs(erg1).value.real < CSNumber.eps;
-    var erg2zero = List.abs(erg2).value.real < CSNumber.eps;
-
-    if (!erg1zero && !erg2zero) {
-        erg1 = List.normalizeMax(erg1);
-        erg2 = List.normalizeMax(erg2);
-    } else if (erg1zero) {
-        erg2 = List.normalizeMax(erg2);
-    } else if (erg2zero) {
-        erg1 = List.normalizeMax(erg1);
-    }
-
-    // degenrate case
-    if ((List.almostequals(erg1, List.linfty).value && erg2zero) || (List.almostequals(erg2, List.linfty).value && erg1zero)) {
-        var mu, tau, mux, tauy;
-        if (List.abs(erg1).value.real < List.abs(erg2).value.real) {
-            mu = List.det3(poi, yy.homog, erg2);
-            tau = List.det3(poi, xx.homog, erg2);
-
-            mux = General.mult(xx.homog, mu);
-            tauy = General.mult(yy.homog, tau);
-
-            erg1 = List.add(mux, tauy);
-
-        } else {
-            mu = List.det3(poi, yy.homog, erg1);
-            tau = List.det3(poi, xx.homog, erg1);
-
-            mux = General.mult(xx.homog, mu);
-            tauy = General.mult(yy.homog, tau);
-
-            erg2 = List.add(mux, tauy);
-        }
-    }
-
-    erg1 = List.normalizeMax(erg1);
-    erg2 = List.normalizeMax(erg2);
-
+    var a = csgeo.csnames[el.args[0]].homog;
+    var b = csgeo.csnames[el.args[1]].homog;
+    var abs = function(v) {
+        return CSNumber.sqrt(CSNumber.add(CSNumber.mult(v[0], v[0]), CSNumber.mult(v[1], v[1])));
+    };
+    var as = List.scalmult(abs(b.value), a);
+    var bs = List.scalmult(abs(a.value), b);
+    var erg1 = List.normalizeMax(List.sub(as, bs));
+    var erg2 = List.normalizeMax(List.add(as, bs));
     el.results = tracing2(erg1, erg2);
 };
 geoOps.angleBisector.stateSize = tracing2.stateSize;

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1671,9 +1671,25 @@ geoOps.SelectP.updatePosition = function(el) {
 geoOps.SelectL = {};
 geoOps.SelectL.kind = "L";
 geoOps.SelectL.signature = ["Ls"];
+geoOps.SelectL.initialize = function(el) {
+    if (el.index !== undefined)
+        return el.index - 1;
+    var set = csgeo.csnames[(el.args[0])].results.value;
+    var pos = geoOps._helper.initializeLine(el);
+    var d1 = List.projectiveDistMinScal(pos, set[0]);
+    var best = 0;
+    for (var i = 1; i < set.length; ++i) {
+        var d2 = List.projectiveDistMinScal(pos, set[i]);
+        if (d2 < d1) {
+            d1 = d2;
+            best = i;
+        }
+    }
+    return best;
+};
 geoOps.SelectL.updatePosition = function(el) {
     var set = csgeo.csnames[(el.args[0])];
-    el.homog = set.results.value[el.index - 1];
+    el.homog = set.results.value[el.param];
     el.homog = General.withUsage(el.homog, "Line");
 };
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1336,25 +1336,22 @@ geoOps.angleBisector.signature = ["L", "L", "P"];
 geoOps.angleBisector.updatePosition = function(el) {
     var a = csgeo.csnames[el.args[0]].homog;
     var b = csgeo.csnames[el.args[1]].homog;
-    var mult = CSNumber.mult;
-    var scalAbs = function(v, l) {
-        return List.scalmult(CSNumber.sqrt(CSNumber.add(mult(v[0], v[0]), mult(v[1], v[1]))), l);
-    };
-    var as = scalAbs(b.value, a);
-    var bs = scalAbs(a.value, b);
-    var res = [List.sub(as, bs), List.add(as, bs)];
-    var chk = function(which) {
-        // Check for concurrent lines
-        var t = res[which];
-        if (List._helper.isAlmostZero(t)) {
-            // Produce a line that is perpendicular to the other line at the point given
-            var l = res[1 - which].value;
-            var p = csgeo.csnames[(el.args[2])].homog;
-            t = List.cross(List.turnIntoCSList([l[0], l[1], CSNumber.zero]), p);
-        }
-        return List.normalizeMax(t);
-    };
-    el.results = tracing2(chk(0), chk(1));
+    var p = csgeo.csnames[el.args[2]].homog;
+    var add = List.add;
+    var sub = List.sub;
+    var abs = List.abs;
+    var cross = List.cross;
+    var sm = List.scalmult;
+    var nm = List.normalizeMax;
+    var isAlmostZero = List._helper.isAlmostZero;
+    var linfty = List.linfty;
+    var na = sm(abs(cross(cross(linfty, b), linfty)), a);
+    var nb = sm(abs(cross(cross(linfty, a), linfty)), b);
+    var res1 = sub(na, nb);
+    var res2 = add(na, nb);
+    if (isAlmostZero(res1)) res1 = cross(cross(cross(linfty, res2), linfty), p);
+    if (isAlmostZero(res2)) res2 = cross(cross(cross(linfty, res1), linfty), p);
+    el.results = tracing2(nm(res1), nm(res2));
 };
 geoOps.angleBisector.stateSize = tracing2.stateSize;
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1330,10 +1330,10 @@ geoOps.PolarOfLine.updatePosition = function(el) {
 };
 
 
-geoOps.angleBisector = {};
-geoOps.angleBisector.kind = "Ls";
-geoOps.angleBisector.signature = ["L", "L", "P"];
-geoOps.angleBisector.updatePosition = function(el) {
+geoOps.AngleBisector = {};
+geoOps.AngleBisector.kind = "Ls";
+geoOps.AngleBisector.signature = ["L", "L", "P"];
+geoOps.AngleBisector.updatePosition = function(el) {
     var a = csgeo.csnames[el.args[0]].homog;
     var b = csgeo.csnames[el.args[1]].homog;
     var p = csgeo.csnames[el.args[2]].homog;
@@ -1353,7 +1353,7 @@ geoOps.angleBisector.updatePosition = function(el) {
     if (isAlmostZero(res2)) res2 = cross(cross(cross(linfty, res1), linfty), p);
     el.results = tracing2(nm(res1), nm(res2));
 };
-geoOps.angleBisector.stateSize = tracing2.stateSize;
+geoOps.AngleBisector.stateSize = tracing2.stateSize;
 
 geoOps._helper.IntersectLC = function(l, c) {
 
@@ -2453,6 +2453,23 @@ geoMacros.Arc = function(el) {
 geoMacros.EuclideanMid = function(el) {
     el.type = "Mid";
     return [el];
+};
+
+geoMacros.AngularBisector = function(el) {
+    el.type = "AngleBisector";
+    return [el];
+};
+
+geoMacros.angleBisector = function(el) {
+    var point = {
+        name: el.name + "_Intersection",
+        type: "Meet",
+        args: el.args,
+        visible: false
+    };
+    el.type = "AngleBisector";
+    el.args = [el.args[0], el.args[1], point.name];
+    return [point, el];
 };
 
 geoMacros.Transform = function(el) {

--- a/tests/GeoOps_tests.js
+++ b/tests/GeoOps_tests.js
@@ -2,12 +2,142 @@ var assert = require("assert");
 var should = require("should");
 var rewire = require("rewire");
 
+var createCindy = require("../build/js/Cindy.plain.js");
 var cindyJS = rewire("../build/js/exposed.js");
 
 var List = cindyJS.__get__("List");
 var CSNumber = cindyJS.__get__("CSNumber");
 var geoOps = cindyJS.__get__("geoOps");
 var niceprint = cindyJS.__get__("niceprint");
+
+function almostEqualVector(a, b) {
+  return List._helper.isAlmostZero(a) == List._helper.isAlmostZero(b) &&
+    List.projectiveDistMinScal(a, b) < 1e-8;
+}
+
+function homog(expected) {
+  if (!expected.ctype)
+    expected = List.realVector(expected);
+  return function(el) {
+    if (!almostEqualVector(el.homog, expected))
+      niceprint(el.homog).should.equal(niceprint(expected));
+  };
+}
+
+function homogPair(expected1, expected2) {
+  if (!expected1.ctype)
+    expected1 = List.realVector(expected1);
+  if (!expected2.ctype)
+    expected2 = List.realVector(expected2);
+  return function(el) {
+    var actual1 = el.results.value[0];
+    var actual2 = el.results.value[1];
+    if (!((almostEqualVector(actual1, expected1) &&
+           almostEqualVector(actual2, expected2)) ||
+          (almostEqualVector(actual1, expected2) &&
+           almostEqualVector(actual2, expected1))))
+      niceprint(el.results).should.equal(
+        niceprint(List.turnIntoCSList([expected1, expected2])));
+  };
+}
+
+function testGeo(geometry, verifier, done) {
+  var initscript = 'use("verify");\nverify(' +
+      geometry[geometry.length - 1].name + ')';
+  function plugin(api) {
+    api.defineFunction("verify", 1, function(args, modifs) {
+      var el = api.evaluate(args[0]).value;
+      try {
+        verifier(el);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  }
+  plugin.apiVersion = 1;
+  var data = {
+    isNode: true,
+    geometry: geometry,
+    scripts: { init: initscript },
+    plugins: { verify: plugin }
+  };
+  createCindy(data);
+}
+
+//////////////////////////////////////////////////////////////////////
+// Now come the test cases
+
+describe("Free point", function() {
+  it("must have the given coordinates", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[12,34]}
+    ], homog([-120, -340, -10]), done);
+  });
+});
+
+describe("Angle bisector", function() {
+  it("generic input", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[3,2]},
+      {name:"B", type:"Free", pos:[7,5]},
+      {name:"C", type:"Free", pos:[-9,7]},
+      {name:"a", type:"Join", args:["A","B"]},
+      {name:"b", type:"Join", args:["A","C"]},
+      {name:"cd", type:"AngleBisector", args:["a","b","A"]},
+    ], homogPair([8,1,-26], [1,-8,13]), done);
+  });
+  it("finite identical", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[-3,2]},
+      {name:"B", type:"Free", pos:[6,5]},
+      {name:"C", type:"Free", pos:[3,4]},
+      {name:"a", type:"Join", args:["A","B"]},
+      {name:"b", type:"Join", args:["A","C"]},
+      {name:"cd", type:"AngleBisector", args:["a","b","A"]},
+    ], homogPair([1,-3,9], [3,1,7]), done);
+  });
+  it("parallel", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[3,2,0]},
+      {name:"B", type:"Free", pos:[7,5]},
+      {name:"C", type:"Free", pos:[-9,7]},
+      {name:"a", type:"Join", args:["A","B"]},
+      {name:"b", type:"Join", args:["A","C"]},
+      {name:"cd", type:"AngleBisector", args:["a","b","A"]},
+    ], homogPair([2,-3,20], [0,0,1]), done);
+  });
+  it("identical with far point", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[3,1,0]},
+      {name:"B", type:"Free", pos:[6,5]},
+      {name:"C", type:"Free", pos:[3,4]},
+      {name:"a", type:"Join", args:["A","B"]},
+      {name:"b", type:"Join", args:["A","C"]},
+      {name:"cd", type:"AngleBisector", args:["a","b","A"]},
+    ], homogPair([1,-3,9], [0,0,1]), done);
+  });
+  it("finite and infinite", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[3,1,0]},
+      {name:"B", type:"Free", pos:[0,1,0]},
+      {name:"C", type:"Free", pos:[3,4,1]},
+      {name:"a", type:"Join", args:["A","B"]},
+      {name:"b", type:"Join", args:["A","C"]},
+      {name:"cd", type:"AngleBisector", args:["a","b","A"]},
+    ], homogPair([0,0,1], [0,0,1]), done);
+  });
+  it("twice infinite", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[3,1,0]},
+      {name:"B", type:"Free", pos:[4,5,0]},
+      {name:"C", type:"Free", pos:[1,2,0]},
+      {name:"a", type:"Join", args:["A","B"]},
+      {name:"b", type:"Join", args:["A","C"]},
+      {name:"cd", type:"AngleBisector", args:["a","b","A"]},
+    ], homogPair([0,0,0], [0,0,0]), done);
+  });
+});
 
 describe("IntersectLC helper", function() {
   it("must not return null vector just because one result has x == 0", function() {


### PR DESCRIPTION
After #172 and #183 this is yet another candidate for angle bisectors. It is mostly a rebased version of #183, but with those changes that originated in #172 cherry-picked from there instead. The macro changes were not picked, but left for the very end to see whether aa5728897ce1c210d7d8e71cc51da0cadcc386b2 avoids the need for #229 and similar tricks.

Also omitted were the examples from Cinderella, since I haven't really looked at those good enough, and won't today because it's *really* late now. So I'm not requesting a review yet, since I'll have to add at least one Cinderella-generated example.

As a *huge* benefit, this pull request contains a new kind of unit tests, where you plug in a geometry description and can then verify the coordinates of the final object of that. There is a whole test suite in there verifying the angle bisector against the criteria from https://github.com/CindyJS/CindyJS/pull/183#issuecomment-175115285. This implementation satisfies all requirements.