### PR TITLE
Negative radius

### DIFF
--- a/ref/Elementary_Drawing_Functions.md
+++ b/ref/Elementary_Drawing_Functions.md
@@ -223,7 +223,7 @@ This operator can handle the following modifiers:
 
 **Description:**
 Draws a circle at `‹point›` with radius given by a number `‹radius›`.
-The point may be given either in euclidean or in homogeneous coordinates.
+The point may be given either in Euclidean or in homogeneous coordinates.
 
 **Modifiers:**
 This operator can handle the same modifiers as the `draw(‹expr›)` operator.
@@ -234,7 +234,7 @@ This operator can handle the same modifiers as the `draw(‹expr›)` operator.
 
 **Description:**
 Draws the interior of a circle at `‹point›` with radius given by a number `‹radius›`.
-The point may be given either in euclidean or in homogeneous coordinates.
+The point may be given either in Euclidean or in homogeneous coordinates.
 
 **Modifiers:**
 This operator can handle the following modifiers:
@@ -262,7 +262,7 @@ The following piece of code shows a combined usage of the `drawcircle` and the `
 **Description:**
 Draws a circular arc from `‹point1›` to `‹point3›` via `‹point2›`.
 
-The points may be given either in euclidean or in homogeneous coordinates.
+The points may be given either in Euclidean or in homogeneous coordinates.
 
 **Modifiers:**
 This operator can handle the same modifiers as the `draw(‹expr›)` operator.
@@ -273,7 +273,7 @@ This operator can handle the same modifiers as the `draw(‹expr›)` operator.
 
 **Description:**
 Draws the interior of a circular arc `‹point1›` to `‹point3›` via `‹point2›`.
-The points may be given either in euclidean or in homogeneous coordinates.
+The points may be given either in Euclidean or in homogeneous coordinates.
 
 **Modifiers:**
 This operator can handle the following modifiers:

--- a/ref/Script_Coordinate_System.md
+++ b/ref/Script_Coordinate_System.md
@@ -13,7 +13,7 @@ We first introduce the operators and than give a combined example.
 
 **Caution:**
 In the current version of Cinderella 2.6 the application of the transformations is not yet implemented for circles.
-For circles only euclidean transformations (rotations, translations, reflections, scalings) are supported.
+For circles only Euclidean transformations (rotations, translations, reflections, scalings) are supported.
 Affine and projective transformations will be provided in a later release.
 
 ------

--- a/ref/User_Input.md
+++ b/ref/User_Input.md
@@ -12,7 +12,7 @@ If one wants to react to the corresponding event data, there are several operato
 **Description:**
 Returns a vector that represents the current position of the mouse if the mouse is pressed.
 The vector is given in homogeneous coordinates (this allows also for access of infinite objects).
-If one needs the two-dimensional euclidean coordinates of the mouse position one can access them via `mouse().xy`.
+If one needs the two-dimensional Euclidean coordinates of the mouse position one can access them via `mouse().xy`.
 
 ------
 

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -298,7 +298,7 @@ eval_helper.drawcircle = function(args, modifs, df) {
     Render2D.preDrawCurve();
 
     csctx.beginPath();
-    csctx.arc(xx, yy, v1.value.real * m.sdet, 0, 2 * Math.PI);
+    csctx.arc(xx, yy, Math.abs(v1.value.real) * m.sdet, 0, 2 * Math.PI);
 
 
     if (df === "D") {


### PR DESCRIPTION
I noticed that canvas implementations reject an arc command with negative radius. Cinderella however has no trouble drawing circles with negative radii. So we should take the absolute value of the radius when drawing. I also fixed some capitalization issues in the documentation which I noticed in passing.

I'd have liked to add a reftest for this, but don't know how to deal with the fact that all the other examples in the documentation on Elementary Drawing Functions yield over 4000 lines of drawing instructions. Adding all that makes the documenation alsmost unreadable. Should we ignore them, or write them to separate files? I guess I'd rather ignore them, and leave rendering tests to the planned recording facility.