### PR TITLE
Dehomogenize center field

### DIFF
--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -33,14 +33,21 @@ Accessor.setGeoField = function(geoname, field, value) {
     return nada;
 };
 
+function dehom(v) {
+    v = v.value.slice();
+    var n = v.length - 1;
+    var d = CSNumber.inv(v[n]);
+    v.length = n;
+    for (var i = 0; i < n; ++i)
+        v[i] = CSNumber.mult(d, v[i]);
+    return List.turnIntoCSList(v);
+}
 
 Accessor.getField = function(geo, field) {
     var erg;
     if (geo.kind === "P") {
         if (field === "xy") {
-            var xx = CSNumber.div(geo.homog.value[0], geo.homog.value[2]);
-            var yy = CSNumber.div(geo.homog.value[1], geo.homog.value[2]);
-            erg = List.turnIntoCSList([xx, yy]);
+            erg = dehom(geo.homog);
             return General.withUsage(erg, "Point");
         }
 
@@ -102,6 +109,7 @@ Accessor.getField = function(geo, field) {
 
         if (field === "center") {
             var cen = geoOps._helper.CenterOfConic(geo.matrix);
+            cen = dehom(cen);
             return General.withUsage(cen, "Point");
         }
 


### PR DESCRIPTION
Accessing `C0.center` for a conic C0 in Cinderella yields the *Euclidean* coordinates of the center point, while CindyJS used to return the homogeneous ones.

This fixes #258.