### PR TITLE
always return either value of second argument of if$2 or glsl-default…

### DIFF
--- a/plugins/cindygl/src/js/Types.js
+++ b/plugins/cindygl/src/js/Types.js
@@ -702,7 +702,7 @@ typeinference["if"] = [{
   //- ("if", 2, OpIf.class);  error @done(2015-03-17)
   {
     args: [type.bool, template1],
-    res: type.voidt
+    res: template1
   }
 ];
 //- ("trigger", 2, OpTrigger.class); @rethink


### PR DESCRIPTION
… value of same type instead of trying to cast to void-type, which probably results in errors, as described in #245.

I cannot see where this will cause unwanted side effects.