### PR TITLE
CindyGL-examples: cglres.js needs not to be included

### DIFF
--- a/examples/cindygl/21_pickit.html
+++ b/examples/cindygl/21_pickit.html
@@ -6,7 +6,6 @@
 <meta charset="UTF-8">
 <script type="text/javascript" src="../../build/js/Cindy.js"></script>
 <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
-<script type="text/javascript" src="../../build/js/cglres.js"></script>
 <script id="csinit" type="text/x-cindyscript">
 animate(a1, a2, a3) := (
     A0 = A.xy;


### PR DESCRIPTION
cglres.js is already contained in CindyGL.js.