### PR TITLE
CindyGL: Added `colorplot` and `imagergb[a]` function with no coordinate arguments

### DIFF
--- a/examples/cindygl/08_julia.html
+++ b/examples/cindygl/08_julia.html
@@ -28,12 +28,12 @@
       color(z) := (
         z = f(z, c);
         if(abs(z)<1.5,
-          imagergb([-1.5,-1.5], [1.5,-1.5], "julia", z) + 0.01*(1,2,3),
+          imagergb("julia", z) + 0.01*(1,2,3),
           (0,0,0)
         )
       );
       
-      colorplot([-1.5,-1.5], [1.5,-1.5], "julia", (color(complex(#))));
+      colorplot("julia", (color(complex(#))));
       drawimage([-1.5,-1.5], [1.5,-1.5], "julia");
     </script>
 

--- a/examples/cindygl/08_julia_advanced.html
+++ b/examples/cindygl/08_julia_advanced.html
@@ -19,7 +19,7 @@
       f(z, c) := z*z+c;
       
       createimage("julia", 1024, 1024);
-      colorplot([-2,-2], [2,-2], "julia", (#.x, #.y, 0, 0));
+      colorplot("julia", (#.x, #.y, 0, 0));
       lastupdate = 0;
     </script> 
     <script id="csdraw" type="text/x-cindyscript">
@@ -39,8 +39,8 @@
       );
       
       coordtime(z) := (
-        currentcolor = imagergba([-2,-2], [2,-2], "julia", z);
-        othercolor = imagergba([-2,-2], [2,-2], "julia", f(z, c));
+        currentcolor = imagergba("julia", z);
+        othercolor = imagergba("julia", f(z, c));
         cz = if(lastupdate>0, complex((currentcolor.x, currentcolor.y)), z);
         
         nz =  if(abs(cz)<2, f(cz, c), cz);
@@ -54,14 +54,14 @@
       lastupdate = if(c==lastc, lastupdate+1, 0); //how many frames elapsed since the last time that c was updated?
       lastc = c;
       
-      colorplot([-2,-2], [2,-2], "julia", coordtime(complex(#)));
+      colorplot("julia", coordtime(complex(#)));
       
       
       timetocolor(f) := (
         l = min(f/250,1);
         min(0.1+f/30, 1)*((1-l)*(hue(f/300-.5))+l*(1,1,1));
       );
-      colorplot(timetocolor(imagergb([-2,-2], [2,-2], "julia", #).b));   
+      colorplot(timetocolor(imagergb("julia", #).b));   
     </script>
 
     <canvas  id="CSCanvas"></canvas>

--- a/examples/cindygl/12_kleinian.html
+++ b/examples/cindygl/12_kleinian.html
@@ -22,10 +22,10 @@
       createimage("a", 500, 500);
       createimage("B", 500, 500);
       createimage("b", 500, 500);
-      colorplot([-1.5,-1.5], [1.5,-1.5], "A", 0); //initialize as black
-      colorplot([-1.5,-1.5], [1.5,-1.5], "a", 0);
-      colorplot([-1.5,-1.5], [1.5,-1.5], "B", 0);
-      colorplot([-1.5,-1.5], [1.5,-1.5], "b", 0);      
+      colorplot("A", 0); //initialize as black
+      colorplot("a", 0);
+      colorplot("B", 0);
+      colorplot("b", 0);      
     </script>
     
     <script id="csmove" type="text/x-cindyscript">
@@ -55,10 +55,10 @@
   <script id="cskeydown" type="text/x-cindyscript">
       print("pressed key" + keycode());
       if(keycode()==32, 
-        colorplot([-1.5,-1.5], [1.5,-1.5], "A", 0);
-        colorplot([-1.5,-1.5], [1.5,-1.5], "a", 0);
-        colorplot([-1.5,-1.5], [1.5,-1.5], "B", 0);
-        colorplot([-1.5,-1.5], [1.5,-1.5], "b", 0);
+        colorplot("A", 0);
+        colorplot("a", 0);
+        colorplot("B", 0);
+        colorplot("b", 0);
       ); //space -> black
  </script>
     
@@ -79,10 +79,10 @@
         a/(1+a);
       );
 
-      readA(z) := T(imagergb([-1.5,-1.5], [1.5,-1.5], "A", z).r);
-      reada(z) := T(imagergb([-1.5,-1.5], [1.5,-1.5], "a", z).r);
-      readB(z) := T(imagergb([-1.5,-1.5], [1.5,-1.5], "B", z).r);
-      readb(z) := T(imagergb([-1.5,-1.5], [1.5,-1.5], "b", z).r);
+      readA(z) := T(imagergb("A", z).r);
+      reada(z) := T(imagergb("a", z).r);
+      readB(z) := T(imagergb("B", z).r);
+      readb(z) := T(imagergb("b", z).r);
       
       compose(f, a, b, c, x) := (
         Tinv(f*f*(a+b+c) + .00001*exp(-(x*x)));
@@ -90,23 +90,23 @@
       
       
       
-      colorplot([-1.5,-1.5], [1.5,-1.5], "a",
+      colorplot("a",
         r = moebius(a, complex(#));
         compose(dmoebius(a, complex(#)), reada(r), readb(r), readB(r), #)
       );
       
-      colorplot([-1.5,-1.5], [1.5,-1.5], "A",
+      colorplot("A",
         r = moebius(A, complex(#));
         compose(dmoebius(A, complex(#)), readA(r), readb(r), readB(r), #)
       );
       
-      colorplot([-1.5,-1.5], [1.5,-1.5], "b",
+      colorplot("b",
         r = moebius(b, complex(#));
         compose(dmoebius(b, complex(#)), reada(r), readA(r), readb(r), #)
       );
       
       
-      colorplot([-1.5,-1.5], [1.5,-1.5], "B",
+      colorplot("B",
         r = moebius(B, complex(#));
         compose(dmoebius(B, complex(#)), reada(r), readA(r), readB(r), #)
       );
@@ -114,10 +114,10 @@
       
       
       colorplot(
-        s0 = imagergb([-1.5,-1.5], [1.5,-1.5], "a", #).r;
-        s1 = imagergb([-1.5,-1.5], [1.5,-1.5], "A", #).r;
-        s2 = imagergb([-1.5,-1.5], [1.5,-1.5], "b", #).r;
-        s3 = imagergb([-1.5,-1.5], [1.5,-1.5], "B", #).r;
+        s0 = imagergb("a", #).r;
+        s1 = imagergb("A", #).r;
+        s2 = imagergb("b", #).r;
+        s3 = imagergb("B", #).r;
         sum = (s0+s1+s2+s3);
         gray(sum)+
         s0*hue(1/8)+s1*hue(3/8)+s2*hue(5/8)+s3*hue(7/8)

--- a/examples/cindygl/12_kleinian_big.html
+++ b/examples/cindygl/12_kleinian_big.html
@@ -22,10 +22,10 @@
       createimage("a", 1600, 800);
       createimage("B", 1600, 800);
       createimage("b", 1600, 800);
-      colorplot([-3,-1.5], [3,-1.5], "A", 0); //initialize as black
-      colorplot([-3,-1.5], [3,-1.5], "a", 0);
-      colorplot([-3,-1.5], [3,-1.5], "B", 0);
-      colorplot([-3,-1.5], [3,-1.5], "b", 0);
+      colorplot("A", 0); //initialize as black
+      colorplot("a", 0);
+      colorplot("B", 0);
+      colorplot("b", 0);
     </script>
     
     <script id="csmove" type="text/x-cindyscript">
@@ -64,10 +64,10 @@
   <script id="cskeydown" type="text/x-cindyscript">
       print("pressed key" + keycode());
       if(keycode()==32, 
-        colorplot([-3,-1.5], [3,-1.5], "A", 0);
-        colorplot([-3,-1.5], [3,-1.5], "a", 0);
-        colorplot([-3,-1.5], [3,-1.5], "B", 0);
-        colorplot([-3,-1.5], [3,-1.5], "b", 0);
+        colorplot("A", 0);
+        colorplot("a", 0);
+        colorplot("B", 0);
+        colorplot("b", 0);
       ); //space -> black
  </script>
     
@@ -88,10 +88,10 @@
         a/(1+a);
       );
 
-      readA(z) := T(imagergb([-3,-1.5], [3,-1.5], "A", z).r);
-      reada(z) := T(imagergb([-3,-1.5], [3,-1.5], "a", z).r);
-      readB(z) := T(imagergb([-3,-1.5], [3,-1.5], "B", z).r);
-      readb(z) := T(imagergb([-3,-1.5], [3,-1.5], "b", z).r);
+      readA(z) := T(imagergb("A", z).r);
+      reada(z) := T(imagergb("a", z).r);
+      readB(z) := T(imagergb("B", z).r);
+      readb(z) := T(imagergb("b", z).r);
       
       compose(f, a, b, c, x) := (
         Tinv(f*f*(a+b+c) + .000001*exp(-(x*x)));
@@ -99,23 +99,23 @@
       
       
       
-      colorplot([-3,-1.5], [3,-1.5], "a",
+      colorplot("a",
         r = moebius(a, complex(#));
         compose(dmoebius(a, complex(#)), reada(r), readb(r), readB(r), #)
       );
       
-      colorplot([-3,-1.5], [3,-1.5], "A",
+      colorplot("A",
         r = moebius(A, complex(#));
         compose(dmoebius(A, complex(#)), readA(r), readb(r), readB(r), #)
       );
       
-      colorplot([-3,-1.5], [3,-1.5], "b",
+      colorplot("b",
         r = moebius(b, complex(#));
         compose(dmoebius(b, complex(#)), reada(r), readA(r), readb(r), #)
       );
       
       
-      colorplot([-3,-1.5], [3,-1.5], "B",
+      colorplot("B",
         r = moebius(B, complex(#));
         compose(dmoebius(B, complex(#)), reada(r), readA(r), readB(r), #)
       );
@@ -123,10 +123,10 @@
       
       
       colorplot( //crops internal textures from 1600x800 to 1200x800
-        s0 = imagergb([-3,-1.5], [3,-1.5], "a", #).r;
-        s1 = imagergb([-3,-1.5], [3,-1.5], "A", #).r;
-        s2 = imagergb([-3,-1.5], [3,-1.5], "b", #).r;
-        s3 = imagergb([-3,-1.5], [3,-1.5], "B", #).r;
+        s0 = imagergb("a", #).r;
+        s1 = imagergb("A", #).r;
+        s2 = imagergb("b", #).r;
+        s3 = imagergb("B", #).r;
         sum = (s0+s1+s2+s3);
         gray(sum)+
         s0*hue(1/8)+s1*hue(3/8)+s2*hue(5/8)+s3*hue(7/8)

--- a/plugins/cindygl/src/js/General.js
+++ b/plugins/cindygl/src/js/General.js
@@ -147,3 +147,30 @@ function enlargeCanvasIfRequired(sizeX, sizeY) {
     glcanvas.height = Math.ceil(sizeY);
   }
 }
+
+function transf(api, px, py) { //copied from Operators.js
+  let m = api.getInitialMatrix();
+  let xx = px - m.tx;
+  let yy = py + m.ty;
+  let x = (xx * m.d - yy * m.b) / m.det;
+  let y = -(-xx * m.c + yy * m.a) / m.det;
+  return {
+    x: x,
+    y: y
+  };
+};
+
+function computeLowerLeftCorner(api) {
+  let ch = api.instance['canvas']['clientHeight'];
+  return transf(api, 0, ch);
+}
+
+function computeLowerRightCorner(api) {
+  let cw = api.instance['canvas']['clientWidth'];
+  let ch = api.instance['canvas']['clientHeight'];
+  return transf(api, cw, ch);
+}
+
+function computeUpperLeftCorner(api) {
+  return transf(api, 0, 0);
+}

--- a/plugins/cindygl/src/js/TextureReader.js
+++ b/plugins/cindygl/src/js/TextureReader.js
@@ -1,4 +1,4 @@
-function useimagergba(args, codebuilder) {
+function useimagergba4(args, codebuilder) {
   let name = args[2];
   if (!codebuilder.texturereaders.hasOwnProperty(name)) {
     codebuilder.texturereaders[name] = [
@@ -24,10 +24,26 @@ function useimagergba(args, codebuilder) {
 }
 
 
-function useimagergb(args, codebuilder) {
+function useimagergb4(args, codebuilder) {
   let name = args[2];
-  useimagergba(args, codebuilder);
+  useimagergba4(args, codebuilder);
   return ['_imagergb_', name, '(', args[0], ',', args[1], ',', args[3], ')'].join('');
+}
+
+function useimagergba2(args, codebuilder) {
+  let name = args[0];
+  useimagergba4(['', ''].concat(args), codebuilder);
+  let a = computeLowerLeftCorner(codebuilder.api);
+  let b = computeLowerRightCorner(codebuilder.api);
+  return ['_imagergba_', name, '(vec2(', a.x, ',', a.y, '),vec2(', b.x, ',', b.y, '), ', args[1], ')'].join('');
+}
+
+function useimagergb2(args, codebuilder) {
+  let name = args[0];
+  useimagergba4(['', ''].concat(args), codebuilder);
+  let a = computeLowerLeftCorner(codebuilder.api);
+  let b = computeLowerRightCorner(codebuilder.api);
+  return ['_imagergb_', name, '(vec2(', a.x, ',', a.y, '),vec2(', b.x, ',', b.y, '), ', args[1], ')'].join('');
 }
 
 

--- a/plugins/cindygl/src/js/Types.js
+++ b/plugins/cindygl/src/js/Types.js
@@ -931,11 +931,17 @@ typeinference["genList"] = [{
 ];
 
 typeinference["imagergb"] = [{
+  args: [type.string, type.coordinate2d],
+  res: type.vec3
+}, {
   args: [type.coordinate2d, type.coordinate2d, type.string, type.coordinate2d],
   res: type.vec3
 }];
 
 typeinference["imagergba"] = [{
+  args: [type.string, type.coordinate2d],
+  res: type.vec4
+}, {
   args: [type.coordinate2d, type.coordinate2d, type.string, type.coordinate2d],
   res: type.vec4
 }];

--- a/plugins/cindygl/src/js/WebGLImplementation.js
+++ b/plugins/cindygl/src/js/WebGLImplementation.js
@@ -431,15 +431,23 @@ webgltr["%"] = [
 
 webgltr["imagergb"] = [
   [{
+    args: [type.string, type.coordinate2d],
+    res: type.vec3
+  }, useimagergb2],
+  [{
     args: [type.coordinate2d, type.coordinate2d, type.string, type.coordinate2d],
     res: type.vec3
-  }, useimagergb]
+  }, useimagergb4]
 ];
 webgltr["imagergba"] = [
   [{
+    args: [type.string, type.coordinate2d],
+    res: type.vec4
+  }, useimagergba2],
+  [{
     args: [type.coordinate2d, type.coordinate2d, type.string, type.coordinate2d],
     res: type.vec4
-  }, useimagergba]
+  }, useimagergba4]
 ];
 
 


### PR DESCRIPTION
Now it is also possible to call `colorplot("canvas", term)` instead of `colorplot(A, B, "canvasname", term)`. In this case we will simply assume that "canvas" has the same coordinates at the main-canvas, i.e. A and B will become the lower left and upper right corner.

In the same manner now one can read textures with `imagergb("canvas", coordinate)` instead of  `imagergb(A, B, "canvas", coordinate)`

This should make programs using feedback loops without coordinate change - which happens according to my experience in the many cases - more easy to write and read.