### PR TITLE
center of conic (again)

### DIFF
--- a/examples/109_CenterOfConic.html
+++ b/examples/109_CenterOfConic.html
@@ -5,6 +5,11 @@
 <title>Cindy JS Example</title>
 <meta charset="UTF-8">
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+<script id="csdraw" type="text/x-cindyscript">
+
+println(X.homog);
+</script>
 <script type="text/javascript">
 
 var cdy = createCindy({ // See ref/createCindy documentation for details.

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -33,21 +33,14 @@ Accessor.setGeoField = function(geoname, field, value) {
     return nada;
 };
 
-function dehom(v) {
-    v = v.value.slice();
-    var n = v.length - 1;
-    var d = CSNumber.inv(v[n]);
-    v.length = n;
-    for (var i = 0; i < n; ++i)
-        v[i] = CSNumber.mult(d, v[i]);
-    return List.turnIntoCSList(v);
-}
 
 Accessor.getField = function(geo, field) {
     var erg;
     if (geo.kind === "P") {
         if (field === "xy") {
-            erg = dehom(geo.homog);
+            var xx = CSNumber.div(geo.homog.value[0], geo.homog.value[2]);
+            var yy = CSNumber.div(geo.homog.value[1], geo.homog.value[2]);
+            erg = List.turnIntoCSList([xx, yy]);
             return General.withUsage(erg, "Point");
         }
 
@@ -109,7 +102,6 @@ Accessor.getField = function(geo, field) {
 
         if (field === "center") {
             var cen = geoOps._helper.CenterOfConic(geo.matrix);
-            cen = dehom(cen);
             return General.withUsage(cen, "Point");
         }
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -595,12 +595,11 @@ geoOps.PointOnSegment.stateSize = 2;
 geoOps._helper.CenterOfConic = function(c) {
     // The center is the pole of the line at infinity.
     var cen = General.mult(List.adjoint3(c), List.linfty);
-    if(List.abs(cen).value.real < CSNumber.eps){
+    if (List.abs(cen).value.real < CSNumber.eps) {
         var lines = geoOps._helper.splitDegenConic(c);
         cen = List.cross(lines[0], lines[1]);
-        cen = List.normalizeMax(cen);
     }
-    return cen;
+    return List.normalizeMax(cen);
 };
 
 geoOps.CenterOfConic = {};

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -594,7 +594,13 @@ geoOps.PointOnSegment.stateSize = 2;
 
 geoOps._helper.CenterOfConic = function(c) {
     // The center is the pole of the line at infinity.
-    return General.mult(List.adjoint3(c), List.linfty);
+    var cen = General.mult(List.adjoint3(c), List.linfty);
+    if(List.abs(cen).value.real < CSNumber.eps){
+        var lines = geoOps._helper.splitDegenConic(c);
+        cen = List.cross(lines[0], lines[1]);
+        cen = List.normalizeMax(cen);
+    }
+    return cen;
 };
 
 geoOps.CenterOfConic = {};


### PR DESCRIPTION
Hi,

i was thinking about the code of #261 which i merged today and i think it's (mathematically) imprecise. 

The center of a conic isn't an euclidean object: consider a degenerate conic. The center of this is the intersection of the two lines the conic collapses into. This will be, of course, a far point iff the lines are parallel. 

So Cinderella is wrong in this case and we should discuss whether we change its (her?) behavior. 