### PR TITLE
Handle per-element dimDependent settings

### DIFF
--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -37,6 +37,7 @@ function csinit(gslp) {
 
     //Relevant fields for appearance:
     //color
+    //dimDependent
     //size
     //alpha
     //overhang
@@ -65,7 +66,10 @@ function pointDefault(el) {
     el.size = CSNumber.real(el.size);
     if (!el.movable || el.pinned) {
         el.color = List.realVector(el.color || defaultAppearance.pointColor);
-        el.color = List.scalmult(CSNumber.real(defaultAppearance.dimDependent), el.color);
+        var dimDependent = el.dimDependent;
+        if (dimDependent === undefined)
+            dimDependent = defaultAppearance.dimDependent;
+        el.color = List.scalmult(CSNumber.real(dimDependent), el.color);
     } else {
         el.color = List.realVector(el.color || defaultAppearance.pointColor);
     }

--- a/src/js/libgeo/StateIO.js
+++ b/src/js/libgeo/StateIO.js
@@ -17,6 +17,7 @@ var attributesToClone = [
     "clip",
     "color",
     "dashtype",
+    "dimDependent",
     //"dir", // Through, not needed if we export pos
     //"dock", // needs dedicated code
     "drawtrace",


### PR DESCRIPTION
When switching an element to a custom color in Cinderella, by a scripted assignment of the form `el.color = [r, g, b]`, the dimming of dependent points won't apply to such an element any more.  So we need to exclude certain elements from the dimming rule.  I've already posted a Cinderella merge request for matching export code.

This is a follow-up to #231.
