### PR TITLE
Do not draw lines beyond boundary of canvas

### DIFF
--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -523,9 +523,9 @@ Render2D.drawline = function(homog) {
     // do not draw beyond canvas boundary
     var m = csport.drawingstate.matrix;
     var b1 = [m.a, m.b, m.tx]; // left boundary
-    var b2 = [m.a, m.b, m.tx - csctx.canvas.width]; // right boundary
+    var b2 = [m.a, m.b, m.tx - csw]; // right boundary
     var b3 = [m.c, m.d, m.ty]; // upper boundary
-    var b4 = [m.c, m.d, csctx.canvas.height - m.ty]; // lower boundary
+    var b4 = [m.c, m.d, csh - m.ty]; // lower boundary
     if (l[0] === 0) { // horizontal line
         Render2D.drawsegcore(crossxy(l, b1), crossxy(l, b2));
         return;

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -547,16 +547,18 @@ Render2D.drawline = function(homog) {
         y: (-c - a * xMin) / b
     });
 
-    var toUserSpace = function (p) {
-        var q = List.productMV(mInverse, List.realVector([p.x, p.y, 1]));
-        return {
-            x: q.value[0].value.real / q.value[2].value.real,
-            y: q.value[1].value.real / q.value[2].value.real
-        };
-    };
+    if (erg.length === 2 && Render2D.lsize >= 0.01) {
+        csctx.lineWidth = Render2D.lsize;
+        csctx.lineCap = Render2D.lineCap;
+        csctx.lineJoin = Render2D.lineJoin;
+        csctx.miterLimit = Render2D.miterLimit;
+        csctx.strokeStyle = Render2D.lineColor;
 
-    if (erg.length === 2)
-        Render2D.drawsegcore(toUserSpace(erg[0]), toUserSpace(erg[1]));
+        csctx.beginPath();
+        csctx.moveTo(erg[0].x, erg[0].y);
+        csctx.lineTo(erg[1].x, erg[1].y);
+        csctx.stroke();
+    }
 };
 
 Render2D.dashTypes = {

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -500,8 +500,11 @@ Render2D.drawline = function(homog) {
 
     // transformation to canvas coordinates
     var m = csport.drawingstate.matrix;
-    var mInverse = List.inverse(List.realMatrix([[m.a, -m.b, m.tx],
-        [m.c, -m.d, -m.ty], [0, 0, 1]]));
+    var mInverse = List.inverse(List.realMatrix([
+        [m.a, -m.b, m.tx],
+        [m.c, -m.d, -m.ty],
+        [0, 0, 1]
+    ]));
     var n = List.normalizeMax(List.productMV(List.transpose(mInverse), homog));
     var a = n.value[0].value.real;
     var b = n.value[1].value.real;

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -505,11 +505,11 @@ Render2D.drawline = function(homog) {
     var l = List.normalizeMax(homog);
     l = [l.value[0].value.real, l.value[1].value.real, l.value[2].value.real];
 
-    function crossxy(u, v) {
-        var zInverse = 1 / (u[0] * v[1] - u[1] * v[0]);
+    function lcrossxy(v) {
+        var zInverse = 1 / (l[0] * v[1] - l[1] * v[0]);
         return {
-            x: (u[1] * v[2] - u[2] * v[1]) * zInverse,
-            y: (u[2] * v[0] - u[0] * v[2]) * zInverse
+            x: (l[1] * v[2] - l[2] * v[1]) * zInverse,
+            y: (l[2] * v[0] - l[0] * v[2]) * zInverse
         };
     }
 
@@ -527,13 +527,13 @@ Render2D.drawline = function(homog) {
     var b3 = [m.c, m.d, m.ty]; // upper boundary
     var b4 = [m.c, m.d, csh - m.ty]; // lower boundary
     if (l[0] === 0) { // horizontal line
-        Render2D.drawsegcore(crossxy(l, b1), crossxy(l, b2));
+        Render2D.drawsegcore(lcrossxy(b1), lcrossxy(b2));
         return;
     } else if (l[1] === 0) { // vertical line
-        Render2D.drawsegcore(crossxy(l, b3), crossxy(l, b4));
+        Render2D.drawsegcore(lcrossxy(b3), lcrossxy(b4));
         return;
     }
-    var intersection = [b1, b2, b3, b4].map(crossxy.bind(null, l)).sort(sortxy);
+    var intersection = [b1, b2, b3, b4].map(lcrossxy).sort(sortxy);
     Render2D.drawsegcore(intersection[1], intersection[2]);
 };
 

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -518,10 +518,11 @@ Render2D.drawline = function(homog) {
     };
 
     // do not draw beyond canvas boundary
-    var xMin = 0;
-    var xMax = csw;
-    var yMax = 0;
-    var yMin = csh;
+    var lsize = Render2D.lsize;
+    var xMin = 0 - lsize;
+    var xMax = csw + lsize;
+    var yMax = 0 - lsize;
+    var yMin = csh + lsize;
 
     var ul = distNeg(xMin, yMax);
     var ur = distNeg(xMax, yMax);
@@ -547,8 +548,8 @@ Render2D.drawline = function(homog) {
         y: (-c - a * xMin) / b
     });
 
-    if (erg.length === 2 && Render2D.lsize >= 0.01) {
-        csctx.lineWidth = Render2D.lsize;
+    if (erg.length === 2 && lsize >= 0.01) {
+        csctx.lineWidth = lsize;
         csctx.lineCap = Render2D.lineCap;
         csctx.lineJoin = Render2D.lineJoin;
         csctx.miterLimit = Render2D.miterLimit;

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -500,29 +500,9 @@ Render2D.drawpoint = function(pt) {
 };
 
 Render2D.drawline = function(homog) {
-    var na = CSNumber.abs(homog.value[0]).value.real;
-    var nb = CSNumber.abs(homog.value[1]).value.real;
-    var nc = CSNumber.abs(homog.value[2]).value.real;
-    var divi;
-
-    if (na >= nb && na >= nc) {
-        divi = homog.value[0];
-    }
-    if (nb >= na && nb >= nc) {
-        divi = homog.value[1];
-    }
-    if (nc >= nb && nc >= na) {
-        divi = homog.value[2];
-    }
-    var a = CSNumber.div(homog.value[0], divi);
-    var b = CSNumber.div(homog.value[1], divi);
-    var c = CSNumber.div(homog.value[2], divi); //TODO Realitycheck einbauen
-
-    var l = [
-        a.value.real,
-        b.value.real,
-        c.value.real
-    ];
+    // TODO test whether line has real-valued coordinates
+    var l = List.normalizeMax(homog);
+    l = [l.value[0].value.real, l.value[1].value.real, l.value[2].value.real];
 
     function crossxy(u, v) {
         var z = (u[0] * v[1] - u[1] * v[0]);

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -544,11 +544,7 @@ Render2D.drawline = function(homog) {
     });
 
     if (erg.length === 2 && lsize >= 0.01) {
-        csctx.lineWidth = lsize;
-        csctx.lineCap = Render2D.lineCap;
-        csctx.lineJoin = Render2D.lineJoin;
-        csctx.miterLimit = Render2D.miterLimit;
-        csctx.strokeStyle = Render2D.lineColor;
+        Render2D.preDrawCurve();
         csctx.beginPath();
         csctx.moveTo(erg[0].x, erg[0].y);
         csctx.lineTo(erg[1].x, erg[1].y);

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -523,36 +523,37 @@ Render2D.drawline = function(homog) {
         b.value.real,
         c.value.real
     ];
-    var b1, b2;
-    if (Math.abs(l[0]) < Math.abs(l[1])) {
-        b1 = [1, 0, 30];
-        b2 = [-1, 0, 30];
-    } else {
-        b1 = [0, 1, 30];
-        b2 = [0, -1, 30];
+
+    function crossxy(u, v) {
+        var z = (u[0] * v[1] - u[1] * v[0]);
+        return {
+            x: (u[1] * v[2] - u[2] * v[1]) / z,
+            y: (u[2] * v[0] - u[0] * v[2]) / z
+        };
     }
-    var erg1 = [
-        l[1] * b1[2] - l[2] * b1[1],
-        l[2] * b1[0] - l[0] * b1[2],
-        l[0] * b1[1] - l[1] * b1[0]
-    ];
-    var erg2 = [
-        l[1] * b2[2] - l[2] * b2[1],
-        l[2] * b2[0] - l[0] * b2[2],
-        l[0] * b2[1] - l[1] * b2[0]
-    ];
 
-    var pt1 = {
-        x: erg1[0] / erg1[2],
-        y: erg1[1] / erg1[2]
-    };
-    var pt2 = {
-        x: erg2[0] / erg2[2],
-        y: erg2[1] / erg2[2]
+    function sortxy(u, v) {
+        if (u.x !== v.x)
+            return u.x - v.x;
+        else
+            return u.y - v.y;
+    }
 
-    };
-
-    Render2D.drawsegcore(pt1, pt2);
+    // do not draw beyond canvas boundary
+    var m = csport.drawingstate.matrix;
+    var b1 = [m.a, m.b, m.tx]; // left boundary
+    var b2 = [m.a, m.b, m.tx - csctx.canvas.width]; // right boundary
+    var b3 = [m.c, m.d, m.ty]; // upper boundary
+    var b4 = [m.c, m.d, csctx.canvas.height - m.ty]; // lower boundary
+    if (l[0] === 0) { // horizontal line
+        Render2D.drawsegcore(crossxy(l, b1), crossxy(l, b2));
+        return;
+    } else if (l[1] === 0) { // vertical line
+        Render2D.drawsegcore(crossxy(l, b3), crossxy(l, b4));
+        return;
+    }
+    var intersection = [b1, b2, b3, b4].map(crossxy.bind(null, l)).sort(sortxy);
+    Render2D.drawsegcore(intersection[1], intersection[2]);
 };
 
 Render2D.dashTypes = {

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -500,7 +500,8 @@ Render2D.drawpoint = function(pt) {
 };
 
 Render2D.drawline = function(homog) {
-    // TODO test whether line has real-valued coordinates
+    if (!List._helper.isAlmostReal(homog))
+        return;
     var l = List.normalizeMax(homog);
     l = [l.value[0].value.real, l.value[1].value.real, l.value[2].value.real];
 

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -507,30 +507,25 @@ Render2D.drawline = function(homog) {
     var m = csport.drawingstate.matrix;
     var mInverse = List.inverse(List.realMatrix([[m.a, -m.b, m.tx],
         [m.c, -m.d, -m.ty], [0, 0, 1]]));
-
     var n = List.normalizeMax(List.productMV(List.transpose(mInverse), homog));
     var a = n.value[0].value.real;
     var b = n.value[1].value.real;
     var c = n.value[2].value.real;
 
-    var distNeg = function(x, y) {
-        return x * a + y * b + c < 0;
-    };
-
-    // do not draw beyond canvas boundary
+    // clip to canvas boundary (up to line size)
     var lsize = Render2D.lsize;
     var xMin = 0 - lsize;
     var xMax = csw + lsize;
     var yMax = 0 - lsize;
     var yMin = csh + lsize;
-
+    var distNeg = function(x, y) {
+        return x * a + y * b + c < 0;
+    };
     var ul = distNeg(xMin, yMax);
     var ur = distNeg(xMax, yMax);
     var ll = distNeg(xMin, yMin);
     var lr = distNeg(xMax, yMin);
-
     var erg = [];
-
     if (ul !== ur) erg.push({
         x: (-c - b * yMax) / a,
         y: yMax
@@ -554,7 +549,6 @@ Render2D.drawline = function(homog) {
         csctx.lineJoin = Render2D.lineJoin;
         csctx.miterLimit = Render2D.miterLimit;
         csctx.strokeStyle = Render2D.lineColor;
-
         csctx.beginPath();
         csctx.moveTo(erg[0].x, erg[0].y);
         csctx.lineTo(erg[1].x, erg[1].y);

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -506,10 +506,10 @@ Render2D.drawline = function(homog) {
     l = [l.value[0].value.real, l.value[1].value.real, l.value[2].value.real];
 
     function crossxy(u, v) {
-        var z = (u[0] * v[1] - u[1] * v[0]);
+        var zInverse = 1 / (u[0] * v[1] - u[1] * v[0]);
         return {
-            x: (u[1] * v[2] - u[2] * v[1]) / z,
-            y: (u[2] * v[0] - u[0] * v[2]) / z
+            x: (u[1] * v[2] - u[2] * v[1]) * zInverse,
+            y: (u[2] * v[0] - u[0] * v[2]) * zInverse
         };
     }
 

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -385,12 +385,7 @@ Render2D.drawsegcore = function(pt1, pt2) {
     var overhang1y = overhang1 * endpoint1y + overhang2 * endpoint2y;
     var overhang2x = overhang1 * endpoint2x + overhang2 * endpoint1x;
     var overhang2y = overhang1 * endpoint2y + overhang2 * endpoint1y;
-    csctx.lineWidth = Render2D.lsize;
-    csctx.lineCap = Render2D.lineCap;
-    csctx.lineJoin = Render2D.lineJoin;
-    csctx.miterLimit = Render2D.miterLimit;
-    csctx.strokeStyle = Render2D.lineColor;
-
+    Render2D.preDrawCurve();
 
     if (!Render2D.isArrow ||
         (endpoint1x === endpoint1y && endpoint2x === endpoint2y)) {

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -512,10 +512,11 @@ Render2D.drawline = function(homog) {
 
     // clip to canvas boundary (up to line size)
     var lsize = Render2D.lsize;
-    var xMin = 0 - lsize;
-    var xMax = csw + lsize;
-    var yMax = 0 - lsize;
-    var yMin = csh + lsize;
+    var margin = Math.sqrt(0.5) * lsize;
+    var xMin = 0 - margin;
+    var xMax = csw + margin;
+    var yMax = 0 - margin;
+    var yMin = csh + margin;
     var distNeg = function(x, y) {
         return x * a + y * b + c < 0;
     };


### PR DESCRIPTION
This is a follow up of #289. I realized that it is actually `Render2D.drawline` that needs be fixed, not `Render2D.drawsegcore`.

This fixes line rendering bugs in Firefox (see also https://bugzilla.mozilla.org/show_bug.cgi?id=1183702 and [CindyJS GitLab issue #6](https://gitlab.cinderella.de:8082/cindyjs/cindyjs/issues/6)).

This is also related to #56, and maybe also to #97.