### PR TITLE
Formulate incidence checks as conjectures

### DIFF
--- a/examples/114_allops.html
+++ b/examples/114_allops.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Konstruktion.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+<script id='csmove' type='text/x-cindyscript'>
+println("allpoints, should be A, B, C, D, E, F, G, H, K, L, M, N, O");
+println(allpoints());
+println("alllines, should be a,b,c");
+println(alllines());
+println("allsegments, should be a,c");
+println(allsegments());
+println("allconics, should be C1, C2, C0");
+println(allconics());
+println("allcircles, should be C0, C2");
+println(allcircles());
+println("allmasses, should be M, O");
+println(allmasses());
+println("allsprings, should be c");
+println(allsprings());
+
+println("allelements");
+println(allelements());
+
+
+// INCIDENCES
+
+println("allpoints incident to b, should be K");
+println(allpoints(b));
+println("allpoints incident to C1, should be A B C D E");
+println(allpoints(C1));
+println("alllines incident to K, should be b");
+println(alllines(K));
+
+println("allsegments incident to L, should be c");
+println(allsegments(L));
+
+println("allmasses incident to Segment N-O, should be O");
+println(allmasses(no));
+println("allsprings incident to L, should be c");
+println(allsprings(L));
+println("allconics incident to A, should be C1");
+println(allconics(A));
+
+println("allcircles incident to G, should be C2");
+println(allcircles(G));
+
+println("allelements incident to K, should be b");
+println(allelements(K));
+
+
+//faulty case
+println("faulty case");
+A = [1,2,3];
+println(alllines(A));
+
+</script>
+
+    <script type="text/javascript">
+            var physics=[
+                       {behavior:{type:"Environment",gravity:-.2}},
+                       {name:"M", behavior:{type:"Mass",friction:0.1}},
+                       {name:"O", behavior:{type:"Mass",friction:0.1}},
+                       {name:"c", behavior:{type:"Spring"}}
+                       ];
+
+var cdy = createCindy({ 
+	scripts: "cs*", 
+	defaultAppearance: {}, 
+	behavior:physics,
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ 2.6486486486486487, -4.0, -0.6756756756756757 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "B", type: "Free", pos: [ 4.0, -3.183673469387755, -1.0204081632653061 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C", type: "Free", pos: [ 2.8888888888888893, -4.0, -2.7777777777777777 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "D", type: "Free", pos: [ -2.795180722891566, -4.0, -1.2048192771084338 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "E", type: "Free", pos: [ 0.20382165605095542, -4.0, -0.6369426751592356 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "F", type: "Free", pos: [ 4.0, 0.8928571428571428, 0.4464285714285714 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "C0", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.807571404451924, args: [ "F" ], size: 1, printname: "$C_{0}$" }, 
+		{ name: "C1", type: "ConicBy5", color: [ 0.0, 0.0, 1.0 ], args: [ "A", "B", "C", "D", "E" ], size: 1, printname: "$C_{1}$" }, 
+		{ name: "G", type: "Free", pos: [ -1.6536312849162011, -4.0, -0.5586592178770949 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "H", type: "Free", pos: [ -3.4254143646408846, -4.0, -0.5524861878453039 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "a", type: "Segment", pos: [ 0.013936311058462669, -0.5644205978677443, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "G", "H" ], labeled: true, size: 1 }, 
+		{ name: "K", type: "Free", pos: [ 4.0, 0.9929078014184397, -0.7092198581560284 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "b", type: "Through", pos: [ 0.694924364585733, 0.0575904169546188, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "K" ], labeled: true, size: 1 }, 
+		{ name: "L", type: "Free", pos: [ 4.0, 0.6588235294117648, -1.1764705882352942 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "M", type: "Free", pos: [ 0.8979591836734694, -4.0, 2.0408163265306123 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "c", type: "Segment", pos: [ 0.8103727714748782, 2.2227367446168094, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "L", "M" ], render: true, labeled: true, size: 1 }, 
+		{ name: "N", type: "Free", pos: [ 4.0, 0.7792207792207791, 1.2987012987012987 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "O", type: "Free", pos: [ 4.0, -0.6419753086419752, 1.2345679012345678 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+		{ name: "no", type: "Segment" , color: [ 0.0, 0.0, 1.0 ], args: [ "N", "O" ], render: true, labeled: true, size: 1 }, 
+		{ name: "C2", type: "CircleBy3", color: [ 0.0, 0.0, 1.0 ], args: [ "G", "H", "F" ], size: 1, printname: "$C_{2}$" }, 
+ ],
+	ports: [ 
+		{ id: "CSCanvas", width: 680, height: 335, transform: [ { visibleRect: [ -9.04, 9.32, 18.16, -4.08 ] } ], background: "rgb(168,176,192)" } ] });
+    </script>
+</head>
+
+
+
+<body>
+    <canvas id="CSCanvas"></canvas>
+    <br>
+               <button onclick="cdy.play()" type="button" >Play</button>
+        <button onclick="cdy.pause()" type="button" >Pause</button>
+        <button onclick="cdy.stop()" type="button" >Stop</button>
+
+</body>
+</html>

--- a/examples/114_allops.html
+++ b/examples/114_allops.html
@@ -24,11 +24,11 @@
 <script id='csmove' type='text/x-cindyscript'>
 println("allpoints, should be A, B, C, D, E, F, G, H, K, L, M, N, O");
 println(allpoints());
-println("alllines, should be a,b,c");
+println("alllines, should be a, b, c, no");
 println(alllines());
-println("allsegments, should be a,c");
+println("allsegments, should be a, c, no");
 println(allsegments());
-println("allconics, should be C1, C2, C0");
+println("allconics, should be C0, C1, C2");
 println(allconics());
 println("allcircles, should be C0, C2");
 println(allcircles());
@@ -45,7 +45,7 @@ println(allelements());
 
 println("allpoints incident to b, should be K");
 println(allpoints(b));
-println("allpoints incident to C1, should be A B C D E");
+println("allpoints incident to C1, should be A, B, C, D, E");
 println(allpoints(C1));
 println("alllines incident to K, should be b");
 println(alllines(K));

--- a/make/sources.js
+++ b/make/sources.js
@@ -21,6 +21,7 @@ exports.libgeo = [
     "src/js/libgeo/GeoBasics.js",
     "src/js/libgeo/GeoRender.js",
     "src/js/libgeo/Tracing.js",
+    "src/js/libgeo/Prover.js",
     "src/js/libgeo/GeoOps.js",
     "src/js/libgeo/GeoScripts.js",
     "src/js/libgeo/StateIO.js",

--- a/ref/Lists_of_Geometric_Elements.md
+++ b/ref/Lists_of_Geometric_Elements.md
@@ -6,20 +6,35 @@ This is done with operators that return lists of elements of a particular kind.
 
 #### All points of the construction: `allpoints()`
 
+#### All points incident to a geometric object: `allpoints(‹geo›)`
+
 #### All lines of the construction: `alllines()`
+
+#### All lines incident to a geometric object: `alllines(‹geo›)`
 
 #### All segments of the construction: `allsegments()`
 
+#### All segments incident to a geometric object: `allsegments(‹geo›)`
+
 #### All circles of the construction: `allcircles()`
+
+#### All circles incident to a geometric object: `allcircles(‹geo›)`
 
 #### All conics of the construction: `allconics()`
 
+#### All conics incident to a geometric object: `allconics(‹geo›)`
+
 #### All masses of the construction: `allmasses()`
+
+#### All masses incident to a geometric object: `allmasses(‹geo›)`
 
 #### All springs of the construction: `allsprings()`
 
-#### All elements incident to a given one: `allsegments(‹geo›)`
+#### All springs incident to a geometric object: `allsprings(‹geo›)`
+
 
 #### All elements of the construction: `allelements()`
+
+#### All elements incident to a given one: `allelements(‹geo›)`
 
 Please refer to the examples section for more on the use of these operators.

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -2490,3 +2490,14 @@ List.getField = function(li, key) {
     return nada;
 
 };
+
+List.nil = List.turnIntoCSList([]);
+
+List.ofGeos = function(geos) {
+    return List.turnIntoCSList(geos.map(function(geo) {
+        return {
+            ctype: "geo",
+            value: geo
+        };
+    }));
+};

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -53,8 +53,8 @@ function csinit(gslp) {
     csgeo.texts = [];
     csgeo.free = [];
 
-    gslp.forEach(addElement);
-    guessIncidences();
+    gslp.forEach(addElementNoProof);
+    checkConjectures();
 }
 
 // Setzen der Default appearance
@@ -114,6 +114,12 @@ function segmentDefault(el) {
 }
 
 function addElement(el) {
+    el = addElementNoProof(el);
+    checkConjectures();
+    return el;
+}
+
+function addElementNoProof(el) {
     var i;
 
     // Adding an existing element moves that element to the given position
@@ -237,7 +243,7 @@ function addElement(el) {
     isShowing(el, op);
 
     geoDependantsCache = {};
-    //guessIncidences();
+    guessIncidences(el);
 }
 
 function onSegment(p, s) { //TODO was ist mit Fernpunkten
@@ -329,44 +335,4 @@ function getGeoDependants(mover) {
                 deps.map(function(el) { return el.name; }).join(",") + "]");
     */
     return deps;
-}
-
-function guessIncidences() {
-
-    var gslp = csgeo.gslp;
-    var p, c, erg, i, j, l, pn, ln, prod;
-    for (i = 0; i < csgeo.lines.length; i++) {
-        l = csgeo.lines[i];
-        for (j = 0; j < csgeo.points.length; j++) {
-            p = csgeo.points[j];
-            pn = List.scaldiv(List.abs(p.homog), p.homog);
-            ln = List.scaldiv(List.abs(l.homog), l.homog);
-            prod = CSNumber.abs(List.scalproduct(pn, ln));
-            if (prod.value.real < 0.0000000000001) {
-                p.incidences.push(l.name);
-                l.incidences.push(p.name);
-
-            }
-
-        }
-    }
-
-
-    // points and conics
-    for (i = 0; i < csgeo.conics.length; i++) {
-        c = csgeo.conics[i];
-        for (j = 0; j < csgeo.points.length; j++) {
-            p = csgeo.points[j];
-            erg = General.mult(c.matrix, p.homog);
-            erg = General.mult(p.homog, erg);
-            erg = CSNumber.abs(erg);
-            if (erg.value.real < 0.0000000000001) {
-                p.incidences.push(c.name);
-                c.incidences.push(p.name);
-            }
-
-        }
-    }
-
-
 }

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -334,17 +334,35 @@ function getGeoDependants(mover) {
 function guessIncidences() {
 
     var gslp = csgeo.gslp;
-    for (var i = 0; i < csgeo.lines.length; i++) {
-        var l = csgeo.lines[i];
-        for (var j = 0; j < csgeo.points.length; j++) {
-            var p = csgeo.points[j];
-            var pn = List.scaldiv(List.abs(p.homog), p.homog);
-            var ln = List.scaldiv(List.abs(l.homog), l.homog);
-            var prod = CSNumber.abs(List.scalproduct(pn, ln));
+    var p, c, erg, i, j, l, pn, ln, prod;
+    for (i = 0; i < csgeo.lines.length; i++) {
+        l = csgeo.lines[i];
+        for (j = 0; j < csgeo.points.length; j++) {
+            p = csgeo.points[j];
+            pn = List.scaldiv(List.abs(p.homog), p.homog);
+            ln = List.scaldiv(List.abs(l.homog), l.homog);
+            prod = CSNumber.abs(List.scalproduct(pn, ln));
             if (prod.value.real < 0.0000000000001) {
                 p.incidences.push(l.name);
                 l.incidences.push(p.name);
 
+            }
+
+        }
+    }
+
+
+    // points and conics
+    for (i = 0; i < csgeo.conics.length; i++) {
+        c = csgeo.conics[i];
+        for (j = 0; j < csgeo.points.length; j++) {
+            p = csgeo.points[j];
+            erg = General.mult(c.matrix, p.homog);
+            erg = General.mult(p.homog, erg);
+            erg = CSNumber.abs(erg);
+            if (erg.value.real < 0.0000000000001) {
+                p.incidences.push(c.name);
+                c.incidences.push(p.name);
             }
 
         }

--- a/src/js/libgeo/Prover.js
+++ b/src/js/libgeo/Prover.js
@@ -1,0 +1,88 @@
+var conjectures = [];
+
+function guessIncidences(el) {
+    if (guessIncidences.hasOwnProperty(el.kind))
+        guessIncidences[el.kind](el);
+}
+
+guessIncidences.P = function(p) {
+    csgeo.lines.forEach(function(l) {
+        var conjecture = incidentPL(p, l);
+        if (conjecture.holds())
+            conjectures.push(conjecture);
+    });
+    csgeo.conics.forEach(function(c) {
+        var conjecture = incidentPC(p, c);
+        if (conjecture.holds())
+            conjectures.push(conjecture);
+    });
+};
+
+guessIncidences.L = function(l) {
+    csgeo.points.forEach(function(p) {
+        var conjecture = incidentPL(p, l);
+        if (conjecture.holds())
+            conjectures.push(conjecture);
+    });
+};
+
+guessIncidences.S = guessIncidences.L;
+
+guessIncidences.C = function(c) {
+    csgeo.points.forEach(function(p) {
+        var conjecture = incidentPC(p, c);
+        if (conjecture.holds())
+            conjectures.push(conjecture);
+    });
+};
+
+function applyIncidence(a, b) {
+    return function() {
+        a.incidences.push(b.name);
+        b.incidences.push(a.name);
+    };
+}
+
+function incidentPL(p, l) {
+    return {
+        toString: function() {
+            return "point " + p.name + " incident line " + l.name;
+        },
+        apply: applyIncidence(p, l),
+        holds: function() {
+            var pn = List.scaldiv(List.abs(p.homog), p.homog);
+            var ln = List.scaldiv(List.abs(l.homog), l.homog);
+            var prod = CSNumber.abs(List.scalproduct(pn, ln));
+            return (prod.value.real < 0.0000000000001);
+        }
+    };
+}
+
+function incidentPC(p, c) {
+    return {
+        toString: function() {
+            return "point " + p.name + " incident conic " + c.name;
+        },
+        apply: applyIncidence(p, c),
+        holds: function() {
+            var erg = General.mult(c.matrix, p.homog);
+            erg = General.mult(p.homog, erg);
+            erg = CSNumber.abs(erg);
+            if (erg.value.real < 0.0000000000001) {
+                p.incidences.push(c.name);
+                c.incidences.push(p.name);
+            }
+        }
+    };
+}
+
+function checkConjectures() {
+    if (conjectures.length === 0) return;
+    // TODO: we need some randomized proving here:
+    // move free elements and check conjectures a number of times.
+    // For now assume that all conjectures could be verified.
+    for (var i = 0; i < conjectures.length; ++i) {
+        conjectures[i].apply();
+    }
+    conjectures = [];
+}

--- a/src/js/liblab/LabBasics.js
+++ b/src/js/liblab/LabBasics.js
@@ -45,6 +45,7 @@ fehlberg78.size = 13;
 var rk = doPri45;
 var behaviors;
 var masses = [];
+var springs = [];
 var csPhysicsInited = false;
 
 function csreinitphys(behavs) {
@@ -62,6 +63,7 @@ function csinitphys(behavs) {
 
     behaviors = behavs;
     masses = [];
+    springs = [];
 
 
     behaviors.forEach(function(beh) {
@@ -72,6 +74,10 @@ function csinitphys(behavs) {
                     labObjects[beh.behavior.type].init(beh.behavior, csgeo.csnames[geoname]);
                     if (beh.behavior.type === "Mass") {
                         masses.push(csgeo.csnames[geoname]);
+                    }
+
+                    if (beh.behavior.type === "Spring") {
+                        springs.push(csgeo.csnames[geoname]);
                     }
 
 

--- a/tests/GeoFuncs_tests.js
+++ b/tests/GeoFuncs_tests.js
@@ -41,39 +41,41 @@ function itCmd(command, expected) {
 
 describe("all* operations", function() {
 
-    // See examples/114_allops.html
-    cdy = createCindy({
-        isNode: true,
-        csconsole: null,
-        canvas: new FakeCanvas(),
-        geometry: [
-	    { name: "A", type: "Free", pos: [ 2.6486486486486487, -4.0, -0.6756756756756757 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "B", type: "Free", pos: [ 4.0, -3.183673469387755, -1.0204081632653061 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "C", type: "Free", pos: [ 2.8888888888888893, -4.0, -2.7777777777777777 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "D", type: "Free", pos: [ -2.795180722891566, -4.0, -1.2048192771084338 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "E", type: "Free", pos: [ 0.20382165605095542, -4.0, -0.6369426751592356 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "F", type: "Free", pos: [ 4.0, 0.8928571428571428, 0.4464285714285714 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "C0", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.807571404451924, args: [ "F" ], size: 1, printname: "$C_{0}$" },
-	    { name: "C1", type: "ConicBy5", color: [ 0.0, 0.0, 1.0 ], args: [ "A", "B", "C", "D", "E" ], size: 1, printname: "$C_{1}$" },
-	    { name: "G", type: "Free", pos: [ -1.6536312849162011, -4.0, -0.5586592178770949 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "H", type: "Free", pos: [ -3.4254143646408846, -4.0, -0.5524861878453039 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "a", type: "Segment", pos: [ 0.013936311058462669, -0.5644205978677443, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "G", "H" ], labeled: true, size: 1 },
-	    { name: "K", type: "Free", pos: [ 4.0, 0.9929078014184397, -0.7092198581560284 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "b", type: "Through", pos: [ 0.694924364585733, 0.0575904169546188, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "K" ], labeled: true, size: 1 },
-	    { name: "L", type: "Free", pos: [ 4.0, 0.6588235294117648, -1.1764705882352942 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "M", type: "Free", pos: [ 0.8979591836734694, -4.0, 2.0408163265306123 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "c", type: "Segment", pos: [ 0.8103727714748782, 2.2227367446168094, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "L", "M" ], render: true, labeled: true, size: 1 },
-	    { name: "N", type: "Free", pos: [ 4.0, 0.7792207792207791, 1.2987012987012987 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "O", type: "Free", pos: [ 4.0, -0.6419753086419752, 1.2345679012345678 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
-	    { name: "no", type: "Segment" , color: [ 0.0, 0.0, 1.0 ], args: [ "N", "O" ], render: true, labeled: true, size: 1 },
-	    { name: "C2", type: "CircleBy3", color: [ 0.0, 0.0, 1.0 ], args: [ "G", "H", "F" ], size: 1, printname: "$C_{2}$" },
-        ],
-        behavior: [
-            {behavior:{type:"Environment",gravity:-.2}},
-            {name:"M", behavior:{type:"Mass",friction:0.1}},
-            {name:"O", behavior:{type:"Mass",friction:0.1}},
-            {name:"c", behavior:{type:"Spring"}}
-        ],
+    before(function() {
+        // See examples/114_allops.html
+        cdy = createCindy({
+            isNode: true,
+            csconsole: null,
+            canvas: new FakeCanvas(),
+            geometry: [
+	        { name: "A", type: "Free", pos: [ 2.6486486486486487, -4.0, -0.6756756756756757 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "B", type: "Free", pos: [ 4.0, -3.183673469387755, -1.0204081632653061 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "C", type: "Free", pos: [ 2.8888888888888893, -4.0, -2.7777777777777777 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "D", type: "Free", pos: [ -2.795180722891566, -4.0, -1.2048192771084338 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "E", type: "Free", pos: [ 0.20382165605095542, -4.0, -0.6369426751592356 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "F", type: "Free", pos: [ 4.0, 0.8928571428571428, 0.4464285714285714 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "C0", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.807571404451924, args: [ "F" ], size: 1, printname: "$C_{0}$" },
+	        { name: "C1", type: "ConicBy5", color: [ 0.0, 0.0, 1.0 ], args: [ "A", "B", "C", "D", "E" ], size: 1, printname: "$C_{1}$" },
+	        { name: "G", type: "Free", pos: [ -1.6536312849162011, -4.0, -0.5586592178770949 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "H", type: "Free", pos: [ -3.4254143646408846, -4.0, -0.5524861878453039 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "a", type: "Segment", pos: [ 0.013936311058462669, -0.5644205978677443, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "G", "H" ], labeled: true, size: 1 },
+	        { name: "K", type: "Free", pos: [ 4.0, 0.9929078014184397, -0.7092198581560284 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "b", type: "Through", pos: [ 0.694924364585733, 0.0575904169546188, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "K" ], labeled: true, size: 1 },
+	        { name: "L", type: "Free", pos: [ 4.0, 0.6588235294117648, -1.1764705882352942 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "M", type: "Free", pos: [ 0.8979591836734694, -4.0, 2.0408163265306123 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "c", type: "Segment", pos: [ 0.8103727714748782, 2.2227367446168094, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "L", "M" ], render: true, labeled: true, size: 1 },
+	        { name: "N", type: "Free", pos: [ 4.0, 0.7792207792207791, 1.2987012987012987 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "O", type: "Free", pos: [ 4.0, -0.6419753086419752, 1.2345679012345678 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	        { name: "no", type: "Segment" , color: [ 0.0, 0.0, 1.0 ], args: [ "N", "O" ], render: true, labeled: true, size: 1 },
+	        { name: "C2", type: "CircleBy3", color: [ 0.0, 0.0, 1.0 ], args: [ "G", "H", "F" ], size: 1, printname: "$C_{2}$" },
+            ],
+            behavior: [
+                {behavior:{type:"Environment",gravity:-.2}},
+                {name:"M", behavior:{type:"Mass",friction:0.1}},
+                {name:"O", behavior:{type:"Mass",friction:0.1}},
+                {name:"c", behavior:{type:"Spring"}}
+            ],
+        });
     });
 
     itCmd("allpoints()", "[A, B, C, D, E, F, G, H, K, L, M, N, O]");

--- a/tests/GeoFuncs_tests.js
+++ b/tests/GeoFuncs_tests.js
@@ -1,0 +1,102 @@
+var should = require("should");
+var rewire = require("rewire");
+
+var createCindy = require("../build/js/Cindy.plain.js");
+
+function FakeCanvas() {
+  this.width = 640;
+  this.height = 480;
+};
+FakeCanvas.prototype.measureText = function(txt) {
+  return { width: 8*txt.length };
+};
+function dummy() { return this; }
+[
+    "addEventListener",
+    "removeEventListener",
+    "arc",
+    "beginPath",
+    "clearRect",
+    "clip",
+    "fill",
+    "getContext",
+    "lineTo",
+    "moveTo",
+    "restore",
+    "save",
+    "stroke",
+    "strokeText",
+    "fillText",
+].forEach(function(m) {
+    FakeCanvas.prototype[m] = dummy;
+});
+
+var cdy;
+
+function itCmd(command, expected) {
+    it(command, function() {
+        cdy.niceprint(cdy.evalcs(command)).should.equal(expected);
+    });
+}
+
+describe("all* operations", function() {
+
+    // See examples/114_allops.html
+    cdy = createCindy({
+        isNode: true,
+        csconsole: null,
+        canvas: new FakeCanvas(),
+        geometry: [
+	    { name: "A", type: "Free", pos: [ 2.6486486486486487, -4.0, -0.6756756756756757 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "B", type: "Free", pos: [ 4.0, -3.183673469387755, -1.0204081632653061 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "C", type: "Free", pos: [ 2.8888888888888893, -4.0, -2.7777777777777777 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "D", type: "Free", pos: [ -2.795180722891566, -4.0, -1.2048192771084338 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "E", type: "Free", pos: [ 0.20382165605095542, -4.0, -0.6369426751592356 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "F", type: "Free", pos: [ 4.0, 0.8928571428571428, 0.4464285714285714 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "C0", type: "CircleByRadius", color: [ 0.0, 0.0, 1.0 ], radius: 3.807571404451924, args: [ "F" ], size: 1, printname: "$C_{0}$" },
+	    { name: "C1", type: "ConicBy5", color: [ 0.0, 0.0, 1.0 ], args: [ "A", "B", "C", "D", "E" ], size: 1, printname: "$C_{1}$" },
+	    { name: "G", type: "Free", pos: [ -1.6536312849162011, -4.0, -0.5586592178770949 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "H", type: "Free", pos: [ -3.4254143646408846, -4.0, -0.5524861878453039 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "a", type: "Segment", pos: [ 0.013936311058462669, -0.5644205978677443, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "G", "H" ], labeled: true, size: 1 },
+	    { name: "K", type: "Free", pos: [ 4.0, 0.9929078014184397, -0.7092198581560284 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "b", type: "Through", pos: [ 0.694924364585733, 0.0575904169546188, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "K" ], labeled: true, size: 1 },
+	    { name: "L", type: "Free", pos: [ 4.0, 0.6588235294117648, -1.1764705882352942 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "M", type: "Free", pos: [ 0.8979591836734694, -4.0, 2.0408163265306123 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "c", type: "Segment", pos: [ 0.8103727714748782, 2.2227367446168094, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "L", "M" ], render: true, labeled: true, size: 1 },
+	    { name: "N", type: "Free", pos: [ 4.0, 0.7792207792207791, 1.2987012987012987 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "O", type: "Free", pos: [ 4.0, -0.6419753086419752, 1.2345679012345678 ], color: [ 1.0, 0.0, 0.0 ], labeled: true },
+	    { name: "no", type: "Segment" , color: [ 0.0, 0.0, 1.0 ], args: [ "N", "O" ], render: true, labeled: true, size: 1 },
+	    { name: "C2", type: "CircleBy3", color: [ 0.0, 0.0, 1.0 ], args: [ "G", "H", "F" ], size: 1, printname: "$C_{2}$" },
+        ],
+        behavior: [
+            {behavior:{type:"Environment",gravity:-.2}},
+            {name:"M", behavior:{type:"Mass",friction:0.1}},
+            {name:"O", behavior:{type:"Mass",friction:0.1}},
+            {name:"c", behavior:{type:"Spring"}}
+        ],
+    });
+
+    itCmd("allpoints()", "[A, B, C, D, E, F, G, H, K, L, M, N, O]");
+    itCmd("alllines()", "[a, b, c, no]");
+    itCmd("allsegments()", "[a, c, no]");
+    itCmd("allconics()", "[C0, C1, C2]");
+    itCmd("allcircles()", "[C0, C2]");
+    itCmd("allmasses()", "[M, O]");
+    itCmd("allsprings()", "[c]");
+    itCmd("allelements()", // in the order in which they appear in the gslp
+          "[A, B, C, D, E, F, C0, C1, G, H, a, K, b, L, M, c, N, O, no, C2]");
+    itCmd("allpoints(b)", "[K]");
+    itCmd("allpoints(C1)", "[A, B, C, D, E]");
+    itCmd("alllines(K)", "[b]");
+    itCmd("alllines(L)", "[c]"); // A segment is a special case of a line
+    itCmd("allsegments(L)", "[c]");
+    itCmd("allmasses(no)", "[O]");
+    itCmd("allsprings(L)", "[c]");
+    itCmd("allconics(A)", "[C1]");
+    itCmd("allcircles(G)", "[C2]");
+    itCmd("allelements(K)", "[b]");
+    itCmd("x = C1; allpoints(x)", "[A, B, C, D, E]");
+    itCmd("alllines(K.homog)", "[]");
+    itCmd("K = [1,2,3]; alllines(K)", "[]");
+
+});


### PR DESCRIPTION
This builds on #294, so either review that first before dealing with this here, or review this one only since merging it will close that one as well.

This lays the groundwork for randomized theorem proving, since it allows us (in a future commit) to check those conjectures before turning them into actual incidences. One benefit already obtained from this change in implementation is that dynamically added elements will be checked for incidences, too.