### PR TITLE
element$1 operator and some drive-by fixes

### DIFF
--- a/ref/Interaction_with_Geometry.md
+++ b/ref/Interaction_with_Geometry.md
@@ -79,16 +79,12 @@ They reappear if the mouse moves away again.
 
 #### Incidences of an object: `incidences(‹geo›)`
 
-**Not available in CindyJS yet!**
-
 **Description:**
 This operator returns a list all the elements that are generically incident to a geometric element `‹geo›`.
 
 ------
 
 #### Getting an element by name: `element(‹string›)`
-
-**Not available in CindyJS yet!**
 
 **Description:**
 This operator returns the geometric object identified by the name given in `‹string›`.

--- a/src/js/libcs/Namespace.js
+++ b/src/js/libcs/Namespace.js
@@ -67,8 +67,7 @@ function Namespace() {
         }
     };
     this.isVariable = function(a) {
-        return this.vars[a] !== undefined;
-
+        return this.vars.hasOwnProperty(a);
     };
 
     this.isVariableName = function(a) { //TODO will man das so? Den ' noch dazu machen
@@ -138,7 +137,7 @@ function Namespace() {
         if (stack.length === 0) console.error("Getting non-existing variable " + code);
         var erg = stack[stack.length - 1];
         if (erg === unset) {
-            if (csgeo.csnames[code] !== undefined) {
+            if (csgeo.csnames.hasOwnProperty(code)) {
                 return {
                     'ctype': 'geo',
                     'value': csgeo.csnames[code]

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3588,6 +3588,16 @@ evaluator.halfplane$2 = function(args, modifs) {
 //   Geometric elements      //
 ///////////////////////////////
 
+evaluator.element$1 = function(args, modifs) {
+    var name = evaluate(args[0]);
+    if (name.ctype === "string")
+        if (csgeo.csnames.hasOwnProperty(name.value))
+            return {
+                ctype: "geo",
+                value: csgeo.csnames[name.value]
+            };
+    return nada;
+};
 
 // helper for all*(<geoobject>)
 eval_helper.all$1 = function(args, filter) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -574,31 +574,28 @@ evaluator.if$3 = function(args, modifs) { //OK
 };
 
 function comp_equals(args, modifs) {
-    var v0 = evaluateAndVal(args[0]);
-    var v1 = evaluateAndVal(args[1]);
+    var v0 = evaluate(args[0]);
+    var v1 = evaluate(args[1]);
 
-    if (v0.ctype === 'number' && v1.ctype === 'number') {
-        return {
-            'ctype': 'boolean',
-            'value': (v0.value.real === v1.value.real) &&
-                (v0.value.imag === v1.value.imag)
-        };
-    }
-    if (v0.ctype === 'string' && v1.ctype === 'string') {
-        return {
-            'ctype': 'boolean',
-            'value': (v0.value === v1.value)
-        };
-    }
-    if (v0.ctype === 'boolean' && v1.ctype === 'boolean') {
-        return {
-            'ctype': 'boolean',
-            'value': (v0.value === v1.value)
-        };
-    }
-    if (v0.ctype === 'list' && v1.ctype === 'list') {
-        var erg = List.equals(v0, v1);
-        return erg;
+    if (v0.ctype === v1.ctype) {
+        if (v0.ctype === 'number') {
+            return General.bool(
+                v0.value.real === v1.value.real &&
+                v0.value.imag === v1.value.imag
+            );
+        }
+        if (v0.ctype === 'string') {
+            return General.bool(v0.value === v1.value);
+        }
+        if (v0.ctype === 'boolean') {
+            return General.bool(v0.value === v1.value);
+        }
+        if (v0.ctype === 'list') {
+            return List.equals(v0, v1);
+        }
+        if (v0.ctype === 'geo') {
+            return General.bool(v0.value === v1.value);
+        }
     }
     return {
         'ctype': 'boolean',

--- a/tests/GeoFuncs_tests.js
+++ b/tests/GeoFuncs_tests.js
@@ -137,3 +137,25 @@ describe("==", function() {
     itCmd('A == [0, 0]', 'false');
 
 });
+
+describe("element(‹string›)", function() {
+
+    before(function() {
+        cdy = createCindy({
+            isNode: true,
+            csconsole: null,
+            geometry: [
+                {name: "A", type: "Free", pos: [0, 0]},
+                {name: "B", type: "Free", pos: [1, 0]},
+                {name: "i", type: "Join", args: ["A", "B"]}
+            ]
+        });
+    });
+
+    itCmd('element("i")', 'i');
+    itCmd('element("i") == i', 'false');
+    itCmd('alllines()_1', 'i');
+    itCmd('element("i") == alllines()_1', 'true');
+    itCmd('isgeometric(element("toString"))', 'false');
+
+});

--- a/tests/GeoFuncs_tests.js
+++ b/tests/GeoFuncs_tests.js
@@ -118,3 +118,22 @@ describe("toString as a name", function() {
     itCmd('toString = 1; toString', '1');
 
 });
+
+describe("==", function() {
+
+    before(function() {
+        cdy = createCindy({
+            isNode: true,
+            csconsole: null,
+            geometry: [
+                {name: "A", type: "Free", pos: [0, 0]},
+            ]
+        });
+    });
+
+    itCmd('A == A.xy', 'false');
+    itCmd('A == A.homog', 'false');
+    itCmd('A == A', 'true');
+    itCmd('A == [0, 0]', 'false');
+
+});

--- a/tests/GeoFuncs_tests.js
+++ b/tests/GeoFuncs_tests.js
@@ -35,7 +35,7 @@ var cdy;
 
 function itCmd(command, expected) {
     it(command, function() {
-        cdy.niceprint(cdy.evalcs(command)).should.equal(expected);
+        String(cdy.niceprint(cdy.evalcs(command))).should.equal(expected);
     });
 }
 
@@ -98,5 +98,23 @@ describe("all* operations", function() {
     itCmd("x = C1; allpoints(x)", "[A, B, C, D, E]");
     itCmd("alllines(K.homog)", "[]");
     itCmd("K = [1,2,3]; alllines(K)", "[]");
+
+});
+
+describe("toString as a name", function() {
+
+    before(function() {
+        cdy = createCindy({
+            isNode: true,
+            csconsole: null,
+            geometry: [
+                {name: "A", type: "Free", pos: [0, 0]},
+            ]
+        });
+    });
+
+    itCmd('isgeometric(toString)', 'false');
+    itCmd('isundefined(toString)', 'true');
+    itCmd('toString = 1; toString', '1');
 
 });


### PR DESCRIPTION
This adds the `element(‹string›)` operator. Writing the testcase for this, I found that `==` failed to handle geometric objects, and incorrectly turned points into their `xy` coordinates. And thinking about corner cases, I found errors using JavaScript objects as dictionaries of geometric elements or variables, since inherited properties would cause confusion. That last change will neccessitate a rebase of #257 but that's currently in conflict anyway.