### PR TITLE
Allow setting the homog field of horizontal and vertical lines

### DIFF
--- a/examples/139_LineHomogSetter.html
+++ b/examples/139_LineHomogSetter.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csmove" type="text/x-cindyscript">
+  pos = cross(P1, P2);
+  f.homog = pos;
+  h.homog = pos;
+  v.homog = pos;
+  t1.homog = pos;
+  t2.angle = t1.angle;
+</script>
+<script type="text/javascript">
+
+var cdy = createCindy({
+  scripts: "cs*",
+  ports: [{id: "CSCanvas"}],
+  defaultAppearance: {},
+  geometry: [
+    {name:"x", type:"HorizontalLine", pos:[0,1,0], color:[.7,.7,.7], pinned:true},
+    {name:"y", type:"VerticalLine", pos:[1,0,0], color:[.7,.7,.7], pinned:true},
+    {name:"P1", type:"Free", pos:[2,3]},
+    {name:"P2", type:"Free", pos:[3,2]},
+    {name:"Q1", type:"Free", pos:[-2,-1]},
+    {name:"Q2", type:"Free", pos:[-1,-2]},
+    {name:"f", type:"FreeLine", pos:[1,1,1], color:[0,.5,.3], size:2, pinned:true},
+    {name:"h", type:"HorizontalLine", pos:[0,1,1], pinned:true},
+    {name:"v", type:"VerticalLine", pos:[1,0,1], pinned:true},
+    {name:"t1", type:"Through", args:["Q1"], pos:[1,-2,0], pinned:true},
+    {name:"t2", type:"Through", args:["Q2"], pos:[2,-1,0], pinned:true},
+  ]
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas" width="500" height="500"
+          style="border:2px solid black"></canvas>
+</body>
+
+</html>

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -214,14 +214,8 @@ Accessor.setField = function(geo, field, value) {
         movepointscr(geo, value, "homog");
     }
 
-    if (field === "homog" && geo.type === "FreeLine" && geo.movable && List._helper.isNumberVecN(value, 3)) {
-        movepointscr(geo, value);
-    }
-
-    if (field === "homog" && geo.type === "Through" && geo.movable && List._helper.isNumberVecN(value, 3)) {
-        dir = List.turnIntoCSList([value.value[1], CSNumber.neg(value.value[0]), CSNumber.real(0)]);
-        geo.homog = General.withUsage(value, "Line");
-        movepointscr(geo, dir, "dir");
+    if (field === "homog" && geo.kind === "L" && geo.movable && List._helper.isNumberVecN(value, 3)) {
+        movepointscr(geo, value, "homog");
     }
 
     if (field === "angle" && geo.type === "Through") {

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -41,8 +41,10 @@ geoOps.FreeLine.getParamForInput = function(el, pos, type) {
     if (type === "mouse") {
         homog = List.cross(pos, List.ez);
         homog = List.cross(homog, pos);
-    } else {
+    } else if (type === "homog") {
         homog = pos;
+    } else {
+        homog = List.turnIntoCSList([CSNumber.zero, CSNumber.zero, CSNumber.zero]);
     }
     return List.normalizeMax(homog);
 };
@@ -190,8 +192,17 @@ geoOps.HorizontalLine.initialize = function(el) {
     putStateComplexVector(pos);
 };
 geoOps.HorizontalLine.getParamForInput = function(el, pos, type) {
-    var homog = List.cross(pos, List.ex);
-    return List.normalizeMax(homog);
+    if (type === "mouse") {
+        pos = List.cross(pos, List.ex);
+    } else if (type === "homog") {
+        if (pos.value[0].real !== 0 || pos.value[0].imag !== 0)
+            pos = List.turnIntoCSList([
+                CSNumber.zero, pos.value[1], pos.value[2]
+            ]);
+    } else {
+        pos = List.turnIntoCSList([CSNumber.zero, CSNumber.zero, CSNumber.zero]);
+    }
+    return List.normalizeMax(pos);
 };
 geoOps.HorizontalLine.getParamFromState = function(el) {
     return getStateComplexVector(3);
@@ -231,8 +242,17 @@ geoOps.VerticalLine.initialize = function(el) {
     putStateComplexVector(pos);
 };
 geoOps.VerticalLine.getParamForInput = function(el, pos, type) {
-    var homog = List.cross(pos, List.ey);
-    return List.normalizeMax(homog);
+    if (type === "mouse") {
+        pos = List.cross(pos, List.ey);
+    } else if (type === "homog") {
+        if (pos.value[1].real !== 0 || pos.value[1].imag !== 0)
+            pos = List.turnIntoCSList([
+                pos.value[0], CSNumber.zero, pos.value[2]
+            ]);
+    } else {
+        pos = List.turnIntoCSList([CSNumber.zero, CSNumber.zero, CSNumber.zero]);
+    }
+    return List.normalizeMax(pos);
 };
 geoOps.VerticalLine.getParamFromState = function(el) {
     return getStateComplexVector(3);


### PR DESCRIPTION
This should finally fix #95.

The homog setters for horizontal and vertical lines just set one coordinate to zero. So they intersect the coordinate axes at the same position as the line described by the input coordinates. The provided example demonstrates this.