### PR TITLE
Update Closure Compiler to latest version (v20160315)

### DIFF
--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160208",
+        closure_version: "20160315",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",

--- a/src/js/libcs/RenderBackends.js
+++ b/src/js/libcs/RenderBackends.js
@@ -355,8 +355,7 @@ PdfWriterContext.prototype = {
 
     quadraticCurveTo: function(x1, y1, x2, y2) {
         this.bezierCurveTo(
-            (2 * x1 + this._xPos) / 3, (2 * y1 - this._yPos) / 3,
-            (x2 + 2 * x1) / 3, (y2 + 2 * y1) / 3, x2, y2);
+            (2 * x1 + this._xPos) / 3, (2 * y1 - this._yPos) / 3, (x2 + 2 * x1) / 3, (y2 + 2 * y1) / 3, x2, y2);
     },
 
     _kappa: 0.55228474983079340, // 4 * (Math.sqrt(2) - 1) / 3


### PR DESCRIPTION
See [release notes](https://github.com/google/closure-compiler/wiki/Releases#march-15-2016-v20160315).