### PR TITLE
Disallow function call in indexing constructs

### DIFF
--- a/ref/CSFundamentals.md
+++ b/ref/CSFundamentals.md
@@ -13,7 +13,7 @@ Here, one can specify the occasion on which the program will be executed.
 For instance, it can be executed whenever the user moves the construction or after any mouse click.
 Thus one can easily add functional behavior and graphical enhancements to an existing construction.
 
-The following sections will give you an overview of the global design of the programming language [CindyScript](CindyScript.md).
+The following sections will give you an overview of the global design of the programming language CindyScript.
 The language design follows some guiding principles:
 
 *  The language should be easy to learn, write and read
@@ -51,4 +51,4 @@ Logic statements
 Dealing with strings of characters
 
 For a detailed description of the language it is necessary to consult the documentation on specific parameters.
-We recommend to browse over the [CindyScript](CindyScript.md) manual at least once to get an impression of various possibilities of the language.
+We recommend to browse over the CindyScript manual at least once to get an impression of various possibilities of the language.

--- a/ref/General_Concepts.md
+++ b/ref/General_Concepts.md
@@ -1,10 +1,10 @@
 ## General Concepts of CindyScript
 
-This section is a brief introduction to the most fundamental concepts of [CindyScript](CindyScript.md).
+This section is a brief introduction to the most fundamental concepts of CindyScript.
 
-### CindyScript Is a Functional Language
+### CindyScript is a Functional Language
 
-All calculations in [CindyScript](CindyScript.md) are performed by executing functions.
+All calculations in CindyScript are performed by executing functions.
 A function can be considered as a kind of calculation that takes the arguments of the function and produces some kind of output value.
 Many calculations can already be expressed using only elementary functions.
 Thus the code fragment
@@ -40,21 +40,21 @@ Depending on the evaluation of the condition, the `if` function returns the valu
 
 ### Side Effects
 
-If a function is evaluated in [CindyScript](CindyScript.md), it may have "side effects." Side effects are important for all kinds of interactions between a [CindyScript](CindyScript.md) program and a Cinderella construction.
+If a function is evaluated in CindyScript, it may have "side effects." Side effects are important for all kinds of interactions between a CindyScript program and a Cinderella construction.
 Typical side effects are:
 
 *  **Drawing:**
-A [CindyScript](CindyScript.md) statement may cause drawing operations in the construction views.
+A CindyScript statement may cause drawing operations in the construction views.
 
 *  **Assignments:**
-A [CindyScript](CindyScript.md) operation may change the position, color, size, etc.
+A CindyScript operation may change the position, color, size, etc.
 of geometric objects.
 
 *  **Variable assignments:**
-A [CindyScript](CindyScript.md) statement can create variables and assign values to them.
+A CindyScript statement can create variables and assign values to them.
 
 *  **Function creation:**
-A [CindyScript](CindyScript.md) statement can create and define a function that can be used later.
+A CindyScript statement can create and define a function that can be used later.
 
 For instance, the statement
 
@@ -71,8 +71,8 @@ sets the color of point *A* to *white*.
 ###  Control Flow
 
 Most users are probably accustomed to sequential programming languages like C, Java, Pascal, and Basic.
-In practice, writing sequential code in [CindyScript](CindyScript.md) is not so different from writing code in these languages.
-[CindyScript](CindyScript.md) has a `;` operator `‹statement1›;‹statement2›` that simply first evaluates `statement1` and then `statement2`.
+In practice, writing sequential code in CindyScript is not so different from writing code in these languages.
+CindyScript has a `;` operator `‹statement1›;‹statement2›` that simply first evaluates `statement1` and then `statement2`.
 The return value of the `;` operator is the result of the last non-empty statement.
 
     > 5; 7
@@ -104,9 +104,9 @@ The body of the loop is the two lines `j=i*i; draw([i,j]);`.
 
 ###  No Explicit Typing
 
-[CindyScript](CindyScript.md) is designed to provide a maximum of functionality with a minimum of syntactic overhead.
-Therefore, [CindyScript](CindyScript.md) does not have explicit typing of values.
-Like many other languages, [CindyScript](CindyScript.md) uses the concept of variables.
+CindyScript is designed to provide a maximum of functionality with a minimum of syntactic overhead.
+Therefore, CindyScript does not have explicit typing of values.
+Like many other languages, CindyScript uses the concept of variables.
 However, in contrast to other languages, the variables do not belong to a specific type.
 Any value of any type can be assigned to any variable.
 On the one hand, this gives the programmer a great deal of freedom to generate powerful code.
@@ -122,10 +122,10 @@ So, in the above example, `f([1,2],[3,4])` will perform a vector addition and ev
 
 ### Local Variables: The `#` Variable
 
-There are several loop-like constructions in [CindyScript](CindyScript.md).
+There are several loop-like constructions in CindyScript.
 For instance, the operator `select(‹list›,‹condition‹)` traverses all elements of `‹list›` and returns a list of objects that satisfy the condition.
 For this to occur, there must be a way to feed elements that are to be tested to the condition.
-By default, [CindyScript](CindyScript.md) uses a variable #, which serves as a handle for the run variable.
+By default, CindyScript uses a variable #, which serves as a handle for the run variable.
 For instance, the statement
 
     > select(1..30, isodd(#))
@@ -151,9 +151,9 @@ Thus `select(1..30,i,isodd(i))` and `repeat(9,i,print(i))` are equivalent to the
 
 ### The Data Types of CindyScript
 
-As already mentioned, [CindyScript](CindyScript.md) does not have explicit typing.
+As already mentioned, CindyScript does not have explicit typing.
 Nevertheless, any *value* of a variable belongs to an explicit type.
-The basic types of [CindyScript](CindyScript.md) are
+The basic types of CindyScript are
 
 *  ‹number›: Any numeric value.
 Numbers can be integers, real numbers, or complex numbers.
@@ -167,7 +167,7 @@ The number type is particularly powerful, since it can contain integers, floatin
 
 ### Variables and Their Scope
 
-Since [CindyScript](CindyScript.md) does not have explicit typing for variables, it allows variables to be created "on the fly" as needed.
+Since CindyScript does not have explicit typing for variables, it allows variables to be created "on the fly" as needed.
 A variable is created when it is assigned for the first time.
 If `x` is not already being used, the statement
 
@@ -207,7 +207,7 @@ This uses dynamic scoping, too.
 ### Access to Geometric Elements and Their Properties
 
 Variables are also used as a kind of handle to geometric objects.
-They form a major link of [CindyScript](CindyScript.md) to Cinderella and [CindyLab](CindyLab.md).
+They form a major link of CindyScript to Cinderella and [CindyLab](CindyLab.md).
 If a variable has a name that is identical to the label of a geometric object, it provides a link to that geometric object.
 The value of the variable can still be overloaded by an explicit assignment of a value to the variable.
 The different properties of a geometric object (position, color, size, etc.) are accessible via the . operator.
@@ -217,7 +217,7 @@ Furthermore, properties relevant to physics simulation (mass, velocity, kinetic 
 
 ### Modifiers
 
-Many operators in [CindyScript](CindyScript.md) provide more functionality than one may notice at first glance.
+Many operators in CindyScript provide more functionality than one may notice at first glance.
 Usually these features can be accessed using so-called modifiers.
 The operators are defined in a way such that their default usage provides a suitable behavior for most situations.
 However, it may be necessary to modify the default behavior.
@@ -242,31 +242,31 @@ They may occur in any order and at any position of the function call.
 
 ### Lists/Vectors/Matrices
 
-[CindyScript](CindyScript.md) offers *lists* as elementary data types.
+CindyScript offers *lists* as elementary data types.
 Lists are the fundamental paradigm that is used to define more complex data structures.
 In addition to the obvious application as enumeration objects, lists can also be used to represent vectors and matrices.
 A vector is a list of numbers.
 A list of vectors whose vectors all have the same length will be interpreted as a matrix.
-[CindyScript](CindyScript.md) provides the usual operations for combining vectors, matrices, and numbers.
+CindyScript provides the usual operations for combining vectors, matrices, and numbers.
 Depending on the content of `a` and `b`, the expression `a*b` may represent a usual multiplication of numbers, a matrix product, or a matrix/vector multiplication.
 
-In [CindyScript](CindyScript.md) there is no distinction between row vectors and column vectors on the level of vectors.
+In CindyScript there is no distinction between row vectors and column vectors on the level of vectors.
 However, by the use of suitable functions one can convert a vector of length `n` to an (*n* × 1) matrix or to a (1 × *n*) matrix.
 
 ### Drawing
 
-[CindyScript](CindyScript.md) provides many statements with which one can draw directly on the canvas of the geometric views.
+CindyScript provides many statements with which one can draw directly on the canvas of the geometric views.
 Using this feature it is possible to enrich the behavior of Cinderella constructions significantly.
 It is possible to draw points, lines, segments, polygons, tables, functions, etc.
 However, it is important not to confuse a script-drawn geometric object with a geometric object that is active in geometry.
 It is not possible to use such script-drawn elements as definers in Cinderella modes.
 
-If one wants to modify active elements using a script, then it is necessary to first construct them and then alter their positions using [CindyScript](CindyScript.md) statements.
+If one wants to modify active elements using a script, then it is necessary to first construct them and then alter their positions using CindyScript statements.
 All free elements can be moved by setting their position parameters.
 
 ### Execution Slots
 
-The [script window of Cinderella](The_CindyScript_Editor.md) in which one enters the [CindyScript](CindyScript.md) code contains several slots in which the text can be entered.
+The [script window of Cinderella](The_CindyScript_Editor.md) in which one enters the CindyScript code contains several slots in which the text can be entered.
 The particular slots are called
 
 *  Draw
@@ -279,17 +279,17 @@ The particular slots are called
 
 Each of these entries corresponds to the occasion that triggers the execution of the script.
 For instance, scripts in the *Draw* slot is executed directly before a screen refresh in the view.
-The *Initialization* slot is executed directly after the [CindyScript](CindyScript.md) code is parsed.
+The *Initialization* slot is executed directly after the CindyScript code is parsed.
 *Simulation Start* is executed before starting an animation when the play button is pressed.
 Using this mechanism it is possible to write programs that react nicely to user events.
 
 ### Runtime Error handling
 
-[CindyScript](CindyScript.md) runs in a runtime environment.
+CindyScript runs in a runtime environment.
 In principle, every tiny move in a construction can cause the evaluation of a script.
 For this to happen, a reasonable design decision in the language had to be made concerning the occurrence of runtime errors.
 It would be very distractive if the usual user interaction was interrupted by error messages over and over (in particular, if a construction is used as an applet within an HTML page).
-For this reason, error handling in [CindyScript](CindyScript.md) at runtime reports only the first ten errors.
+For this reason, error handling in CindyScript at runtime reports only the first ten errors.
 However, runtime errors will never interrupt execution.
 Runtime errors (such as division by zero, or access to a nonexistent array index) are simply ignored in the program flow.
 Erroneous function evaluations simply produce an undefined result, and the calculation proceeds (perhaps causing more undefined results).

--- a/ref/Interaction_with_C-Books.md
+++ b/ref/Interaction_with_C-Books.md
@@ -126,13 +126,13 @@ set the pinning property to "false" for B and C (or even for all points) in the 
 2.
 and to set it later (e.g., in the "draw" event) to "true".
 
-This can be achieved using the following [CindyScript](CindyScript.md) code.
-Paste this into the "initialization" event part of the Cinderella "[CindyScript](CindyScript.md) Editor":
+This can be achieved using the following CindyScript code.
+Paste this into the "initialization" event part of the Cinderella "CindyScript Editor":
 
 forall(allpoints(), inspect(,"pinning", false));
 
 In order to pinn the points after having changed the x-coordinates of B and C,
-paste this into the "draw" event part of the Cinderella "[CindyScript](CindyScript.md) Editor":
+paste this into the "draw" event part of the Cinderella "CindyScript Editor":
 
 forall(allpoints(), inspect(,"pinning", true));
 
@@ -145,7 +145,7 @@ We will not go into this here.
 
 Moreover, not only coordinates of points can be set via the random parameters feature.
 
-You may change any other numerical property of a Cinderella object which is changeable from [CindyScript](CindyScript.md) via the syntax
+You may change any other numerical property of a Cinderella object which is changeable from CindyScript via the syntax
 
 ...
 = integer number

--- a/ref/Language.md
+++ b/ref/Language.md
@@ -752,6 +752,7 @@ powerNoBars
     ;
 indexed
     : atom
+    | functionCall
     | indexed OP_KEY atom
     | indexed OP_FIELD IDENTIFIER
     | indexed OP_TAKE atom
@@ -760,6 +761,7 @@ indexed
     ;
 indexedNoBars
     : atomNoBars
+    | functionCall
     | indexedNoBars OP_KEY atomNoBars
     | indexedNoBars OP_FIELD IDENTIFIER
     | indexedNoBars OP_TAKE atomNoBars
@@ -769,7 +771,6 @@ indexedNoBars
 atom
     : ROUND_OPEN expression ROUND_CLOSE
     | list
-    | functionCall
     | absNormDist
     | number
     | string
@@ -778,7 +779,6 @@ atom
 atomNoBars
     : ROUND_OPEN expression ROUND_CLOSE
     | list
-    | functionCall
     | number
     | string
     | variable
@@ -807,7 +807,6 @@ absNormDist
 functionCall
     : functionName ROUND_OPEN args ROUND_CLOSE
     | functionName SQUARE_OPEN args SQUARE_CLOSE
-    | functionName CURLY_OPEN args CURLY_CLOSE
     ;
 args
     : arg
@@ -827,3 +826,118 @@ string
     : STRING
     ;
 ```
+
+The associated terminals are defined as follows:
+
+```bnf
+OP_KEY: ':';
+OP_FIELD: '.';
+OP_DEG: '°';
+OP_TAKE: '_'; // also used inside := _
+
+OP_POW: '^';
+OP_SQRT: '√';
+
+OP_MUL
+    : '*'
+    | '\u2062' // invisible times
+    | '\u22c5' // ⋅ dot operator
+    | '\u00b7' // · middle dot
+    ;
+OP_CROSS: '×';
+OP_DIV
+    : '/'
+    | '\u00f7' // ÷ division sign
+    | '\u2215' // ∕ division slash
+    | '\u2236' // ∶ ratio
+    ;
+OP_ADD: '+';
+OP_SUB: '-' | '−';
+OP_NEG: '!' | '¬';
+
+OP_SEQ: '..';
+
+OP_EQ: '==' | '≟';
+OP_NE: '!=' | '<>' | '≠';
+OP_LT: '<';
+OP_GT: '>';
+OP_LE: '<=' | '≤' | '≦';
+OP_GE: '>=' | '≥' | '≧';
+OP_AEQ: '~=' | '≈';
+OP_ANE: '~!=' | '≉';
+OP_ALT: '~<' | '⪉';
+OP_AGT: '~>' | '⪊';
+OP_ALE: '~<=' | '⪅';
+OP_AGE: '~>=' | '⪆';
+OP_IN: '∈';
+OP_NIN: '∉';
+
+OP_AND: '&' | '∧';
+OP_OR: '%' | '∨';
+
+OP_PREPEND: '<:';
+
+OP_APPEND: ':>';
+OP_CONCAT: '++' | '∪';
+OP_REMOVE: '--' | '∖';
+OP_COMMON: '~~' | '∩';
+
+OP_ASSIGN: '=';
+OP_DEFINE: ':='; // also used inside := _
+OP_BDEFINE: '::=';
+
+OP_SEMI: ';';
+
+OP_MODIF: '->' | '→';
+
+OP_LIST: ',';
+
+BAR: '|';
+ROUND_OPEN: '(';
+ROUND_CLOSE: ')';
+SQUARE_OPEN: '[';
+SQUARE_CLOSE: ']';
+
+STRING: '"' .*? '"'
+FLOAT
+    : [0-9] (WS [0-9])* (WS [.] (?![.]))? (WS [Ee] (WS [+\-])? (WS [0-9])+)?
+    | ([0-9] WS)* [.] (WS [0-9])+ (WS [Ee] (WS [+\-])? (WS [0-9])+)?
+    ;
+SUBSCRIPT: ([₊₋] WS)? [₀₁₂₃₄₅₆₇₈₉] (WS [₀₁₂₃₄₅₆₇₈₉])*
+SUPERSCRIPT: ([₊₋] WS)? [⁰¹²³⁴⁵⁶⁷⁸⁹] (WS [⁰¹²³⁴⁵⁶⁷⁸⁹])*
+IDENTIFIER
+    : (LETTER | [']) (WS ([0-9'] | LETTER))*
+    | [#] (WS [0-9])?
+    ;
+```
+
+The non-operator tokens at the end of this list may contain optional
+in-token whitespace `WS`, which can be any sequence consisting of
+space characters and/or horizontal tabs. It is without semantic relevance.
+
+```bnf
+WS: [ \t]*;
+```
+
+Between tokens, the following lexical constructs are allowed
+and will be ignored by subsequent processing steps.
+
+```bnf
+SPACE: [ \t\n]+;
+SINGLE_LINE_COMMENT: '//' [^\n]*;
+MULTI_LINE_COMMENT: '/*' (MLC_BODY MULTI_LINE_COMMENT)* MLC_BODY '*'+ '/';
+MLC_BODY: ([^/*] | [/]+[^/*] | [*]+[^/*])*;
+```
+
+Of course, many lexer generators don't allow recursive token definitions,
+so an implementation may want to treat `/*` and `*/` as separate tokens,
+and switch between normal and comment parsing mode.
+
+As stated [above](#identifier-names), the `LETTER` construct
+represents any codepoint which has general category `L`
+in the Unicode 8.0.0 standard.
+
+Within the `FLOAT` token, `(?![.])` is used to denote a negative
+look-ahead assertion: the next character at this point *must not* be a
+second dot.  If it is, the first dot and any whitespace preceding it
+is not part of the `FLOAT` token.

--- a/ref/Language.md
+++ b/ref/Language.md
@@ -508,6 +508,37 @@ Curly braces are reserved for future applications.
     > sin{30°}
     ! CindyScriptParseError: {…} reserved for future use at 1:3
 
+#### Function invocation
+
+A function invocation is a function name (which is an identifier),
+followed by zero or more arguments enclosed in square or round brackets.
+
+    > sin[0]
+    < 0
+    > resetclock()
+    < ___
+
+It is permissible for function arguments to be empty.
+This is particularly relevant for control flow functions,
+where an empty argument can represent an empty sequence of commands.
+
+    > if (2 < 3, , println("Back to school!"))
+    < ___
+
+When a function is used in the index position of an indexing construct
+using `_`, `.` or `:`, it has to be enclosed in parentheses.
+(This reserves such constructs for method-like invocations
+of probably anonymous functions in an object-oriented programming style.)
+
+    > lst = 10 * (1..7);
+    > f(x) := x + 1;
+    > lst_(f(3))
+    < 40
+
+    - CindyScript >=2016
+    > lst_f(3)
+    ! CindyScriptParseError: Function call in indexing construct must be enclosed in parentheses at 1:5
+
 #### Vertical bars `|…|`
 
 With a single argument, [`|‹expr›|`](Arithmetic_Operators.md#$7cu_$7cu)

--- a/ref/The_CindyScript_Editor.md
+++ b/ref/The_CindyScript_Editor.md
@@ -2,7 +2,7 @@
 
 ###  The CindyScript Editor
 
-To enter [CindyScript](CindyScript.md) one can use the editor that is available from the menu *Scripting/Edit Scripts*.
+To enter CindyScript one can use the editor that is available from the menu *Scripting/Edit Scripts*.
 Here we explain briefly how to use the editor.
 
 ####  The Input Window
@@ -16,7 +16,7 @@ type) scripts, and a smaller text area that shows any output from the scripts.
 
 ####  Occasions
 
-Cinderella is highly interactive, and that is the reason for many "occasions" that are suited for triggering the execution of [CindyScript](CindyScript.md) commands.
+Cinderella is highly interactive, and that is the reason for many "occasions" that are suited for triggering the execution of CindyScript commands.
 On the left side of the script editor you see the available occasions.
 
 Usually, you write scripts for the "Draw" occasion.
@@ -38,7 +38,7 @@ You find an overview over all occasions in [the introduction to CindyScript](CSF
 
 ###  The Shell
 
-You can also enter [CindyScript](CindyScript.md) commands and have them executed immediately.
+You can also enter CindyScript commands and have them executed immediately.
 Just choose the "Shell" item from the left panel, and type the commands into the text area on the right.
 Pressing shift+enter will execute the command you typed, and you will see the in- and output in the lower text area.
 You can use shift-up and shift-down to scroll through a history of commands entered.
@@ -74,7 +74,7 @@ Checking the Script Editor reveals the automatically generated draw occasion scr
 
 Many text input fields of the [Inspector](Inspector.md) window accept CindyScript code as input.
 The script will only be evaluated once – if you want to make permanent changes you have to use either the command line or the draw occasion in the Script Editor.
-After pressing enter, you can still see your [CindyScript](CindyScript.md) code, but if the input field looses the input focus its value will be replaced with the evaluation result.
+After pressing enter, you can still see your CindyScript code, but if the input field looses the input focus its value will be replaced with the evaluation result.
 
 ![Image](img/CindyScriptInspector.png)
 
@@ -89,7 +89,7 @@ As the field for script code is very small we recommend to just call functions d
 ###  Other Languages
 
 You can choose the programming language used to interpret a script using the choice box in the top panel.
-Available languages are [CindyScript](CindyScript.md), Python, JRuby and CDY, the internal language that is used to store constructions.
+Available languages are CindyScript, Python, JRuby and CDY, the internal language that is used to store constructions.
 However, currently we only support CindyScript, and this is also the only language you can use in [Cinderella applets](HTML_Export.md).
 
 ![Image](img/ScriptEditor-languages.png)

--- a/ref/User_Input.md
+++ b/ref/User_Input.md
@@ -79,7 +79,7 @@ The calibrated data is a vector of unit length that represents the orientation o
 
 Cinderella can be used to export interactive worksheets to an html page.
 Very often it is desirable not only to export an interactive construction but also a set of construction tools along with it (like buttons for constructing points, lines or circles).
-By using the following set of [CindyScript](CindyScript.md) operations it is easily possible to create (and remove) custom toolbars that reside within an applet window.
+By using the following set of CindyScript operations it is easily possible to create (and remove) custom toolbars that reside within an applet window.
 
 Toolbars are in particular important for creating interactive student exercises.
 An example for this is given in [Interactive Exercises](Interactive_Exercises.md).

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -9,6 +9,8 @@ var operatorLevels = [{
     deg: ['°'],
     take: ['_'],
 }, {
+    functionCall: true
+}, {
     rassoc: true,
     pow: ['^'],
     sqrt: ['√'],
@@ -80,12 +82,15 @@ var flexfix = [';', ','];
 
 var operatorSymbols = [];
 var operators = {};
+var functionCallPrecedence;
 
 (function initializeOperators() {
     var precedence = 0;
     operatorLevels.forEach(function(level) {
         precedence += 2;
         var rassoc = !!level.rassoc;
+        if (level.functionCall)
+            functionCallPrecedence = precedence;
         for (var name in level) {
             var symbols = level[name];
             if (typeof symbols === 'boolean')
@@ -567,6 +572,11 @@ function parseRec(tokens, closing) {
                         throw ParseError(
                             'Function name must be an identifier',
                             fname.start);
+                    if (seq.length > 2 &&
+                        seq[seq.length - 2].precedence < functionCallPrecedence)
+                        throw ParseError(
+                            'Function call in indexing construct must be enclosed in parentheses',
+                            tok.start);
                     fname.ctype = 'function';
                     var args = fname.args = [];
                     var modifs = fname.modifs = {};


### PR DESCRIPTION
One day we may want to write things that look like a method call, e.g. `foo.bar(baz)` where `foo.bar` is the thing to call.  To make sure that we don't break any existing code when we introduce this, we disallow function calls directly (i.e.  without parentheses) in an indexing construct (i.e. `.`, `:` and `_` operators).

As a drive-by fix I've eliminated several dead links in our reference documentation.