### PR TITLE
Add macro ConicFoci as alias for ConicBy2Foci1P

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2487,6 +2487,11 @@ geoMacros.CircleByRadius = function(el) {
     return [el];
 };
 
+geoMacros.ConicFoci = function(el) {
+    el.type = "ConicBy2Foci1P";
+    return [el];
+};
+
 geoMacros.IntersectionConicLine = function(el) {
     el.args = [el.args[1], el.args[0]];
     el.type = "IntersectLC";


### PR DESCRIPTION
Cinderella exports `ConicFoci` as the name for a conic defined by two foci and one point, whereas CindyJS uses `ConicBy2Foci1P`.

This pull request adds a macro `ConicFoci` as an alias for `ConicBy2Foci1P`.

I am slightly unhappy with the ambiguousness of `ConicFoci`. So it might be better to adapt the export to CindyJS in Cinderella. What do you think?