### PR TITLE
Source maps

### DIFF
--- a/make/build.js
+++ b/make/build.js
@@ -299,7 +299,7 @@ module.exports = function build(settings, task) {
             source_map_format: "V3",
             source_map_location_mapping: [
                 "build/js/|",
-                "src/js/|../../plugins/cindy3d/src/js/",
+                "plugins/|../../plugins/",
             ],
             output_wrapper_file: "plugins/cindy3d/src/js/Cindy3D.js.wrapper",
             js_output_file: "build/js/Cindy3D.js",
@@ -368,7 +368,7 @@ module.exports = function build(settings, task) {
             source_map_format: "V3",
             source_map_location_mapping: [
                 "build/js/|",
-                "src/js/|../../plugins/cindygl/src/js/",
+                "plugins/|../../plugins/",
             ],
             output_wrapper_file: "plugins/cindygl/src/js/CindyGL.js.wrapper",
             js_output_file: "build/js/CindyGL.js",

--- a/tools/prepare-deploy.js
+++ b/tools/prepare-deploy.js
@@ -75,7 +75,7 @@ function subst(name, err, content) {
     fs.writeFile(path.join(outDir, name), content);
 }
 
-var mapKeys = ["version", "file", "sourceRoot", "sources", "names", "mappings"];
+var mapKeys = ["version", "file", "sourceRoot", "sources", "sourcesContent", "names", "mappings"];
 mapKeys.reverse(); // so that missing keys (indexOf returns -1) go to the end
 
 function map(name, err, content) {
@@ -89,6 +89,10 @@ function map(name, err, content) {
     map.sourceRoot = "https://raw.githubusercontent.com/CindyJS/CindyJS/" + head + "/";
     map.sources = map.sources.map(function(src) {
         return ppath.normalize(ppath.join("build/js", root, src));
+    });
+    map.sourcesContent = map.sources.map(function(src) {
+        if (!/^build/.test(src)) return null;
+        return fs.readFileSync(src, "utf-8");
     });
     var keys = Object.keys(map);
     keys.sort(function(a, b) {


### PR DESCRIPTION
Two improvements aimed at making source maps more useable. The first fixes an incorrect path for closure-compiled plugins, introduced by 6c689f3706ad671879b9cb19f4d463a5dac38fde for #191. The other includes the content of generated sources in the sourcemap itself, since those are obviously not available from GitHub.