### PR TITLE
Update list of contributors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+Jürgen Richter-Gebert <richter@ma.tum.de>
+<aaron.montag@tum.de> <montag@ma.tum.de>
+<aaron.montag@tum.de> <amontag@ma.tum.de>
+<stefan.kranich@ma.tum.de> <kranich@users.noreply.github.com>
+<jw@tophostingteam.de> <jens.wurster@codenic.de>
+<jw@tophostingteam.de> <wurster@cermat.org>
+<gagern@ma.tum.de> <Martin.vGagern@gmx.net>

--- a/package.json
+++ b/package.json
@@ -50,12 +50,13 @@
   ],
   "author": "Jürgen Richter-Gebert <richter@ma.tum.de>",
   "contributors": [
+    "Aaron Montag <aaron.montag@tum.de>",
+    "Alexander Elkins",  
     "Martin von Gagern <gagern@ma.tum.de>",
-    "Michael Strobel <strobel@ma.tum.de>",
-    "Stefan Kranich <stefan.kranich@ma.tum.de>",
     "Ulrich Kortenkamp <kortenkamp@cinderella.de>",
-    "Jens Wurster <jw@tophostingteam.de>",
-    "Aaron Montag <aaron.montag@tum.de>"
+    "Stefan Kranich <stefan.kranich@ma.tum.de>",
+    "Michael Strobel <strobel@ma.tum.de>",
+    "Jens Wurster <jw@tophostingteam.de>"
   ],
   "license": "Apache-2.0",
   "main": "build/js/Cindy.js",


### PR DESCRIPTION
This adds Alexander Elkins to the list of contributors in `package.json`, since he has made several valuable contributions to the project. It also sorts the list of contributors by family name, and helps unify the various alternative spellings and addresses of some authors. @montaga and @wursterje might want to check whether they agree with my choice for the canonical email address for them, but we can always switch that later on, so I see no pressing need to wait for consent before merging.