### PR TITLE
Reduce arrow size

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -295,14 +295,14 @@ function updateCindy() {
         csctx.beginPath();
         csctx.moveTo(0, -m.ty);
         csctx.lineTo(csw - 6, -m.ty);
-        csctx.moveTo(csw - 23, -10 - m.ty);
+        csctx.moveTo(csw - 13, -5 - m.ty);
         csctx.lineTo(csw - 3, -m.ty);
-        csctx.lineTo(csw - 23, 10 - m.ty);
+        csctx.lineTo(csw - 13, 5 - m.ty);
         csctx.moveTo(m.tx, csh);
         csctx.lineTo(m.tx, 6);
-        csctx.moveTo(m.tx - 10, 23);
+        csctx.moveTo(m.tx - 5, 13);
         csctx.lineTo(m.tx, 3);
-        csctx.lineTo(m.tx + 10, 23);
+        csctx.lineTo(m.tx + 5, 13);
         csctx.stroke();
     }
     traceMouseAndScripts();


### PR DESCRIPTION
I misread the arrow-drawing code in Render2D, leading to twice the intended arrow size. Found by @kranich in https://github.com/CindyJS/CindyJS/pull/326#issuecomment-209522413.