### PR TITLE
better midpoint handling

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -127,9 +127,21 @@ geoOps.Meet.visiblecheck = function(el) {
 };
 
 geoOps._helper.midpoint = function(a, b) {
+    var aZ = a.value[2];
+    var bZ = b.value[2];
+
+    // case both points on l_infty
+    if (CSNumber._helper.isAlmostZero(aZ) && CSNumber._helper.isAlmostZero(bZ)) {
+        var aY = a.value[1];
+        var bY = b.value[1];
+        return List.normalizeMax(List.add(
+            List.scalmult(bY, a),
+            List.scalmult(aY, b)));
+    }
+    // finite points + 1 finite and 1 infinite 
     return List.normalizeMax(List.add(
-        List.scalmult(b.value[2], a),
-        List.scalmult(a.value[2], b)));
+        List.scalmult(bZ, a),
+        List.scalmult(aZ, b)));
 };
 
 geoOps.Mid = {};

--- a/tests/GeoOps_tests.js
+++ b/tests/GeoOps_tests.js
@@ -166,3 +166,35 @@ describe("IntersectLC helper", function() {
     p2.value[1].value.imag.should.be.approximately(0, 1e-12);
   });
 });
+
+
+describe("MidPoint", function() {
+  it("generic input", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[0,0]},
+      {name:"B", type:"Free", pos:[2,2]},
+      {name:"M", type:"Mid", args:["A","B"]},
+    ], homog([1,1,1]), done);
+  });
+  it("finite identical", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[2,2]},
+      {name:"B", type:"Free", pos:[2,2]},
+      {name:"M", type:"Mid", args:["A","B"]},
+    ], homog([2,2,1]), done);
+  });
+  it("finite point + far point", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[0,0,1]},
+      {name:"B", type:"Free", pos:[1,1,0]},
+      {name:"M", type:"Mid", args:["A","B"]},
+    ], homog([1,1,0]), done);
+  });
+  it("2 x infinite", function(done) {
+    testGeo([
+      {name:"A", type:"Free", pos:[2,2,0]},
+      {name:"B", type:"Free", pos:[0,-1,0]},
+      {name:"M", type:"Mid", args:["A","B"]},
+    ], homog([1,2,0]), done);
+  });
+});


### PR DESCRIPTION
Hi,

the midpoint algorithm does not handle the case where both points are at l_infty and returns the zero vector (or perhaps even worse). 

We can specify a correct midpoint analogously to the RP^2 case in RP^1, multiplying with the y-coordinate instead of the z-coordinate. 

On the go i implemented some tests. 