### PR TITLE
New representation of images

### DIFF
--- a/examples/Bastelbogen.html
+++ b/examples/Bastelbogen.html
@@ -172,18 +172,14 @@ function utf8Decode(bytes) {
 createCindy.registerPlugin(1, "imgmeta", function(api) {
     api.defineFunction("xmpdescription", 1, function(args, modifs) {
         var img = api.evaluate(args[0]);
-        if (img.ctype === "image") { // dropped image file
-            img = img.value;
-        } else if (img.ctype === "string") {
-            img = api.getImage(img.value);
-            if (!img || !img.src) {
-                console.warn(img.value + " does not name an image");
-                return api.nada;
-            }
-        } else {
+        console.log(img);
+        img = api.getImage(img);
+        console.log(img);
+        if (!img) {
             console.warn("Argument does not name an image");
             return api.nada;
         }
+        img = img.img;
         var data = img.src.replace(/^data:image\/png;base64,/, "");
         if (data === img.src) {
             console.warn("Only data:image/png;base64,… supported");

--- a/plugins/cindygl/src/js/CanvasWrapper.js
+++ b/plugins/cindygl/src/js/CanvasWrapper.js
@@ -7,7 +7,7 @@ function addCanvasWrapperIfRequired(name, api) {
     canvaswrappers[name] = new CanvasWrapper(img); //this might be a 0x0px trash-image if image was not loaded.
     if (!img.ready) {
       console.error("Image not ready. Creating onload event.");
-      img.callWhenReady(function() {
+      img.whenReady(function() {
         console.log("Image " + name + " has been loaded now");
         requiredcompiletime++; //force recompile
       });

--- a/plugins/cindyjs.externs
+++ b/plugins/cindyjs.externs
@@ -21,6 +21,17 @@ createCindy.anyval;
  *            createCindy.anyval} */
 createCindy.op;
 
+/** @typedef {{
+ *    img: (HTMLImageElement|HTMLCanvasElement|HTMLVideoElement),
+ *    width: number,
+ *    height: number,
+ *    ready: boolean,
+ *    live: boolean,
+ *    callWhenReady: function(function()),
+ *    drawTo: (undefined|function(CanvasRenderingContext2D,number,number))
+ *  }}
+ */
+createCindy.image;
 
 /** @typedef {{
  *    instance: Object,
@@ -35,7 +46,7 @@ createCindy.op;
  *    getVariable: function(string):createCindy.anyval,
  *    getInitialMatrix: function():{a:number,b:number,c:number,d:number,
  *      tx:number,ty:number,det:number,sdet:number},
- *    getImage: function(string, boolean),
+ *    getImage: function((string|createCindy.anyval),boolean=):createCindy.image,
  *    getMyfunction: function(string)
  *  }}
  */

--- a/plugins/cindyjs.externs
+++ b/plugins/cindyjs.externs
@@ -27,7 +27,7 @@ createCindy.op;
  *    height: number,
  *    ready: boolean,
  *    live: boolean,
- *    callWhenReady: function(function()),
+ *    whenReady: function(function()),
  *    drawTo: (undefined|function(CanvasRenderingContext2D,number,number))
  *  }}
  */

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -208,11 +208,7 @@ function setuplisteners(canvas, data) {
                 reader.onload = function() {
                     var img = new Image();
                     img.onload = function() {
-                        var value = {
-                            ctype: "image",
-                            value: img
-                        };
-                        oneDone(i, value);
+                        oneDone(i, loadImage(img));
                     };
                     img.src = reader.result;
                 };

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -217,20 +217,10 @@ function createCindyNow() {
     if (typeof csinitphys === 'function')
         csinitphys(data.behavior);
 
-    //Read images: TODO ordentlich machen
     for (var k in data.images) {
-        var name = data.images[k];
-        images[k] = new Image();
-        images[k].ready = false;
-        /*jshint -W083 */
-        images[k].onload = function() {
-            images[k].ready = true;
-            updateCindy();
-
-
-        };
-        /*jshint +W083 */
-        images[k].src = name;
+        var img = loadImage(data.images[k]);
+        if (img !== nada)
+            images[k] = img;
     }
 
     globalInstance.canvas = c;
@@ -251,6 +241,85 @@ function createCindyNow() {
         });
     loadExtraModules();
     doneLoadingModule();
+}
+
+/*
+ * An image wrapper object contains the following properties:
+ * img: the actual drawable, i.e. an <img>, <canvas>, <video> or similar
+ * width, height: dimensions of the image
+ * ready: boolean indicating whether the image been loaded already
+ * live: boolean indicating whether the image is expected to change continuously
+ */
+function loadImage(obj) {
+    var img;
+    if (typeof obj === "string") {
+        img = new Image();
+        img.src = obj;
+    } else {
+        img = obj;
+    }
+    if (!img.tagName) {
+        console.error("Not a valid image element", img);
+        return nada;
+    }
+    var value = {
+        img: img,
+        width: NaN,
+        height: NaN,
+        ready: true,
+        live: false,
+        whenReady: callFunctionNow,
+    };
+    var tag = img.tagName.toLowerCase();
+    var callWhenReady = [];
+    if (tag === "img") {
+        if (img.complete) {
+            value.width = img.width;
+            value.height = img.height;
+        } else {
+            value.ready = false;
+            img.addEventListener("load", function() {
+                value.width = img.width;
+                value.height = img.height;
+                value.ready = true;
+                value.whenReady = callFunctionNow;
+                callWhenReady.forEach(callFunctionNow);
+                updateCindy();
+            });
+            value.whenReady = callWhenReady.push.bind(callWhenReady);
+        }
+    } else if (tag === "video") {
+        value.live = true;
+        if (img.readyState >= img.HAVE_METADATA) {
+            value.width = img.videoWidth;
+            value.height = img.videoHeight;
+        } else {
+            value.ready = false;
+            img.addEventListener("loadedmetadata", function() {
+                value.width = img.videoWidth;
+                value.height = img.videoHeight;
+                value.ready = true;
+                value.whenReady = callFunctionNow;
+                callWhenReady.forEach(callFunctionNow);
+                updateCindy();
+            });
+            value.whenReady = callWhenReady.push.bind(callWhenReady);
+        }
+    } else if (tag === "canvas") {
+        value.width = img.width;
+        value.height = img.height;
+    } else {
+        console.error("Not a valid image element", tag, img);
+        return nada;
+    }
+    return {
+        ctype: "image",
+        value: value,
+    };
+}
+
+function callFunctionNow(f) {
+    return f();
 }
 
 function loadExtraModules() {

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1403,7 +1403,7 @@ evaluator.createimage$3 = function(args, modifs) {
     // canvas.style.border="1px solid #FF0000";
     canvas.style.display = "none";
     document.body.appendChild(canvas);
-    images[v0.value] = canvas;
+    images[v0.value] = loadImage(canvas);
 
     return nada;
 };

--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -7,24 +7,32 @@ function imageFromValue(val) {
         return val.value;
     }
     if (val.ctype === 'string' && images.hasOwnProperty(val.value)) {
-        return images[val.value];
+        return images[val.value].value;
     }
     return null;
 }
 
 evaluator.imagesize$1 = function(args, modifs) {
     var img = imageFromValue(evaluateAndVal(args[0]));
-    if (img) {
-        return List.realVector([+img.width, +img.height]);
+    if (!img) {
+        return nada;
     }
-    return nada;
+    return List.realVector([+img.width, +img.height]);
+};
+
+evaluator.imageready$1 = function(args, modifs) {
+    var img = imageFromValue(evaluateAndVal(args[0]));
+    if (!img) {
+        return nada;
+    }
+    return General.bool(img.ready);
 };
 
 function drawImageIndirection(img, x, y) {
     if (img.drawTo) {
         img.drawTo(csctx, x, y);
     } else {
-        csctx.drawImage(img, x, y);
+        csctx.drawImage(img.img, x, y);
     }
 }
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3872,10 +3872,11 @@ evaluator.use$1 = function(args, modifs) {
                     textRenderer = handler;
                 },
                 "getImage": function(name, lazy) {
-                    if (!images.hasOwnProperty(name))
-                        return null;
-                    var img = images[name];
-                    if (!lazy && img.cdyUpdate())
+                    if (typeof name === "string")
+                        name = General.string(name);
+                    var img = imageFromValue(name);
+                    if (!img) return null;
+                    if (!lazy && img.cdyUpdate)
                         img.cdyUpdate();
                     return img;
                 },

--- a/src/js/libcs/RenderBackends.js
+++ b/src/js/libcs/RenderBackends.js
@@ -785,7 +785,7 @@ function parseColor(spec, cb) {
 function cacheImages(cb) {
     var toCache = 1;
     Object.keys(images).forEach(function(name) {
-        var img = images[name];
+        var img = images[name].value.img;
         if (img.cachedDataURL !== undefined) return;
         if (!img.src) return;
         if (img.src.substr(0, 5) === 'data:') {


### PR DESCRIPTION
I recently started working on video support. Videos are mostly like images, since they can be passed as an argument to a `CanvasRenderingContext2D.drawImage` call or a `WebGLRenderingContext.texImage2D` call. But some other things are different. In particular, `width` and `height` represent the attributes of these names, and will therefore be missing if no such attributes were given for the DOM element. The native size of the image is `videoWidth` resp. `videoHeight`.

This change here abstracts away that difference, by introducing an intermediate layer. Now an image object has `ctype:"image"` and `value:{img,width,height,ready,whenReady,…}`. The `value.img` element is the actual HTMLImageElement or HTMLCanvasElement or HTMLVideoElement in question. The width and height are computed in a suitable fashion. An image is considered ready when it's fully loaded, but a video is considered ready as soon as we have sufficient metadata to know its size. We might want to wait for some other state here, I'm not sure. Getting the `ready` flag out of the image element avoids conflict with future or vendor-specific extensions. The `whenReady` function allows registering a callback to be invoked once the image is ready, abtracting away the different underlying events.

The instance-global `images` dictionary now holds complete image objects, i.e. including the outer layer with its `ctype` and `value` properties. This should make some things more consistent.