### PR TITLE
CindyGL: fixed kleinian examples. 

### DIFF
--- a/examples/cindygl/12_kleinian.html
+++ b/examples/cindygl/12_kleinian.html
@@ -79,9 +79,9 @@
         a/(1+a);
       );
 
-      readA(z) := T(imagergb("A", z).r);
+      readInvA(z) := T(imagergb("A", z).r);
       reada(z) := T(imagergb("a", z).r);
-      readB(z) := T(imagergb("B", z).r);
+      readInvB(z) := T(imagergb("B", z).r);
       readb(z) := T(imagergb("b", z).r);
       
       compose(f, a, b, c, x) := (
@@ -92,23 +92,23 @@
       
       colorplot("a",
         r = moebius(a, complex(#));
-        compose(dmoebius(a, complex(#)), reada(r), readb(r), readB(r), #)
+        compose(dmoebius(a, complex(#)), reada(r), readb(r), readInvB(r), #)
       );
       
       colorplot("A",
         r = moebius(A, complex(#));
-        compose(dmoebius(A, complex(#)), readA(r), readb(r), readB(r), #)
+        compose(dmoebius(A, complex(#)), readInvA(r), readb(r), readInvB(r), #)
       );
       
       colorplot("b",
         r = moebius(b, complex(#));
-        compose(dmoebius(b, complex(#)), reada(r), readA(r), readb(r), #)
+        compose(dmoebius(b, complex(#)), reada(r), readInvA(r), readb(r), #)
       );
       
       
       colorplot("B",
         r = moebius(B, complex(#));
-        compose(dmoebius(B, complex(#)), reada(r), readA(r), readB(r), #)
+        compose(dmoebius(B, complex(#)), reada(r), readInvA(r), readInvB(r), #)
       );
       
       

--- a/examples/cindygl/12_kleinian2.html
+++ b/examples/cindygl/12_kleinian2.html
@@ -87,9 +87,9 @@
         a/(1+a);
       );
 
-      readA(z) := imagergb([-2.5, -2.5], [2.5, -2.5], "A", (z)).r;
+      readInvA(z) := imagergb([-2.5, -2.5], [2.5, -2.5], "A", (z)).r;
       reada(z) := imagergb([-2.5, -2.5], [2.5, -2.5], "a", (z)).r;
-      readB(z) := imagergb([-2.5, -2.5], [2.5, -2.5], "B", (z)).r;
+      readInvB(z) := imagergb([-2.5, -2.5], [2.5, -2.5], "B", (z)).r;
       readb(z) := imagergb([-2.5, -2.5], [2.5, -2.5], "b", (z)).r;
       readC(z) := imagergb([-2.5, -2.5], [2.5, -2.5], "C", (z)).r;
       readc(z) := imagergb([-2.5, -2.5], [2.5, -2.5], "c", (z)).r;
@@ -102,41 +102,41 @@
       
       colorplot([-2.5, -2.5], [2.5, -2.5], "a",
         r = moebius(a, (complex(#)));
-        compose(dmoebius(a, (complex(#))), reada(r), readb(r), readB(r), 0, 0)
+        compose(dmoebius(a, (complex(#))), reada(r), readb(r), readInvB(r), 0, 0)
       );
       
       colorplot([-2.5, -2.5], [2.5, -2.5], "A",
         r = moebius(A, (complex(#)));
-        compose(dmoebius(A, (complex(#))), readA(r), 0, readc(r), readC(r), 0)
+        compose(dmoebius(A, (complex(#))), readInvA(r), 0, readc(r), readC(r), 0)
       );
       
       colorplot([-2.5, -2.5], [2.5, -2.5], "b",
         r = moebius(b, (complex(#)));
-        compose(dmoebius(b, (complex(#))), reada(r), readA(r), readb(r), readc(r), readC(r))
+        compose(dmoebius(b, (complex(#))), reada(r), readInvA(r), readb(r), readc(r), readC(r))
       );
       
       colorplot([-2.5, -2.5], [2.5, -2.5], "B",
         r = moebius(B, (complex(#)));
-        compose(dmoebius(B, (complex(#))), reada(r), readA(r), readB(r), readc(r), readC(r))
+        compose(dmoebius(B, (complex(#))), reada(r), readInvA(r), readInvB(r), readc(r), readC(r))
       );
       
       colorplot([-2.5, -2.5], [2.5, -2.5], "c",
         r = moebius(c, (complex(#)));
-        compose(dmoebius(c, (complex(#))), reada(r), readA(r), readB(r), readb(r), readc(r))
+        compose(dmoebius(c, (complex(#))), reada(r), readInvA(r), readInvB(r), readb(r), readc(r))
       );
       
       colorplot([-2.5, -2.5], [2.5, -2.5], "C",
         r = moebius(C, (complex(#)));
-        compose(dmoebius(C, (complex(#))), reada(r), readA(r), readB(r), readb(r), readC(r))
+        compose(dmoebius(C, (complex(#))), reada(r), readInvA(r), readInvB(r), readb(r), readC(r))
       );
       
       
       
       colorplot( //crops internal textures from 1000x1000 to 1000x1000
         z = (complex(#));
-        s0 = readA(z);
+        s0 = readInvA(z);
         s1 = reada(z);
-        s2 = readB(z);
+        s2 = readInvB(z);
         s3 = readb(z);
         s4 = readC(z);
         s5 = readc(z);

--- a/examples/cindygl/12_kleinian_big.html
+++ b/examples/cindygl/12_kleinian_big.html
@@ -88,9 +88,9 @@
         a/(1+a);
       );
 
-      readA(z) := T(imagergb("A", z).r);
+      readInvA(z) := T(imagergb("A", z).r);
       reada(z) := T(imagergb("a", z).r);
-      readB(z) := T(imagergb("B", z).r);
+      readInvB(z) := T(imagergb("B", z).r);
       readb(z) := T(imagergb("b", z).r);
       
       compose(f, a, b, c, x) := (
@@ -101,23 +101,23 @@
       
       colorplot("a",
         r = moebius(a, complex(#));
-        compose(dmoebius(a, complex(#)), reada(r), readb(r), readB(r), #)
+        compose(dmoebius(a, complex(#)), reada(r), readb(r), readInvB(r), #)
       );
       
       colorplot("A",
         r = moebius(A, complex(#));
-        compose(dmoebius(A, complex(#)), readA(r), readb(r), readB(r), #)
+        compose(dmoebius(A, complex(#)), readInvA(r), readb(r), readInvB(r), #)
       );
       
       colorplot("b",
         r = moebius(b, complex(#));
-        compose(dmoebius(b, complex(#)), reada(r), readA(r), readb(r), #)
+        compose(dmoebius(b, complex(#)), reada(r), readInvA(r), readb(r), #)
       );
       
       
       colorplot("B",
         r = moebius(B, complex(#));
-        compose(dmoebius(B, complex(#)), reada(r), readA(r), readB(r), #)
+        compose(dmoebius(B, complex(#)), reada(r), readInvA(r), readInvB(r), #)
       );
       
       
@@ -146,7 +146,7 @@
                     autoplay: true,
                     ports: [{
                       id: "CSCanvas",
-                      width: 1200,
+                      width: 1600,
                       height: 800,
                       transform: [ { visibleRect: [-2, -1.5, 2, 1.5] } ]
                     }]

--- a/examples/cindygl/12_kleinian_conjugated.html
+++ b/examples/cindygl/12_kleinian_conjugated.html
@@ -95,9 +95,9 @@
         a/(1+a);
       );
 
-      readA(z) := imagergb([-pi, -pi], [pi, -pi], "A", z).r;
+      readInvA(z) := imagergb([-pi, -pi], [pi, -pi], "A", z).r;
       reada(z) := imagergb([-pi, -pi], [pi, -pi], "a", z).r;
-      readB(z) := imagergb([-pi, -pi], [pi, -pi], "B", z).r;
+      readInvB(z) := imagergb([-pi, -pi], [pi, -pi], "B", z).r;
       readb(z) := imagergb([-pi, -pi], [pi, -pi], "b", z).r;
       readC(z) := imagergb([-pi, -pi], [pi, -pi], "C", z).r;
       readc(z) := imagergb([-pi, -pi], [pi, -pi], "c", z).r;
@@ -112,51 +112,51 @@
         ze = exp(complex(#));
         r0 = moebius(a, ze);
         r = log(r0);
-        compose(dmoebius(a, ze)/abs(r0)*abs(ze), reada(r), readb(r), readB(r), 0, 0)
+        compose(dmoebius(a, ze)/abs(r0)*abs(ze), reada(r), readb(r), readInvB(r), 0, 0)
       );
       
       colorplot([-pi, -pi], [pi, -pi], "A",
         ze = exp(complex(#));
         r0 = moebius(A, ze);
         r = log(r0);
-        compose(dmoebius(A, ze)/abs(r0)*abs(ze), readA(r), 0, readc(r), readC(r), 0)
+        compose(dmoebius(A, ze)/abs(r0)*abs(ze), readInvA(r), 0, readc(r), readC(r), 0)
       );
       
       colorplot([-pi, -pi], [pi, -pi], "b",
         ze = exp(complex(#));
         r0 = moebius(b, ze);
         r = log(r0);
-        compose(dmoebius(b, ze)/abs(r0)*abs(ze), reada(r), readA(r), readb(r), readc(r), readC(r))
+        compose(dmoebius(b, ze)/abs(r0)*abs(ze), reada(r), readInvA(r), readb(r), readc(r), readC(r))
       );
       
       colorplot([-pi, -pi], [pi, -pi], "B",
         ze = exp(complex(#));
         r0 = moebius(B, ze);
         r = log(r0);
-        compose(dmoebius(B, ze)/abs(r0)*abs(ze), reada(r), readA(r), readB(r), readc(r), readC(r))
+        compose(dmoebius(B, ze)/abs(r0)*abs(ze), reada(r), readInvA(r), readInvB(r), readc(r), readC(r))
       );
       
       colorplot([-pi, -pi], [pi, -pi], "c",
         ze = exp(complex(#));
         r0 = moebius(c, ze);
         r = log(r0);
-        compose(dmoebius(c, ze)/abs(r0)*abs(ze), reada(r), readA(r), readB(r), readb(r), readc(r))
+        compose(dmoebius(c, ze)/abs(r0)*abs(ze), reada(r), readInvA(r), readInvB(r), readb(r), readc(r))
       );
       
       colorplot([-pi, -pi], [pi, -pi], "C",
         ze = exp(complex(#));
         r0 = moebius(C, ze);
         r = log(r0);
-        compose(dmoebius(C, ze)/abs(r0)*abs(ze), reada(r), readA(r), readB(r), readb(r), readC(r))
+        compose(dmoebius(C, ze)/abs(r0)*abs(ze), reada(r), readInvA(r), readInvB(r), readb(r), readC(r))
       );
       
       
       
       colorplot([-pi, -pi], [pi, -pi], "conjugatedoutput",
         z = (complex(#));
-        s0 = readA(z);
+        s0 = readInvA(z);
         s1 = reada(z);
-        s2 = readB(z);
+        s2 = readInvB(z);
         s3 = readb(z);
         s4 = readC(z);
         s5 = readc(z);


### PR DESCRIPTION
They did not work because the new parser does not treat function names case-sensitive anymore.