### PR TITLE
Minor simplification

### DIFF
--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -569,7 +569,7 @@ Render2D.clipLineCore = function(a, b, c) {
 
 Render2D.clipLine = function(homog) {
     // transformation to canvas coordinates
-    var n = List.normalizeMax(List.productMV(List.transpose(csport.toMat()), homog));
+    var n = List.normalizeMax(List.productVM(homog, csport.toMat()));
     var a = n.value[0].value.real;
     var b = n.value[1].value.real;
     var c = n.value[2].value.real;


### PR DESCRIPTION
Follow up of #343.

> Minor simplification: one could use productVM in order to avoid the transpose step.

@gagern Thanks for the suggestion.