### PR TITLE
Consistent text sizes using defaultAppearance

### DIFF
--- a/examples/textsize.html
+++ b/examples/textsize.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Text sizes</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+
+  drawtext((0, 0), "drawtext default");
+  drawtext((0, -1), "drawtext small", size->12);
+  drawtext((0, 1), "drawtext large", size->20);
+  textsize(12);
+  drawtext((0, -0.5), "textsize small");
+  textsize(20);
+  drawtext((0, 0.5), "textsize large");
+
+</script>
+<script type="text/javascript">
+
+function doCreate(id, defaultAppearance) {
+  return createCindy({
+    ports: [{id: id, transform:[{visibleRect:[-1,0,7,0]}]}],
+    scripts: "cs*",
+    language: "en",
+    defaultAppearance: defaultAppearance,
+    geometry: [
+      {name:"A", type:"Free", pos:[3,0], labeled:true},
+      {name:"B", type:"Free", pos:[3,-1], labeled:true, textsize:12},
+      {name:"C", type:"Free", pos:[3,1], labeled:true, textsize:20},
+      {name:"T1", type:"Text", text:"Text default", pos:[5,0]},
+      {name:"T2", type:"Text", text:"Text small", pos:[5,-1], size:12},
+      {name:"T3", type:"Text", text:"Text large", pos:[5,1], size:20},
+    ]
+  });
+}
+var cdy1 = doCreate("CSCanvas1", {});
+var cdy2 = doCreate("CSCanvas2", {textsize: 12});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas1" width="500" height="200"
+          style="border:2px solid black"></canvas>
+  <canvas id="CSCanvas2" width="500" height="200"
+          style="border:2px solid black"></canvas>
+</body>
+
+</html>

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -899,6 +899,7 @@ evaluator.drawtext$2 = function(args, modifs) {
     var col = csport.drawingstate.textcolor;
     Render2D.handleModifs(modifs, Render2D.textModifs);
     var size = csport.drawingstate.textsize;
+    if (size === null) size = defaultAppearance.textsize;
     if (Render2D.size !== null) size = Render2D.size;
     csctx.fillStyle = Render2D.textColor;
 

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -9,6 +9,7 @@ defaultAppearance.overhangLine = 1.1;
 defaultAppearance.overhangSeg = 1;
 defaultAppearance.dimDependent = 0.7;
 defaultAppearance.fontFamily = "sans-serif";
+defaultAppearance.textsize = 20; // Cinderella uses 12 by default
 
 function setDefaultAppearance(obj) {
     var key;

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -17,7 +17,7 @@ function drawgeopoint(el) {
             'x': 3,
             'y': 3
         };
-        var textsize = el.textsize || 12;
+        var textsize = el.textsize || defaultAppearance.textsize;
         var bold = (el.textbold === true);
         var italics = (el.textitalics === true);
         var family = el.text_fontfamily || defaultAppearance.fontFamily;

--- a/src/js/libgeo/GeoState.js
+++ b/src/js/libgeo/GeoState.js
@@ -11,7 +11,7 @@ csport.drawingstate.textcolorraw = [0, 0, 0];
 csport.drawingstate.alpha = 1.0;
 csport.drawingstate.pointsize = 4.0;
 csport.drawingstate.linesize = 1.0;
-csport.drawingstate.textsize = 20;
+csport.drawingstate.textsize = null; // use defaultAppearance.textsize
 
 csport.drawingstate.matrix = {};
 csport.drawingstate.matrix.a = 25;


### PR DESCRIPTION
This is yet another attempt to address #49, taking the direction discussed by the dev team some time ago:

* The CindyJS default remains at 20
* Cinderella exports `defaultAppearance: { textsize: 12, … }` (already does so for some time now)
* This defaultAppearance affects both `drawtext` and geometric elements, so that the default exported by Cinderella is enough to provide full Cinderella compatibility

This is a breaking change, for two reasons:

1. The default size of point labels is now 20, as opposed to the hard-wired default of 12 we had before.
2. The setting exported from Cinderella is now honored for the first time, causing widgets created using Cinderella but edited subsequently to look different than before.

I had a look at all the examples which either use `drawtext` or labels. As far as I can tell, many are affected by the increased point labels, but none look considerably worse due to this change. So I modified none of the examples contained in the repository.