### PR TITLE
Fix date function

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3985,7 +3985,7 @@ evaluator.time$0 = function(args, modifs) {
 evaluator.date$0 = function(args, modifs) {
     var now = new Date();
     return List.realVector([
-        now.getFullYear(), now.getMonth(), now.getDay()
+        now.getFullYear(), now.getMonth() + 1, now.getDate()
     ]);
 };
 


### PR DESCRIPTION
[Day is day of week](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay), not [of month](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate).  [Month is zero-based](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth).

Shame on me for not properly testing this back in adbc9ae5396876c79f7829bc7f0d19b2194e00fb. Luckily I at least did add a test case, which was what allowed me to notice this today.

The `date()` function in Cinderella is broken as well, in a different way. Will file a bug report there, too.