### PR TITLE
Document version() function

### DIFF
--- a/ref/Special_Operators.md
+++ b/ref/Special_Operators.md
@@ -14,4 +14,6 @@ Some of them are even necessary for the interaction of Cinderella and CindyScrip
 
 *  [User Input](User_Input.md): Keyboard and mouse handling
 
+*  [System Information](System_Information.md): Obtaining information about the runtime system
+
 *  [Interaction with CindyLab](Interaction_with_CindyLab.md): How [CindyLab](CindyLab.md) and CindyScript can influence each other

--- a/ref/System_Information.md
+++ b/ref/System_Information.md
@@ -6,8 +6,20 @@ These functions provide access to the environment in which the script is being e
 
 **Description:**
 This operator returns a list.
-The first element of that list is the string `Cinderella` when run inside Cinderella.
-Other [CindyScript](CindyScript.md) implementations will return other values, e.g.
-`CindyJS` for the CindyJS project.
+The first element of that list is the string `CindyJS` when run inside CindyJS.
+Other CindyScript implementations will return other values,
+e.g. `Cinderella` for the Java version of Cinderella.
 The remaining components describe the actual version of the engine in question.
-For Cinderella there are three version components, namely major, minor and build number.
+
+For CindyJS, there are five version components after the engine name.
+The first three are the major, minor and patch version components
+of [semantic versioning](http://semver.org/).
+Next comes the number of commits since the release, so this will always be zero
+for an official release, but may be non-zero for development snapshots.
+The last component is a string, indicating the git commit id
+of the working tree in question.
+This can be used to distinguish parallel development branches.
+An exclamation mark will be appended to this string if the code
+contains additional uncommited changes.
+For snapshots taken before the first official release,
+The version will be `0.0.0` and the number of commits will be `-1`.

--- a/ref/System_Information.md
+++ b/ref/System_Information.md
@@ -1,0 +1,13 @@
+## System Information
+
+These functions provide access to the environment in which the script is being executed.
+
+#### Version information: `version()`
+
+**Description:**
+This operator returns a list.
+The first element of that list is the string `Cinderella` when run inside Cinderella.
+Other [CindyScript](CindyScript.md) implementations will return other values, e.g.
+`CindyJS` for the CindyJS project.
+The remaining components describe the actual version of the engine in question.
+For Cinderella there are three version components, namely major, minor and build number.

--- a/ref/docscrub.py
+++ b/ref/docscrub.py
@@ -248,6 +248,7 @@ names = [
     "MIDI+Functions",
     "Sampled-Audio+Functions",
     "Special+Operators",
+    "System+Information",
     "Interaction+with+Geometry",
     "File+Management",
     "Console+Output",


### PR DESCRIPTION
I've finally managed to [document](http://doc.cinderella.de/tiki-index.php?page=System+Information#version) the `version()` function for Cinderella, and to scrub said documentation before adapting it for CindyJS. Is this documentation too verbose?