### PR TITLE
Rename createCindy to CindyJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ and are accompanied by a suitable test case or demonstrating example
 
 ## Documentation
 
-[The `CindyJS` documentation]
+[The CindyJS API documentation]
 (https://github.com/CindyJS/CindyJS/blob/master/ref/createCindy.md)
 describes how to create a widget on an HTML page using this framework.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ and are accompanied by a suitable test case or demonstrating example
 
 ## Documentation
 
-[The `createCindy` documentation]
+[The `CindyJS` documentation]
 (https://github.com/CindyJS/CindyJS/blob/master/ref/createCindy.md)
 describes how to create a widget on an HTML page using this framework.
 

--- a/examples/00_Playground.html
+++ b/examples/00_Playground.html
@@ -29,7 +29,7 @@
                       {name:"B", kind:"P", type:"Free", pos:[0,9,1]},
                       ];
 
-            cdy=createCindy({canvasname:"CSCanvas",
+            cdy=CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {pointColor: [1,0.7,0]},
                         scripts: "cs*",
                         use: ["katex"],

--- a/examples/01_sunflower.html
+++ b/examples/01_sunflower.html
@@ -34,7 +34,7 @@
                       {name:"B", kind:"P", type:"Free", pos:[0,9]},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {pointColor: [1,0.7,0]},
                         movescript:"csmove",
                         geometry:gslp});

--- a/examples/02_ComplexSpiral.html
+++ b/examples/02_ComplexSpiral.html
@@ -40,7 +40,7 @@
                       {name:"A", kind:"P", type:"Free", pos:[7,1,1]},
                       {name:"C", kind:"P", type:"Free", pos:[0,9,1]},
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/03_ParabolaEnvelope.html
+++ b/examples/03_ParabolaEnvelope.html
@@ -49,7 +49,7 @@
                       {name:"D", kind:"P", type:"Free", pos:[-2,7,1]},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {pointColor: [1,1,1]},
                         movescript:"csmove",
                         geometry:gslp});

--- a/examples/04_SimpleGeo.html
+++ b/examples/04_SimpleGeo.html
@@ -44,7 +44,7 @@
                       {name:"D", kind:"P", type:"Free", pos:[-2,7,1]},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/05_SinCaustic.html
+++ b/examples/05_SinCaustic.html
@@ -60,7 +60,7 @@
 
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/06_ConvexHull.html
+++ b/examples/06_ConvexHull.html
@@ -46,7 +46,7 @@
                       {name:"N", kind:"P", type:"Free", pos:[Math.random()*8-4,Math.random()*8-4,1]},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/07_Feldlinien.html
+++ b/examples/07_Feldlinien.html
@@ -51,7 +51,7 @@
                       {name:"A",  type:"Free", pos:[-4,-2],color:[1,0,0],size:7},
                       {name:"B", type:"Free", pos:[6,4],color:[0,1,0],size:7}
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         transform:[{scale:.5},{translate:[0,0]}],
 

--- a/examples/07_Feldlinien_newarrows.html
+++ b/examples/07_Feldlinien_newarrows.html
@@ -52,7 +52,7 @@
                       {name:"A",  type:"Free", pos:[-4,-2],color:[1,0,0],size:7},
                       {name:"B", type:"Free", pos:[6,4],color:[0,1,0],size:7}
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/08_zHochAlpha.html
+++ b/examples/08_zHochAlpha.html
@@ -113,7 +113,7 @@ javascript("document.onkeydown={}");
                       {name:"C",  type:"Free", pos:[-5,-5+1],size:4 }
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/08a_zHochAlpha.html
+++ b/examples/08a_zHochAlpha.html
@@ -166,7 +166,7 @@ var gslp=[
 //    {name:"bb", type:"Through", args:["A"],dir:[0,1,0],color:[0,0,0],size:2},
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 mousedownscript:"down",
 initscript:"init",

--- a/examples/08cont_zHochAlpha.html
+++ b/examples/08cont_zHochAlpha.html
@@ -197,7 +197,7 @@ var gslp=[
     //    {name:"bb", type:"Through", args:["A"],dir:[0,1,0],color:[0,0,0],size:2},
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 mousedownscript:"down",
 initscript:"init",

--- a/examples/08contb_zHochAlpha.html
+++ b/examples/08contb_zHochAlpha.html
@@ -225,7 +225,7 @@ var gslp=[
     //    {name:"bb", type:"Through", args:["A"],dir:[0,1,0],color:[0,0,0],size:2},
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 mousedownscript:"down",
 initscript:"init",

--- a/examples/08d_zHochAlpha.html
+++ b/examples/08d_zHochAlpha.html
@@ -305,7 +305,7 @@ var gslp=[
     //    {name:"bb", type:"Through", args:["A"],dir:[0,1,0],color:[0,0,0],size:2},
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 mousedownscript:"down",
 initscript:"init",

--- a/examples/09_Regression.html
+++ b/examples/09_Regression.html
@@ -61,7 +61,7 @@
                       {name:"N", kind:"P", type:"Free", pos:[Math.random()*12-6,Math.random()*12-6,1]},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {pointSize: 4, pointColor: [1,0.7,0]},
                         movescript:"csmove",
                         geometry:gslp});

--- a/examples/100_PointMirror.html
+++ b/examples/100_PointMirror.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   "scripts": "cs*",
   "defaultAppearance": {},
   "geometry": [

--- a/examples/100_ScreenResolution.html
+++ b/examples/100_ScreenResolution.html
@@ -47,7 +47,7 @@ timosWinkel(A,C,B,1,(.5,.5,0));
 </script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   "scripts": "cs*",
   "defaultAppearance": {},
   "geometry": [

--- a/examples/101_PolarOperations.html
+++ b/examples/101_PolarOperations.html
@@ -25,7 +25,7 @@
 </script>
 
     <script type="text/javascript">
-var cdy = createCindy({
+var cdy = CindyJS({
   scripts: "cs*",
   defaultAppearance: {},
   ports: [{

--- a/examples/102_Slider.html
+++ b/examples/102_Slider.html
@@ -12,7 +12,7 @@ C.printlabel = round(C.x);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/103_BadElements.html
+++ b/examples/103_BadElements.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/104_arcppp.html
+++ b/examples/104_arcppp.html
@@ -18,7 +18,7 @@ drawarc(A,B.homog,C.xy);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas", snap: true, grid: 1}],
   scripts: "cs*",
   language: "en",

--- a/examples/104_isOperations.html
+++ b/examples/104_isOperations.html
@@ -79,7 +79,7 @@ println(isundefined(aaa));
 </script>
 
     <script type="text/javascript">
-var cdy = createCindy({
+var cdy = CindyJS({
   scripts: "cs*",
   defaultAppearance: {},
   ports: [{

--- a/examples/104b_arcfill.html
+++ b/examples/104b_arcfill.html
@@ -18,7 +18,7 @@ fillarc(A,B,C, color-> [142/255, 214/255, 1], alpha->0.5);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas", snap: true, grid: 1}],
   scripts: "cs*",
   language: "en",

--- a/examples/104c_arc_gslp.html
+++ b/examples/104c_arc_gslp.html
@@ -17,7 +17,7 @@
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/105_LineWidth.html
+++ b/examples/105_LineWidth.html
@@ -30,7 +30,7 @@ linecolor([1,0,0]);
 testcase(8,5);
     </script>
     <script type="text/javascript">
-createCindy({csconsole:true,
+CindyJS({csconsole:true,
   scripts: "cs*",
   defaultAppearance: { alpha: 0.5, lineColor: [0.25, 0, 0.5] },
   angleUnit: "°",

--- a/examples/106_DrawTrace1.html
+++ b/examples/106_DrawTrace1.html
@@ -11,7 +11,7 @@
         </style>
         <script type="text/javascript" src="../build/js/Cindy.plain.js"></script>
         <script type="text/javascript">
-var cdy = createCindy({
+var cdy = CindyJS({
   scripts: "cs*",
   defaultAppearance: {},
   ports: [{

--- a/examples/106_DrawTrace2.html
+++ b/examples/106_DrawTrace2.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { pointSize: 5.0, fontFamily: "sans-serif", lineSize: 1.0 }, 
 	angleUnit: "°", 

--- a/examples/107_Overhang.html
+++ b/examples/107_Overhang.html
@@ -21,7 +21,7 @@
     </style>
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { pointSize: 5.0, fontFamily: "sans-serif", lineSize: 1 }, 
 	angleUnit: "°", 

--- a/examples/108_DashType.html
+++ b/examples/108_DashType.html
@@ -21,7 +21,7 @@
     </style>
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { pointSize: 5.0, fontFamily: "sans-serif", lineSize: 3 }, 
 	angleUnit: "°", 

--- a/examples/109_CenterOfConic.html
+++ b/examples/109_CenterOfConic.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas", snap: true, grid: 5}],
   scripts: "cs*",
   language: "en",

--- a/examples/109_xyAccessors.html
+++ b/examples/109_xyAccessors.html
@@ -41,7 +41,7 @@ println(B.y == By);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/110_ConicInSquare.html
+++ b/examples/110_ConicInSquare.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
 	angleUnit: "°", 

--- a/examples/111_Moebius.html
+++ b/examples/111_Moebius.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", snap: true, grid: 1}],
   scripts: "cs*",
   language: "en",

--- a/examples/111_Moebius_Arc.html
+++ b/examples/111_Moebius_Arc.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", snap: true, grid: 1}],
   scripts: "cs*",
   language: "en",

--- a/examples/111_Moebius_CinderellaExportTest.html
+++ b/examples/111_Moebius_CinderellaExportTest.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: {}, 
 	geometry: [ 

--- a/examples/111_Moebius_It.html
+++ b/examples/111_Moebius_It.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: {}, 
 	geometry: [ 

--- a/examples/111_Moebius_Line.html
+++ b/examples/111_Moebius_Line.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", snap: true, grid: 1}],
   scripts: "cs*",
   language: "en",

--- a/examples/111_VeryDegenerateICC.html
+++ b/examples/111_VeryDegenerateICC.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas"}],
   language: "en",
   geometry: [ 

--- a/examples/112_TrAffine.html
+++ b/examples/112_TrAffine.html
@@ -33,7 +33,7 @@ draw(Oi,Zi,arrow->true,color->(0,1,0));
 </script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
 	angleUnit: "°", 

--- a/examples/112_TrSimilarity.html
+++ b/examples/112_TrSimilarity.html
@@ -30,7 +30,7 @@ draw(Oi,Yi,arrow->true,color->(1,0,0));
 </script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
 	angleUnit: "°", 

--- a/examples/112_TrTranslation.html
+++ b/examples/112_TrTranslation.html
@@ -27,7 +27,7 @@ draw(Oi,Xi,arrow->true,color->(0,0,1));
 </script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
 	angleUnit: "°", 

--- a/examples/113_ReflectionInCircle.html
+++ b/examples/113_ReflectionInCircle.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 },
 	angleUnit: "°",

--- a/examples/113_ReflectionInLine.html
+++ b/examples/113_ReflectionInLine.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 },
 	angleUnit: "°", 

--- a/examples/113_ReflectionInPoint.html
+++ b/examples/113_ReflectionInPoint.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 },
 	angleUnit: "°", 

--- a/examples/113_ReflectionInSegment.html
+++ b/examples/113_ReflectionInSegment.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 },
 	angleUnit: "°", 

--- a/examples/113_ReflectionInThreePointCircle.html
+++ b/examples/113_ReflectionInThreePointCircle.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 },
 	angleUnit: "°", 

--- a/examples/114_ParallelSegments.html
+++ b/examples/114_ParallelSegments.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-var g,cdy=createCindy({ csconsole:true,
+var g,cdy=CindyJS({ csconsole:true,
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
 	angleUnit: "°", 

--- a/examples/114_allops.html
+++ b/examples/114_allops.html
@@ -82,7 +82,7 @@ println(alllines(A));
                        {name:"c", behavior:{type:"Spring"}}
                        ];
 
-var cdy = createCindy({ 
+var cdy = CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: {}, 
 	behavior:physics,

--- a/examples/12_L-System.html
+++ b/examples/12_L-System.html
@@ -72,7 +72,7 @@
                                             ];
 
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/133_TransformC.html
+++ b/examples/133_TransformC.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 }, 
 	angleUnit: "°", 

--- a/examples/134_LineCap.html
+++ b/examples/134_LineCap.html
@@ -16,7 +16,7 @@ draw([[-1, -1], [1, -1]], lineCap -> "square", size->10);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", visibleRect: [-2, 2, 2, -2], width: 500, height: 500 }],
   scripts: "cs*"
 });

--- a/examples/135_LineJoin.html
+++ b/examples/135_LineJoin.html
@@ -16,7 +16,7 @@ drawpoly(apply(pts, # + [3, 0]), lineJoin -> "miter", size->7);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", visibleRect: [-5, 5, 5, -5], width: 500, height: 500 }],
   scripts: "cs*"
 });

--- a/examples/136_MiterLimit.html
+++ b/examples/136_MiterLimit.html
@@ -14,7 +14,7 @@ connect(apply(pts, # + [3, 0]), lineJoin -> "miter", miterLimit->20, size->7);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", visibleRect: [-5, 5, 5, -5], width: 500, height: 500 }],
   scripts: "cs*"
 });

--- a/examples/137_FreeLine.html
+++ b/examples/137_FreeLine.html
@@ -12,7 +12,7 @@ err(a.homog);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas", width: 500, height: 500, transform: [ { visibleRect: [ -5, 5, 5, -5 ] } ], background: "rgb(168,176,192)" } ],
   scripts: "cs*",
   geometry: [

--- a/examples/138_Through.html
+++ b/examples/138_Through.html
@@ -14,7 +14,7 @@ err(a.homog);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas", width: 500, height: 500, transform: [ { visibleRect: [ -5, 5, 5, -5 ] } ], background: "rgb(168,176,192)" } ],
   scripts: "cs*",
   geometry: [

--- a/examples/139_LineHomogSetter.html
+++ b/examples/139_LineHomogSetter.html
@@ -15,7 +15,7 @@
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   scripts: "cs*",
   ports: [{id: "CSCanvas"}],
   defaultAppearance: {},

--- a/examples/13_PlotSingularity.html
+++ b/examples/13_PlotSingularity.html
@@ -35,7 +35,7 @@
                       {name:"A", kind:"P", type:"Free", pos:[2,2,1]}
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/140_radius.html
+++ b/examples/140_radius.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/141_fileDrop.html
+++ b/examples/141_fileDrop.html
@@ -36,7 +36,7 @@ draw(point(dropPoint), color->[0,1,0], alpha->0.5);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-1, -25, 25, 1]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/142_kaleido.html
+++ b/examples/142_kaleido.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   scripts: "cs*",
   use: ["katex"],
   defaultAppearance: {

--- a/examples/143_assoc_mult_compare_geoops.html
+++ b/examples/143_assoc_mult_compare_geoops.html
@@ -36,7 +36,7 @@ repeat(n,j,
 </script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   scripts: "cs*",
   defaultAppearance: {
     dimDependent: 0.7,

--- a/examples/144_randomtree.html
+++ b/examples/144_randomtree.html
@@ -69,7 +69,7 @@
     <script type="text/javascript">
         
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[
                       {name:"A", type:"Free", pos:[0, -1.75], color:[1,0,0], pinned:false, size:6, alpha: .3},

--- a/examples/14_ImageSpiral.html
+++ b/examples/14_ImageSpiral.html
@@ -55,7 +55,7 @@
 
 
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp,
                         images:{rost:"rost.png",boe:"boe.png"}

--- a/examples/15_ProjectiveGrid.html
+++ b/examples/15_ProjectiveGrid.html
@@ -49,7 +49,7 @@
                     //  {name:"X", kind:"P", type:"Free", pos:[0,0,1]}
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/16_DMSpiral.html
+++ b/examples/16_DMSpiral.html
@@ -46,7 +46,7 @@
 
 
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/17_ShapeOperations.html
+++ b/examples/17_ShapeOperations.html
@@ -53,7 +53,7 @@
 
 
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/18_CompleteGraph.html
+++ b/examples/18_CompleteGraph.html
@@ -40,7 +40,7 @@ n=round(|(B.x+10)*5|);
 
 
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/19_EuclidsAlg.html
+++ b/examples/19_EuclidsAlg.html
@@ -115,7 +115,7 @@ A.xy=(a/nn-10,b/nn-10);
                       {name:"A", kind:"P", type:"Free", pos:[4,8,1],size:4,color:[0,0,0]}
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/19_EuclidsAlgX.html
+++ b/examples/19_EuclidsAlgX.html
@@ -146,7 +146,7 @@
                       {name:"C", kind:"P", type:"Free", pos:[4,-10,1],size:4,color:[0,0,0]}
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/19_EuclidsAlgX2.html
+++ b/examples/19_EuclidsAlgX2.html
@@ -213,7 +213,7 @@ t=t+"$";
                       {name:"C", kind:"P", type:"Free", pos:[4,-10,1],size:4,color:[0,0,0]}
                       ];
 
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         initscript:"init",
 

--- a/examples/20_Pappos.html
+++ b/examples/20_Pappos.html
@@ -45,7 +45,7 @@
                       {name:"I", type:"Meet", args:["i", "h"]}
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         geometry:gslp});

--- a/examples/21_EulerLine.html
+++ b/examples/21_EulerLine.html
@@ -66,7 +66,7 @@
                        {name:"Y", kind:"P", type:"Free", pos:[-8,.8,1]},
                        {name:"Z", kind:"P", type:"Free", pos:[-6,0,1]}*/
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {clip: "inci", overhangLine: 1.2},
                         movescript:"csmove",
                         geometry:gslp});

--- a/examples/22_AngleBisector.html
+++ b/examples/22_AngleBisector.html
@@ -57,7 +57,7 @@
                       {name:"Y", type:"SelectP", args:["S"],index:1,color:[1,0,0],size:6},
                       {name:"Z", type:"SelectP", args:["S"],index:2,color:[0,1,0],size:6}*/
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/23_Mirrors.html
+++ b/examples/23_Mirrors.html
@@ -118,7 +118,7 @@
 
 
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp,
                         images:{rost:"rost.png",boe:"boe.png"}

--- a/examples/24_SimpleTree.html
+++ b/examples/24_SimpleTree.html
@@ -46,7 +46,7 @@
                       {name:"C", type:"Free", pos:[2,2],color:[1,1,1]},
                       {name:"D", type:"Free", pos:[-2,2.5],color:[1,1,1]},
                                            ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/25_Lagrange.html
+++ b/examples/25_Lagrange.html
@@ -49,7 +49,7 @@
                       {name:"E", type:"Free", pos:[-5,0.5],color:[1,1,1]},
                       {name:"F", type:"Free", pos:[-2,1.5],color:[1,1,1]},
                                            ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/26_Kaleido.html
+++ b/examples/26_Kaleido.html
@@ -100,7 +100,7 @@
                       {name:"E", type:"Free", pos:[-5,7.5],color:[1,1,1],color:[1,.7,0],size:3},
                       {name:"G", type:"Free", pos:[7.5,-7.5],color:[1,1,1],color:[1,.7,0],size:3},
                                            ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp,
                         images:{bild:"bild.png"}}

--- a/examples/27_AllpointsAllLines.html
+++ b/examples/27_AllpointsAllLines.html
@@ -67,7 +67,7 @@
                        {name:"Y", kind:"P", type:"Free", pos:[-8,.8,1]},
                        {name:"Z", kind:"P", type:"Free", pos:[-6,0,1]}*/
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {clip: "inci", overhangLine: 1.2},
                         movescript:"csmove",
                         geometry:gslp});

--- a/examples/28_Schleppkurve.html
+++ b/examples/28_Schleppkurve.html
@@ -144,7 +144,7 @@ for(var i=0;i<30;i++){
 }
    // gslp.push({name:"B", type:"Free", pos:[-7,1],color:[1,.9,0]});
 
-var cdy = createCindy({canvasname:"CSCanvas",
+var cdy = CindyJS({canvasname:"CSCanvas",
 defaultAppearance: {clip: "inci", overhangLine: 1.2},
 movescript:"csmove",
 initscript:"init",

--- a/examples/28b_SchleppkurveTrans.html
+++ b/examples/28b_SchleppkurveTrans.html
@@ -167,7 +167,7 @@ for(var i=0;i<30;i++){
 
     gslp.push({name:"A"+i, type:"Free", pos:[-7+i*0.5,0],color:[1,1,1]});
 }
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 defaultAppearance: {clip: "inci", overhangLine: 1.2},
 movescript:"csmove",
 initscript:"init",

--- a/examples/28c_Antiprism.html
+++ b/examples/28c_Antiprism.html
@@ -129,7 +129,7 @@ var gslp=[];
     gslp.push({name:"G", type:"Free", pos:[0,0],color:[.7,0,0]});
     gslp.push({name:"H", type:"Free", pos:[0,0],color:[0,0,0]});
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 defaultAppearance: {clip: "inci", overhangLine: 1.2},
 movescript:"csmove",
 mousedownscript:"down",

--- a/examples/29_fact.html
+++ b/examples/29_fact.html
@@ -98,7 +98,7 @@
                       {name:"C", type:"Free", pos:[1,-9],color:[1,1,1]},
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/30_C-Test.html
+++ b/examples/30_C-Test.html
@@ -338,7 +338,7 @@ drawing();
             var gslp=[
 
                                            ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         keydownscript:"keyDown",
                         mousedownscript:"mouseDown",

--- a/examples/31_EventTest.html
+++ b/examples/31_EventTest.html
@@ -72,7 +72,7 @@
 
             var gslp=[ ];
 
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         keydownscript:"keyDown",
                         mousedownscript:"mouseDown",

--- a/examples/34_Suns.html
+++ b/examples/34_Suns.html
@@ -51,7 +51,7 @@
                        {name:"A", behavior:{type:"Mass", vy:.7}},
                        {name:"B", behavior:{type:"Sun"}}
                        ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/34_SunsT.html
+++ b/examples/34_SunsT.html
@@ -52,7 +52,7 @@
                        {name:"A", behavior:{type:"Mass", vy:.7}},
                        {name:"B", behavior:{type:"Sun"}}
                        ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/35_Springs.html
+++ b/examples/35_Springs.html
@@ -80,7 +80,7 @@
 
 
                        ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/36_Springs2.html
+++ b/examples/36_Springs2.html
@@ -75,7 +75,7 @@
 
 
                        ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/37_Bouncer.html
+++ b/examples/37_Bouncer.html
@@ -68,7 +68,7 @@
 
 
                        ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/38_ManyParticles.html
+++ b/examples/38_ManyParticles.html
@@ -75,7 +75,7 @@
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/39_ManyBalls.html
+++ b/examples/39_ManyBalls.html
@@ -125,7 +125,7 @@ mat=mmmx*mmmy*mat;
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/39_ManyBallsExplorer.html
+++ b/examples/39_ManyBallsExplorer.html
@@ -263,7 +263,7 @@ forall(pairs,s,
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/39_ManyBallsX.html
+++ b/examples/39_ManyBallsX.html
@@ -84,7 +84,7 @@ masses=allmasses();
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/39_ManyBallsY.html
+++ b/examples/39_ManyBallsY.html
@@ -97,7 +97,7 @@ forall(pairs,s,
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/39_ManyBalls_1_1.html
+++ b/examples/39_ManyBalls_1_1.html
@@ -100,7 +100,7 @@ forall(pairs,s,
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/39_ManyBalls_1_2.html
+++ b/examples/39_ManyBalls_1_2.html
@@ -98,7 +98,7 @@ forall(pairs,s,
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/39_ManyBalls_1_3_a.html
+++ b/examples/39_ManyBalls_1_3_a.html
@@ -100,7 +100,7 @@ forall(pairs,s,
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/40_Swarm.html
+++ b/examples/40_Swarm.html
@@ -108,7 +108,7 @@ for(var i=0;i<nn;i++){
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/40_SwarmExplorer.html
+++ b/examples/40_SwarmExplorer.html
@@ -196,7 +196,7 @@ for(var i=0;i<nn;i++){
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/40_SwarmExplorerX.html
+++ b/examples/40_SwarmExplorerX.html
@@ -160,7 +160,7 @@ for(var i=0;i<nn;i++){
               )
 
 };
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/50_ConvexHull3D.html
+++ b/examples/50_ConvexHull3D.html
@@ -186,7 +186,7 @@ nn=nn/|nn|;
             var gslp=[
                       {name:"A", kind:"P", type:"Free",alpha:0, pos:[-1000,-1000,1]}                      ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         initscript:"init",
                         mousedownscript:"mouseDown",

--- a/examples/51_Archimedean.html
+++ b/examples/51_Archimedean.html
@@ -427,7 +427,7 @@ mat=mmmx*mmmy*mat;
 
                                            ];
 
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         initscript:"init",
                         mousedownscript:"mouseDown",

--- a/examples/51_ArchimedeanX.html
+++ b/examples/51_ArchimedeanX.html
@@ -382,7 +382,7 @@ drawtext(spos2-(.5,.7),5,size->45);
 
                                            ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         initscript:"init",
                         mousedownscript:"mouseDown",

--- a/examples/52_Rays.html
+++ b/examples/52_Rays.html
@@ -145,7 +145,7 @@ while(count<n & !stop,
 
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         initscript:"init",
                         geometry:gslp});

--- a/examples/54_Soddy1.html
+++ b/examples/54_Soddy1.html
@@ -144,7 +144,7 @@ drawlie(ce,(0,0,0),3);
                       {name:"C", type:"Free", pos:[-5,-5],color:[1,1,1]}
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {clip: "inci", overhangLine: 1.2},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/55_Soddy2.html
+++ b/examples/55_Soddy2.html
@@ -376,7 +376,7 @@ translate(-(off+Pos.xy-loc));
 
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {clip: "inci", overhangLine: 1.2},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/56_Ford.html
+++ b/examples/56_Ford.html
@@ -383,7 +383,7 @@ apply(seq,f,ff=f*zoom*2;
 
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {clip: "inci", overhangLine: 1.2},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/57_SnapAndGrid.html
+++ b/examples/57_SnapAndGrid.html
@@ -66,7 +66,7 @@
                        {name:"Y", kind:"P", type:"Free", pos:[-8,.8,1]},
                        {name:"Z", kind:"P", type:"Free", pos:[-6,0,1]}*/
                       ];
-            createCindy({
+            CindyJS({
                 defaultAppearance: {clip: "inci", overhangLine: 1.2},
                 movescript:"csmove",
                 geometry:gslp,

--- a/examples/58_Interpolation.html
+++ b/examples/58_Interpolation.html
@@ -91,7 +91,7 @@ plot[x^3*a_9+x^2*a_10+x*a_11+a_12,start->3,stop->4,size->3];
 
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {clip: "inci", overhangLine: 1.2},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/59_Equilibrium.html
+++ b/examples/59_Equilibrium.html
@@ -136,7 +136,7 @@ renderEq(inpa, inpb, inpc);
 
 
                        ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/60_Rotation.html
+++ b/examples/60_Rotation.html
@@ -172,7 +172,7 @@ if (b==0,pb="+0";mb="+0");
 
 
                     ];
-                     createCindy({canvasname:"CSCanvas",
+                     CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/62_ProjTransform.html
+++ b/examples/62_ProjTransform.html
@@ -46,7 +46,7 @@ var gslp = [
   {name:"P", type:"Free", pos:[0.5,0.5], color:[255, 0, 255]},
   {name:"Q", type:"TransformP", args:["Tr0","P"], color:[0, 255, 255]},
 ];
-createCindy({
+CindyJS({
   canvasname:"CSCanvas",
   scripts:"cs*",
   geometry:gslp,

--- a/examples/63_Conic.html
+++ b/examples/63_Conic.html
@@ -36,7 +36,7 @@
 		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,size:1},
 //		     {name:"l", type:"Join", args:["A", "D"]}
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/63_Conic_from_Script.html
+++ b/examples/63_Conic_from_Script.html
@@ -38,7 +38,7 @@ drawconic(C2,alpha->0.3, color->[0,0,1]);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/63_PizzaTeilen.html
+++ b/examples/63_PizzaTeilen.html
@@ -91,7 +91,7 @@
 
 
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {pointColor: [1,0.7,0]},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/63_PointLabels.html
+++ b/examples/63_PointLabels.html
@@ -15,7 +15,7 @@ var gslp = [
   {"name": "E", "type": "Free", "pos": [-2.4, -4.0, -0.8], "color": [255, 0, 0], "size": 5.0, "labeled": true, "labelpos": {"x": 3, "y": 3}, "textsize": 24.0},
   {"name": "F", "type": "Free", "pos": [4.0, 4.0, 0.8], "color": [255, 0, 0], "size": 5.0, "labeled": true, "labelpos": {"x": 3, "y": 3}, "text_fontfamily": "Serif", "textsize": 24.0}
 ];
-createCindy({
+CindyJS({
   "canvasname":"CSCanvas",
   "scripts":"cs*",
   "geometry":gslp,

--- a/examples/64_Many_Conics.html
+++ b/examples/64_Many_Conics.html
@@ -42,7 +42,7 @@
 		      {name:"Co9", type:"ConicBy5", args:["A","G","C","E","F"]},
 		     //{name:"l", type:"Join", args:["A", "B"]}
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/65_Conic_4P_1l.html
+++ b/examples/65_Conic_4P_1l.html
@@ -35,7 +35,7 @@
 		      {name:"Co1", type:"SelectConic", args:["CoT"], index:1},
 		      {name:"Co2", type:"SelectConic", args:["CoT"], index:2},
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/65a_Conic_3P_2l.html
+++ b/examples/65a_Conic_3P_2l.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-createCindy({ // See ref/createCindy documentation for details.
+CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   grid:1,

--- a/examples/65b_Conic_2P_3l.html
+++ b/examples/65b_Conic_2P_3l.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-createCindy({ // See ref/createCindy documentation for details.
+CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   grid:1,

--- a/examples/65c_Conic_2P_3l.html
+++ b/examples/65c_Conic_2P_3l.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-createCindy({ // See ref/createCindy documentation for details.
+CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   grid:1,

--- a/examples/66_Conic_5lines.html
+++ b/examples/66_Conic_5lines.html
@@ -36,7 +36,7 @@
 		      {name:"l5", type:"Join", args:["E", "A"] },
 		      {name:"Co", type:"ConicBy5lines", args:["l1","l2","l3","l4","l5"]},
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/67_Conic_1P_4l.html
+++ b/examples/67_Conic_1P_4l.html
@@ -43,7 +43,7 @@
   	      	      {name:"Co1", type:"SelectConic", args:["CoT"], index:1},
 	 	      {name:"Co2", type:"SelectConic", args:["CoT"], index:2},
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/68_Surface1.html
+++ b/examples/68_Surface1.html
@@ -533,7 +533,7 @@ var gslp=[
 
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68_Surface2.html
+++ b/examples/68_Surface2.html
@@ -534,7 +534,7 @@ var gslp=[
 
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68_Surface3.html
+++ b/examples/68_Surface3.html
@@ -534,7 +534,7 @@ var gslp=[
 
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68_Surface4.html
+++ b/examples/68_Surface4.html
@@ -681,7 +681,7 @@ var gslp=[
 
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68_Surface5.html
+++ b/examples/68_Surface5.html
@@ -1303,7 +1303,7 @@ var gslp=[
 
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68_Surface6.html
+++ b/examples/68_Surface6.html
@@ -681,7 +681,7 @@ var gslp=[
 
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68_Surface7.html
+++ b/examples/68_Surface7.html
@@ -518,7 +518,7 @@ var gslp=[
 
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68_Surface8.html
+++ b/examples/68_Surface8.html
@@ -274,7 +274,7 @@ var gslp=[
 
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68a_MixedSurfaces.html
+++ b/examples/68a_MixedSurfaces.html
@@ -1221,7 +1221,7 @@ var gslp=[
 
     ];
 
-var cdy = createCindy({canvasname:"CSCanvas",
+var cdy = CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/68b_MixedSurfaces.html
+++ b/examples/68b_MixedSurfaces.html
@@ -2601,7 +2601,7 @@ var gslp=[
 
     ];
 
-var cdy = createCindy({canvasname:"CSCanvas",
+var cdy = CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 mousedownscript:"mouseDown",

--- a/examples/69_Intersection_Conic_Conic.html
+++ b/examples/69_Intersection_Conic_Conic.html
@@ -47,7 +47,7 @@
 		      {name:"P4", type:"SelectP", args:["CoCo"],index:4,color:[1,0.8,0],size:6},
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
 //                        snap:true,

--- a/examples/69_tracing4.html
+++ b/examples/69_tracing4.html
@@ -43,7 +43,7 @@
 		      {name:"P4", type:"SelectP", args:["CoCo"],index:4,color:[1,0,1],size:3},
 
                       ];
-           var cdy = createCindy({canvasname:"CSCanvas",
+           var cdy = CindyJS({canvasname:"CSCanvas",
   			tracingStateReport: "tracingStateReport",
                         movescript:"csmove",
                         //grid:1,

--- a/examples/69_tracing4_many.html
+++ b/examples/69_tracing4_many.html
@@ -85,7 +85,7 @@
 		      {name:"O4", type:"SelectP", args:["CoCo6"],index:4,color:[1,0,1],size:3},
 
                       ];
-           var cdy = createCindy({canvasname:"CSCanvas",
+           var cdy = CindyJS({canvasname:"CSCanvas",
 //  			tracingStateReport: "tracingStateReport",
                         movescript:"csmove",
                         //grid:1,

--- a/examples/70_DownClock.html
+++ b/examples/70_DownClock.html
@@ -80,7 +80,7 @@ drawtext((1,-8.5),"Reset",size->30);
                      // {name:"A1", type:"Free", pos:[3,0]}
 
 		                           ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         initscript:"init",
                         mouseupscript:"up",

--- a/examples/70_TwoInstances.html
+++ b/examples/70_TwoInstances.html
@@ -19,7 +19,7 @@
     <div  id="sunflowerCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
     <script type="text/javascript">
-      createCindy({
+      CindyJS({
         canvasname:"sunflowerCanvas",
         movescript:"sunflowerMove",
         defaultAppearance:{pointColor:[1,.7,0]},
@@ -45,7 +45,7 @@ repeat(1000,draw(gauss(a)*5,size->abs(a)*10,\
                  color->(re(a)*2,im(a)*2,-re(a)),alpha->.7);\
              a=a*c;);\
 draw(A);draw(C);";
-createCindy({canvasname:"spiral",scripts:{move:move},geometry:gslp});
+CindyJS({canvasname:"spiral",scripts:{move:move},geometry:gslp});
     </script>
 
   </body>

--- a/examples/71_InstanceSwappingExclusive.html
+++ b/examples/71_InstanceSwappingExclusive.html
@@ -6,7 +6,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
       function sunflower() {
-        createCindy({
+        CindyJS({
           canvasname:"canvas",
           exclusive:true, // shut down the previous instance
           scripts:{move:
@@ -24,7 +24,7 @@
         ]});
       }
       function spiral() {
-        createCindy({
+        CindyJS({
           canvasname:"canvas",
           exclusive:true, // shut down the previous instance
           scripts:{move:

--- a/examples/72_InstanceSwappingCanvas.html
+++ b/examples/72_InstanceSwappingCanvas.html
@@ -6,7 +6,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
       function sunflower(id) {
-        createCindy({
+        CindyJS({
           canvasname:id,
           scripts:{move:
               "repeat(500,i,"
@@ -23,7 +23,7 @@
         ]});
       }
       function spiral(id) {
-        createCindy({
+        CindyJS({
           canvasname:id,
           scripts:{move:
               "a=complex(A.xy)/5;"

--- a/examples/73_InstanceSwappingElt.html
+++ b/examples/73_InstanceSwappingElt.html
@@ -6,7 +6,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
       function sunflower(c) {
-        createCindy({
+        CindyJS({
           canvas:c,
           scripts:{move:
               "repeat(500,i,"
@@ -23,7 +23,7 @@
         ]});
       }
       function spiral(c) {
-        createCindy({
+        CindyJS({
           canvas:c,
           scripts:{move:
               "a=complex(A.xy)/5;"

--- a/examples/74_CSad_exp_div_x.html
+++ b/examples/74_CSad_exp_div_x.html
@@ -43,7 +43,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
                       {name:"C", type:"Free", pos:[3,0],color:[1,1,0],size:5},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/74_CSad_quadratic.html
+++ b/examples/74_CSad_quadratic.html
@@ -41,7 +41,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
                       {name:"C", type:"Free", pos:[0,-1],color:[1,1,0],size:5},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/74_CSad_rational.html
+++ b/examples/74_CSad_rational.html
@@ -44,7 +44,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
                       {name:"C", type:"Free", pos:[0,-1],color:[1,1,0],size:5},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/74_CSad_root.html
+++ b/examples/74_CSad_root.html
@@ -42,7 +42,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
                       {name:"C", type:"Free", pos:[0,-1],color:[1,1,0],size:5},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/74_CSad_sin.html
+++ b/examples/74_CSad_sin.html
@@ -40,7 +40,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
                       {name:"C", type:"Free", pos:[0,-1],color:[1,1,0],size:5},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/74_CSad_sin_div_x.html
+++ b/examples/74_CSad_sin_div_x.html
@@ -46,7 +46,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
                       {name:"C", type:"Free", pos:[1,0],color:[1,1,0],size:5},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/74_CSad_sincos.html
+++ b/examples/74_CSad_sincos.html
@@ -40,7 +40,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
                       {name:"C", type:"Free", pos:[0,-1],color:[1,1,0],size:5},
                       ];
 
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/74_Focus.html
+++ b/examples/74_Focus.html
@@ -22,7 +22,7 @@
                       {name:"A", kind:"P", type:"Free", pos:[0,0,1]},
                       {name:"B", kind:"P", type:"Free", pos:[0,9,1]},
                       ];
-            var cdy = createCindy({canvasname:"CSCanvas",
+            var cdy = CindyJS({canvasname:"CSCanvas",
                         defaultAppearance:{pointColor:[1,.7,0]},
                         scripts:"cs*",
                         geometry:gslp});

--- a/examples/75_DrawModifs.html
+++ b/examples/75_DrawModifs.html
@@ -173,7 +173,7 @@ x = x + dx;
 
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/76_I18n.html
+++ b/examples/76_I18n.html
@@ -19,14 +19,14 @@ var tr = {
   },
 };
 
-createCindy({
+CindyJS({
   canvasname: "enCindy",
   scripts: "cs*",
   translations: tr,
   defaultAppearance: { },
 });
 
-createCindy({
+CindyJS({
   canvasname: "deCindy",
   scripts: "cs*",
   language: "de",

--- a/examples/77_Plurals.html
+++ b/examples/77_Plurals.html
@@ -22,14 +22,14 @@ var tr = {
   },
 };
 
-createCindy({
+CindyJS({
   canvasname: "enCindy",
   scripts: "cs*",
   translations: tr,
   defaultAppearance: { },
 });
 
-createCindy({
+CindyJS({
   canvasname: "deCindy",
   scripts: "cs*",
   language: "de",

--- a/examples/78_Yahtzee.html
+++ b/examples/78_Yahtzee.html
@@ -146,7 +146,7 @@ if (x > 1 & x < 7 & y < -0.25 & y > -1.25*13,
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/79_Couples.html
+++ b/examples/79_Couples.html
@@ -25,7 +25,7 @@ drawall(apply(1..length(m),[PP_#, QQ_(m_#)]), color->[0,1,0]);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/80_Conic_by_2Foci_1P.html
+++ b/examples/80_Conic_by_2Foci_1P.html
@@ -18,7 +18,7 @@
 
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/81_Clock.html
+++ b/examples/81_Clock.html
@@ -35,7 +35,7 @@ drawtext((3,-5.5),fmt(d_3,2)+"."+fmt(d_2,2)+"."+d_1);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/81_Polar.html
+++ b/examples/81_Polar.html
@@ -33,7 +33,7 @@
 		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,size:1},
 		              {name:"l", type:"PolarOfPoint", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/81_Polar_angular_bisect.html
+++ b/examples/81_Polar_angular_bisect.html
@@ -33,7 +33,7 @@
 		              {name:"Co", type:"ConicBy5", args:["A","B","C","D","E"],color:[0,0,1],alpha:1,size:1},
 		              {name:"l", type:"PolarOfPoint", args:["P","Co"],color:[0,1,0],alpha:1,size:2},
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         grid:1,
                         snap:true,

--- a/examples/81_Wait.html
+++ b/examples/81_Wait.html
@@ -25,7 +25,7 @@ drawtext([-2,7], format(x/(2*pi), 2));
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/82_angle_bisector.html
+++ b/examples/82_angle_bisector.html
@@ -17,7 +17,7 @@
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/85_Createimage.html
+++ b/examples/85_Createimage.html
@@ -55,7 +55,7 @@ createimage("test",400,300);
                       {name:"E", kind:"P", type:"Free", pos:[-9,4,1],color:[1,1,1]},
                       {name:"F", kind:"P", type:"Free", pos:[-4,2,1],color:[1,1,1]}
                       ];
-createCindy({
+CindyJS({
   canvasname: "cindy",
   scripts: "cs*",
   geometry:gslp,

--- a/examples/85a_CreateimageAff.html
+++ b/examples/85a_CreateimageAff.html
@@ -57,7 +57,7 @@ createimage("test",400,400);
                       {name:"F", kind:"P", type:"Free", pos:[-4,2,1],color:[1,1,1]},
                       {name:"EX", kind:"P", type:"Free", pos:[-9,5,1],color:[1,1,1]}
                       ];
-createCindy({
+CindyJS({
   canvasname: "cindy",
   scripts: "cs*",
   geometry:gslp,

--- a/examples/86_IFS.html
+++ b/examples/86_IFS.html
@@ -77,7 +77,7 @@ initiss();
                       {name:"Z", kind:"P", type:"PointOnLine", args:["a"],pos:[-4.5,-9,1],color:[1,1,1],size:3}
 
                       ];
-createCindy({
+CindyJS({
   canvasname: "cindy",
   scripts: "cs*",
   geometry:gslp,

--- a/examples/87_IFSIm.html
+++ b/examples/87_IFSIm.html
@@ -125,7 +125,7 @@ initiss();
                       {name:"Z", kind:"P", type:"PointOnLine", args:["a"],pos:[-7,-9,1],color:[1,1,1],size:3}
 
                       ];
-createCindy({
+CindyJS({
   canvasname: "cindy",
   scripts: "cs*",
   geometry:gslp,

--- a/examples/87_IFSIm2.html
+++ b/examples/87_IFSIm2.html
@@ -95,7 +95,7 @@ initiss();
                       {name:"Z", kind:"P", type:"PointOnLine", args:["a"],pos:[-6.5,-9,1],color:[1,1,1],size:3}
 
                       ];
-createCindy({
+CindyJS({
   canvasname: "cindy",
   scripts: "cs*",
   geometry:gslp,

--- a/examples/88_Eigenvalues.html
+++ b/examples/88_Eigenvalues.html
@@ -126,7 +126,7 @@ if(|im(ew_1)|<eps,
 </script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   "scripts": "cs*",
   "defaultAppearance": {},
   "geometry": [

--- a/examples/88_LA_Tests.html
+++ b/examples/88_LA_Tests.html
@@ -89,7 +89,7 @@
 
 
                     ];
-                     createCindy({canvasname:"CSCanvas",
+                     CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/88_QR.html
+++ b/examples/88_QR.html
@@ -140,7 +140,7 @@ println(|AA*transpose(kernel(AA))_1|)
 
 
                     ];
-                     createCindy({canvasname:"CSCanvas",
+                     CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         initscript:"init",
                         geometry:gslp,

--- a/examples/88_TracingVis1.html
+++ b/examples/88_TracingVis1.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy1 = createCindy({
+var cdy1 = CindyJS({
   canvasname: "CSCanvas1",
   scripts: "cs1*",
   language: "en",
@@ -26,7 +26,7 @@ var cdy1 = createCindy({
   ] // End of geometry array.
 });
 
-var cdy2 = createCindy({
+var cdy2 = CindyJS({
   canvasname: "CSCanvas2",
   scripts: "cs2*",
   language: "en",

--- a/examples/88_TracingVis2.html
+++ b/examples/88_TracingVis2.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy1 = createCindy({
+var cdy1 = CindyJS({
   canvasname: "CSCanvas1",
   scripts: "cs1*",
   language: "en",
@@ -41,7 +41,7 @@ var cdy1 = createCindy({
   ] // End of geometry array.
 });
 
-var cdy2 = createCindy({
+var cdy2 = CindyJS({
   canvasname: "CSCanvas2",
   scripts: "cs2*",
   language: "en",

--- a/examples/88_Vectorfield.html
+++ b/examples/88_Vectorfield.html
@@ -95,7 +95,7 @@ initiss();
                       {name:"A", kind:"P", type:"Free", pos:[1,-1,1],size:3}
 
                       ];
-createCindy({
+CindyJS({
   canvasname: "cindy",
   scripts: "cs*",
   geometry:gslp,

--- a/examples/89_MousePos.html
+++ b/examples/89_MousePos.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/90_Tracing1.html
+++ b/examples/90_Tracing1.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/90_Tracing2.html
+++ b/examples/90_Tracing2.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/90_Tracing3.html
+++ b/examples/90_Tracing3.html
@@ -7,7 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/90_Tracing4.html
+++ b/examples/90_Tracing4.html
@@ -12,7 +12,7 @@ B.xy = A.xy - (0, 5);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/90_Tracing5.html
+++ b/examples/90_Tracing5.html
@@ -19,7 +19,7 @@ B.xy = (4, 3*sin(2*t) - 2);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/96_OtherIntersection.html
+++ b/examples/96_OtherIntersection.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   "scripts": "cs*",
   "defaultAppearance": {},
   "geometry": [

--- a/examples/97_OtherIntersectionCL.html
+++ b/examples/97_OtherIntersectionCL.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   "scripts": "cs*",
   "defaultAppearance": {},
   "geometry": [

--- a/examples/98_Compass.html
+++ b/examples/98_Compass.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   "scripts": "cs*",
   "defaultAppearance": {},
   "geometry": [

--- a/examples/99_LineMirror.html
+++ b/examples/99_LineMirror.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
   "scripts": "cs*",
   "defaultAppearance": {},
   "geometry": [

--- a/examples/Bastelbogen.html
+++ b/examples/Bastelbogen.html
@@ -169,7 +169,7 @@ function utf8Decode(bytes) {
     }).join(""));
 }
 
-createCindy.registerPlugin(1, "imgmeta", function(api) {
+CindyJS.registerPlugin(1, "imgmeta", function(api) {
     api.defineFunction("xmpdescription", 1, function(args, modifs) {
         var img = api.evaluate(args[0]);
         console.log(img);
@@ -245,7 +245,7 @@ createCindy.registerPlugin(1, "imgmeta", function(api) {
     });
 });
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/ConstructionConicFromPrincipalDirections.html
+++ b/examples/ConstructionConicFromPrincipalDirections.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
 	angleUnit: "°", 

--- a/examples/ConstructionFreeLine.html
+++ b/examples/ConstructionFreeLine.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: {}, 
 	geometry: [ 

--- a/examples/ConstructionHorizontalAndVerticalLines.html
+++ b/examples/ConstructionHorizontalAndVerticalLines.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: {}, 
 	geometry: [ 

--- a/examples/ConstructionLineByFixedAngle.html
+++ b/examples/ConstructionLineByFixedAngle.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: {}, angle: 10 * Math.PI / 180,
 	geometry: [ 

--- a/examples/ConstructionParabolaPL.html
+++ b/examples/ConstructionParabolaPL.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0 }, 
 	angleUnit: "°", 

--- a/examples/ConstructionRadicalAxisApart-complex.html
+++ b/examples/ConstructionRadicalAxisApart-complex.html
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { dimDependent: 0.7 },
 	geometry: [ 

--- a/examples/Life2.html
+++ b/examples/Life2.html
@@ -74,7 +74,7 @@ next();
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/Life2a.html
+++ b/examples/Life2a.html
@@ -57,7 +57,7 @@ next();
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/Life2b.html
+++ b/examples/Life2b.html
@@ -57,7 +57,7 @@ next();
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/Parabel.html
+++ b/examples/Parabel.html
@@ -60,7 +60,7 @@ draw(G,K,color->(0,0.6,0),size->3);
 </script>
 
     <script type="text/javascript">
-createCindy({
+CindyJS({
 	scripts: "cs*",
 	defaultAppearance: {},
 	geometry: [

--- a/examples/RegressionTests/86_ScriptCoSy.html
+++ b/examples/RegressionTests/86_ScriptCoSy.html
@@ -17,7 +17,7 @@ draw([1, 0]);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",

--- a/examples/Text1.html
+++ b/examples/Text1.html
@@ -29,7 +29,7 @@ drawtext(screenbounds()_1, "123456", offset->[10,-60]);
 </script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
 	scripts: "cs*", 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, textsize: 12.0 }, 
 	angleUnit: "°", 

--- a/examples/arrow_playground.html
+++ b/examples/arrow_playground.html
@@ -126,7 +126,7 @@ draw(H,K,size->2,alpha->0.5, arrow->true, arrowshape->"full", arrowsides->"==>",
 
 
                     ];
-                     createCindy({canvasname:"CSCanvas",
+                     CindyJS({canvasname:"CSCanvas",
                         defaultAppearance: {dimDependent: 0.7},
                         movescript:"csmove",
                         initscript:"init",

--- a/examples/bugs/0259a_ChromeArc.html
+++ b/examples/bugs/0259a_ChromeArc.html
@@ -13,7 +13,7 @@
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{
     id: "CSCanvas",
     width: 881,

--- a/examples/cassin.html
+++ b/examples/cassin.html
@@ -139,7 +139,7 @@ var gslp=[
 
 
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
      defaultAppearance: {dimDependent: 0.7},
      movescript:"csmove",
     // initscript:"init",

--- a/examples/cindy3d/01_ThreeSpheres.html
+++ b/examples/cindy3d/01_ThreeSpheres.html
@@ -17,7 +17,7 @@ drawsphere3d([cos(120°),-sin(120°),0], 1, color->[0,0,1]);
 end3d();
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/02_Torus.html
+++ b/examples/cindy3d/02_Torus.html
@@ -23,7 +23,7 @@ repeat(n,i,
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/03_Rod.html
+++ b/examples/cindy3d/03_Rod.html
@@ -14,7 +14,7 @@ draw3d([0,0,1],[0,0,-1],color->[0.5,0.75,0.75],size->10);
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/04_Torus.html
+++ b/examples/cindy3d/04_Torus.html
@@ -26,7 +26,7 @@ repeat(n,i,
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/05_FishEye.html
+++ b/examples/cindy3d/05_FishEye.html
@@ -28,7 +28,7 @@ repeat(n,i,
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/06_DrawPoly.html
+++ b/examples/cindy3d/06_DrawPoly.html
@@ -21,7 +21,7 @@ drawpoly3d(apply(1..n,i,f(i/n*360°)));
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/07_Quad.html
+++ b/examples/cindy3d/07_Quad.html
@@ -14,7 +14,7 @@ mesh3d(2, 2, [[-1, -1, 0], [1, -1, 0], [-1, 1, 0], [1, 1, 0]]);
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/08_EnneperWithDots.html
+++ b/examples/cindy3d/08_EnneperWithDots.html
@@ -30,7 +30,7 @@ mesh3d(2*rr+1,2*ss+1,m,normaltype->"pervertex");
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/09_EnneperWithDotsSS.html
+++ b/examples/cindy3d/09_EnneperWithDotsSS.html
@@ -30,7 +30,7 @@ mesh3d(2*rr+1,2*ss+1,m,normaltype->"pervertex");
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/10_EnneperWithDotsLights.html
+++ b/examples/cindy3d/10_EnneperWithDotsLights.html
@@ -33,7 +33,7 @@ mesh3d(2*rr+1,2*ss+1,m,normaltype->"pervertex");
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/11_EnneperWithLights.html
+++ b/examples/cindy3d/11_EnneperWithLights.html
@@ -34,7 +34,7 @@ mesh3d(2*rr+1,2*ss+1,m,normaltype->"pervertex");
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/12_Polygons.html
+++ b/examples/cindy3d/12_Polygons.html
@@ -14,7 +14,7 @@ fillpoly3d(apply(1..5, gauss(1 + exp(i*#*72°)) ++ [0.2 * (# - 3)]));
 end3d()
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/13_Cylinder.html
+++ b/examples/cindy3d/13_Cylinder.html
@@ -17,7 +17,7 @@ mesh3d(m, n, flatten(apply(1..m, i, apply(1..n, j, (
 end3d();
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/14_Cylinder2.html
+++ b/examples/cindy3d/14_Cylinder2.html
@@ -17,7 +17,7 @@ mesh3d(m, n, flatten(apply(1..m, i, apply(1..n, j, (
 end3d();
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/15_Torus.html
+++ b/examples/cindy3d/15_Torus.html
@@ -23,7 +23,7 @@ mesh3d(m, n, flatten(apply(1..m, i, apply(1..n, j, (
 end3d();
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/16_Interaction.html
+++ b/examples/cindy3d/16_Interaction.html
@@ -20,7 +20,7 @@ end3d()
                 ];
 
 
-createCindy({canvasname:"CSCanvas",scripts:"cs*",  geometry:gslp});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*",  geometry:gslp});
 </script>
 </head>
 

--- a/examples/cindy3d/16_MeshNormals.html
+++ b/examples/cindy3d/16_MeshNormals.html
@@ -36,7 +36,7 @@ forall(1..m, i, forall(1..n, j, (
 end3d();
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/17_ColorsMesh.html
+++ b/examples/cindy3d/17_ColorsMesh.html
@@ -24,7 +24,7 @@ mesh3d(m, n, coords, colors->coords, topology->"closeBoth", normaltype->"perVert
 end3d();
 </script>
 <script type="text/javascript">
-createCindy({canvasname:"CSCanvas",scripts:"cs*"});
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
 </script>
 </head>
 

--- a/examples/cindy3d/68_Surface1.html
+++ b/examples/cindy3d/68_Surface1.html
@@ -474,7 +474,7 @@ end3d();
 var gslp=[
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 geometry:gslp});

--- a/examples/cindy3d/68_Surface2.html
+++ b/examples/cindy3d/68_Surface2.html
@@ -474,7 +474,7 @@ end3d();
 var gslp=[
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 geometry:gslp});

--- a/examples/cindy3d/68_Surface3.html
+++ b/examples/cindy3d/68_Surface3.html
@@ -475,7 +475,7 @@ end3d();
 var gslp=[
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 geometry:gslp});

--- a/examples/cindy3d/68_Surface4.html
+++ b/examples/cindy3d/68_Surface4.html
@@ -622,7 +622,7 @@ end3d();
 var gslp=[
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 geometry:gslp});

--- a/examples/cindy3d/68_Surface5.html
+++ b/examples/cindy3d/68_Surface5.html
@@ -1247,7 +1247,7 @@ end3d();
 var gslp=[
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 geometry:gslp});

--- a/examples/cindy3d/68_Surface6.html
+++ b/examples/cindy3d/68_Surface6.html
@@ -625,7 +625,7 @@ end3d();
 var gslp=[
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 geometry:gslp});

--- a/examples/cindy3d/68_Surface7.html
+++ b/examples/cindy3d/68_Surface7.html
@@ -462,7 +462,7 @@ end3d();
 var gslp=[
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 geometry:gslp});

--- a/examples/cindy3d/68_Surface8.html
+++ b/examples/cindy3d/68_Surface8.html
@@ -218,7 +218,7 @@ end3d();
 var gslp=[
     ];
 
-createCindy({canvasname:"CSCanvas",
+CindyJS({canvasname:"CSCanvas",
 movescript:"csmove",
 initscript:"init",
 geometry:gslp});

--- a/examples/cindy3d/Klein.html
+++ b/examples/cindy3d/Klein.html
@@ -173,7 +173,7 @@ gslp=[
     {name:"m", type:"Segment", args:["R1","R2"],color:[0,0,0],pinned:false,size:2},
 
 ];
-createCindy({
+CindyJS({
   canvasname:"CSCanvas",
   scripts:"cs*",
   geometry:gslp,

--- a/examples/cindygl/01_colorplot.html
+++ b/examples/cindygl/01_colorplot.html
@@ -32,7 +32,7 @@
                   {name:"A", kind:"P", type:"Free", pos:[-7,-1,1]},
                   {name:"B", kind:"P", type:"Free", pos:[10,1,1]},
                   ];
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp
                   });

--- a/examples/cindygl/02_mandelbrot.html
+++ b/examples/cindygl/02_mandelbrot.html
@@ -72,7 +72,7 @@
                   {name:"Z0", kind:"P", type:"Free", pos:[5., 0.01]}
                   ];
                   
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     ports: [{

--- a/examples/cindygl/02_mandelbrot_3d.html
+++ b/examples/cindygl/02_mandelbrot_3d.html
@@ -93,7 +93,7 @@
                   {name:"Z0", kind:"P", type:"Free", pos:[5., 0.01]}
                   ];
                   
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/02_mandelbrot_cubic.html
+++ b/examples/cindygl/02_mandelbrot_cubic.html
@@ -71,7 +71,7 @@
                   {name:"C", kind:"P", type:"Free", pos:[0.2,1.8]},
                   {name:"Z0", kind:"P", type:"Free", pos:[5, 0.001]}
                   ];
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     ports: [{

--- a/examples/cindygl/03_complexplot.html
+++ b/examples/cindygl/03_complexplot.html
@@ -36,7 +36,7 @@
                   {name:"B", kind:"P", type:"Free", pos:[.8,-1.5]},
                   {name:"C", kind:"P", type:"Free", pos:[.1,.1]},
                 ];
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp
                     }

--- a/examples/cindygl/04_movingplot.html
+++ b/examples/cindygl/04_movingplot.html
@@ -39,7 +39,7 @@
                   {name:"A", kind:"P", type:"Free", pos:[-20,-1,1]},
                   {name:"B", kind:"P", type:"Free", pos:[20,5,1]},
                   ];
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/05_pixelinterference.html
+++ b/examples/cindygl/05_pixelinterference.html
@@ -34,7 +34,7 @@
         
         var gslp=[
                   ];
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/06_raytracer_bisection.html
+++ b/examples/cindygl/06_raytracer_bisection.html
@@ -182,7 +182,7 @@
     <div  id="CSCanvas" style="border:0px"></div>
     
     <script type="text/javascript">
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     autoplay: true,
                     ports: [{

--- a/examples/cindygl/06_raytracer_homotopy.html
+++ b/examples/cindygl/06_raytracer_homotopy.html
@@ -184,7 +184,7 @@
     <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
     
     <script type="text/javascript">
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     autoplay: true,
                     ports: [{

--- a/examples/cindygl/07_diffusion.html
+++ b/examples/cindygl/07_diffusion.html
@@ -55,7 +55,7 @@
                   {name:"B", kind:"P", type:"Free", pos:[1,6,1]},
                   {name:"C", kind:"P", type:"Free", pos:[3,5,1]},
                   ];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/08_julia.html
+++ b/examples/cindygl/08_julia.html
@@ -40,7 +40,7 @@
     <script type="text/javascript">
         
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/08_julia_advanced.html
+++ b/examples/cindygl/08_julia_advanced.html
@@ -68,7 +68,7 @@
     <script type="text/javascript">
         
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/08_julia_conjugated.html
+++ b/examples/cindygl/08_julia_conjugated.html
@@ -63,7 +63,7 @@
     <script type="text/javascript">
         
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/08_julia_explanation.html
+++ b/examples/cindygl/08_julia_explanation.html
@@ -57,7 +57,7 @@ tp(a) := (re(a), im(a));
     <script type="text/javascript">
         
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[
                       {name:"C", type:"Free", pos:[-0.79, -0.184], color:[1,0,0], pinned:false, size:6}

--- a/examples/cindygl/08_julia_nointerpolation.html
+++ b/examples/cindygl/08_julia_nointerpolation.html
@@ -40,7 +40,7 @@
     <script type="text/javascript">
         
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/09_ifs.html
+++ b/examples/cindygl/09_ifs.html
@@ -45,7 +45,7 @@
           {name:"C", kind:"P", type:"Free", pos:[1,-1]},
           {name:"D", kind:"P", type:"Free", pos:[1.75,0]},
         ];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/09_ifs_barnsley.html
+++ b/examples/cindygl/09_ifs_barnsley.html
@@ -100,7 +100,7 @@
 //{ name: "C3", type: "Free", pos: [-2.066, 4.4006]},
 //{ name: "C4", type: "Free", pos: [2.3973, 3.5191]},
         ];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/09_ifs_sierpinski.html
+++ b/examples/cindygl/09_ifs_sierpinski.html
@@ -62,7 +62,7 @@
 		{ name: "E", type: "Mid", color: [ 1.0, 0.0, 0.0 ], args: [ "B", "C" ], labeled: true, textsize: 24.0 }, 
 		{ name: "F", type: "Mid", color: [ 1.0, 0.0, 0.0 ], args: [ "C", "A" ], labeled: true, textsize: 24.0 }
         ];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/10_gol.html
+++ b/examples/cindygl/10_gol.html
@@ -82,7 +82,7 @@
 
     
     <script type="text/javascript">     
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[],
                     autoplay: true,

--- a/examples/cindygl/11_tilings.html
+++ b/examples/cindygl/11_tilings.html
@@ -137,7 +137,7 @@
     <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry: [
                       

--- a/examples/cindygl/11_tilings_kaleidoscope.html
+++ b/examples/cindygl/11_tilings_kaleidoscope.html
@@ -137,7 +137,7 @@
     <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry: [
     {name:"CDelta", type:"Free", pos:[0, 0],color:[0,0,0],pinned:false,size:1},              

--- a/examples/cindygl/12_kleinian.html
+++ b/examples/cindygl/12_kleinian.html
@@ -101,7 +101,7 @@
     <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry: [{name:"TA", type:"Free", pos:[0.,0.],color:[1,0,0],pinned:false,size:6},
                               {name:"TB", type:"Free", pos:[0.,0.],color:[0,0,1],pinned:false,size:6}],

--- a/examples/cindygl/12_kleinian2.html
+++ b/examples/cindygl/12_kleinian2.html
@@ -113,7 +113,7 @@
     <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry: [{name:"TA", type:"Free", pos:[-1 ,0.],color:[1,.3,.3],pinned:false,size:6},
                                {name:"TB", type:"Free", pos:[-1 ,0.],color:[.3,.3,1],pinned:false,size:6}

--- a/examples/cindygl/12_kleinian2_conjugated.html
+++ b/examples/cindygl/12_kleinian2_conjugated.html
@@ -128,7 +128,7 @@
     <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry: [{name:"TA", type:"Free", pos:[2 ,2],color:[1,.3,.3],pinned:false,size:6},
                                {name:"TB", type:"Free", pos:[2 ,2],color:[.3,.3,1],pinned:false,size:6}],

--- a/examples/cindygl/12_kleinian_explanation.html
+++ b/examples/cindygl/12_kleinian_explanation.html
@@ -135,7 +135,7 @@
     <div  id="CSCanvas" style="border:2px solid black"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry: [
                       

--- a/examples/cindygl/13_random.html
+++ b/examples/cindygl/13_random.html
@@ -25,7 +25,7 @@
     <script type="text/javascript">
         
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/14_reactiondiffusion.html
+++ b/examples/cindygl/14_reactiondiffusion.html
@@ -68,7 +68,7 @@
 
     <div  id="CSCanvas"></div>
     <script type="text/javascript">
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
           scripts: "cs*",
           geometry:[
             {name:"CA", type:"Free", pos:[500,350],color:[1,0,0],pinned:false,size:6},

--- a/examples/cindygl/15_lic.html
+++ b/examples/cindygl/15_lic.html
@@ -93,7 +93,7 @@
     <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[
                       {name:"A", kind:"P", type:"Free", pos:[1  ,-1],size:3},

--- a/examples/cindygl/15_lic2.html
+++ b/examples/cindygl/15_lic2.html
@@ -75,7 +75,7 @@
     <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[
 																					{name:"A", kind:"P", type:"Free", pos:[1.01,-1.01],size:3}

--- a/examples/cindygl/15_lic3.html
+++ b/examples/cindygl/15_lic3.html
@@ -95,7 +95,7 @@
     <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[
 																					{name:"A", kind:"P", type:"Free", pos:[.5  ,.5],size:3},

--- a/examples/cindygl/16_userinput.html
+++ b/examples/cindygl/16_userinput.html
@@ -31,7 +31,7 @@
     
     <script type="text/javascript">
         var gslp=[{name:"A", kind:"P", type:"Free", pos:[-2,2]}];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     autoplay: true,
                     geometry:gslp

--- a/examples/cindygl/16_userinput_lic.html
+++ b/examples/cindygl/16_userinput_lic.html
@@ -75,7 +75,7 @@
     <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[],
                     autoplay: true,

--- a/examples/cindygl/17_images.html
+++ b/examples/cindygl/17_images.html
@@ -30,7 +30,7 @@
     
     <script type="text/javascript">
         var gslp=[{name:"A", kind:"P", type:"Free", pos:[0.1, 0.1]}];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     autoplay: true,
                     geometry: gslp,

--- a/examples/cindygl/17_images_blur.html
+++ b/examples/cindygl/17_images_blur.html
@@ -38,7 +38,7 @@
     
     <script type="text/javascript">
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     autoplay: true,
                     geometry: gslp,

--- a/examples/cindygl/18_hidpitest.html
+++ b/examples/cindygl/18_hidpitest.html
@@ -52,7 +52,7 @@
     
     <script type="text/javascript">
         var gslp=[];
-        cdy = createCindy({canvasname:"CSCanvas",
+        cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     autoplay: true,
                     geometry: gslp,

--- a/examples/cindygl/19_colorplot3.html
+++ b/examples/cindygl/19_colorplot3.html
@@ -28,7 +28,7 @@
                   {name:"A", kind:"P", type:"Free", pos:[-7,-4,1]},
                   {name:"B", kind:"P", type:"Free", pos:[10,5,1]},
                   ];
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp
                   });

--- a/examples/cindygl/20_arctan2.html
+++ b/examples/cindygl/20_arctan2.html
@@ -26,7 +26,7 @@
         var gslp=[
                   {name:"A", kind:"P", type:"Free", pos:[-2,-1.5]},
                 ];
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp
                     }

--- a/examples/cindygl/21_pickit.html
+++ b/examples/cindygl/21_pickit.html
@@ -114,7 +114,7 @@ drawtext([-0.15, -1.25], qualityString(totalQuality));
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [ { visibleRect: [-1.5, 1.5, 1.5, -1.5] }]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cindygl/22_explorer.html
+++ b/examples/cindygl/22_explorer.html
@@ -159,7 +159,7 @@ draw((1,-1),(1,1), color->(0,0,0), size->2);
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{
     id: "CSCanvas",
       width: 820,

--- a/examples/cindygl/23_infix_dist.html
+++ b/examples/cindygl/23_infix_dist.html
@@ -32,7 +32,7 @@
                   {name:"A", kind:"P", type:"Free", pos:[-20,-1,1]},
                   {name:"B", kind:"P", type:"Free", pos:[20,5,1]},
                   ];
-        createCindy({canvasname:"CSCanvas",
+        CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
                     autoplay: true,

--- a/examples/cindygl/24_webcam.html
+++ b/examples/cindygl/24_webcam.html
@@ -17,7 +17,7 @@ if (image ready(video),
 );
 </script>
 <script type="text/javascript">
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform:[{visibleRect:[-0.1,15.1,20.1,-0.1]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cindygl/24_webcam_blur.html
+++ b/examples/cindygl/24_webcam_blur.html
@@ -24,7 +24,7 @@ drawimage(A, B, "motionblur");
 
 </script>
 <script type="text/javascript">
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform:[{visibleRect:[0,0,20,15]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cindygl/24_webcam_julia.html
+++ b/examples/cindygl/24_webcam_julia.html
@@ -57,7 +57,7 @@ window.onload = window.onresize = function() {
   canvas.height = window.innerHeight;
 };
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-10, -10, 10, 10]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cindygl/24_webcam_sierpinski.html
+++ b/examples/cindygl/24_webcam_sierpinski.html
@@ -64,7 +64,7 @@ window.onload = window.onresize = function() {
   canvas.height = window.innerHeight;
 };
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-10, -10, 10, 10]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cindygl/25_dragdrop.html
+++ b/examples/cindygl/25_dragdrop.html
@@ -25,7 +25,7 @@
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-10, -10, 10, 10]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cindygl/26_readcanvasimage.html
+++ b/examples/cindygl/26_readcanvasimage.html
@@ -30,7 +30,7 @@ createimage("test", 400, 300);
 
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-10, -10, 10, 10]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cindygl/27_changingimages.html
+++ b/examples/cindygl/27_changingimages.html
@@ -34,7 +34,7 @@ t0 = seconds();
 
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-10, -10, 10, 10]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cindygl/28_apollian_gasket.html
+++ b/examples/cindygl/28_apollian_gasket.html
@@ -106,7 +106,7 @@ drawcircle(D, c4r);
                       {name:"B", type:"Free", pos:[9.5,2]},
                       {name:"C", type:"Free", pos:[-9,-9]}
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         scripts: "cs*",
                         geometry:gslp,
                         autoplay:true,

--- a/examples/cindygl/29_modifiers_tunnel.html
+++ b/examples/cindygl/29_modifiers_tunnel.html
@@ -41,7 +41,7 @@
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-20, -20, 20, 20]}]}],
   scripts: "cs*",
   language: "en",

--- a/examples/cmdline.html
+++ b/examples/cmdline.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8"/>
     <script src="../build/js/Cindy.plain.js"></script>
     <script>
-      var cindy = createCindy({
+      var cindy = CindyJS({
         canvasname:"Cindy"
       });
       document.addEventListener("DOMContentLoaded", function() {

--- a/examples/createtool/createtool.html
+++ b/examples/createtool/createtool.html
@@ -16,7 +16,7 @@
         </style>
         <script type="text/javascript" src="../../build/js/Cindy.js"></script>
         <script type="text/javascript">
-            var cindy = createCindy({ 
+            var cindy = CindyJS({ 
         	scripts: "cs*", 
         	defaultAppearance: {}, 
         	geometry: [], 

--- a/examples/drawtraceField.html
+++ b/examples/drawtraceField.html
@@ -14,7 +14,7 @@ var gslp = [
     {name:"A", type:"Free", pos:[-5,0], color:[0,1,1], labeled:true, drawtrace:true},
     {name:"B", type:"Free", pos:[5,0], color:[1,0,1], labeled:true}
   ];
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/fullsize.html
+++ b/examples/fullsize.html
@@ -10,7 +10,7 @@
 </style>
 <script type="text/javascript">
 
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{
     id: "CSCanvas",
     transform:[{visibleRect:[-1,1,1,-1]}]

--- a/examples/katex1.html
+++ b/examples/katex1.html
@@ -18,7 +18,7 @@ drawtext([-5,-3],"$A=\begin{pmatrix}" + format(A.x, 4) +
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas"}],
   scripts: "cs*",
   language: "en",

--- a/examples/template.html
+++ b/examples/template.html
@@ -17,7 +17,7 @@
 </script>
 <script type="text/javascript">
 
-var cdy = createCindy({ // See ref/createCindy documentation for details.
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
   ports: [{id: "CSCanvas", width: 500, height: 500}],
   scripts: "cs*",
   language: "en",

--- a/examples/test.html
+++ b/examples/test.html
@@ -36,7 +36,7 @@
                       {name:"E", type:"PointOnCircle", args:["c"],angle:Math.PI/4,color:[1,0,0]},
 
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/test0.html
+++ b/examples/test0.html
@@ -37,7 +37,7 @@
                       {name:"Y", type:"SelectP", args:["S"],index:1,color:[1,0,0],size:6},
                       {name:"Z", type:"SelectP", args:["S"],index:2,color:[0,1,0],size:6}
                       ];
-            createCindy({canvasname:"CSCanvas",
+            CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",
                         geometry:gslp});
 

--- a/examples/test_create.html
+++ b/examples/test_create.html
@@ -11,7 +11,7 @@
         </style>
         <script type="text/javascript" src="../build/js/Cindy.plain.js"></script>
         <script type="text/javascript">
-            createCindy({ 
+            CindyJS({ 
         	scripts: "cs*", 
         	defaultAppearance: {}, 
         	geometry: [], 

--- a/examples/textsize.html
+++ b/examples/textsize.html
@@ -19,7 +19,7 @@
 <script type="text/javascript">
 
 function doCreate(id, defaultAppearance) {
-  return createCindy({
+  return CindyJS({
     ports: [{id: id, transform:[{visibleRect:[-1,0,7,0]}]}],
     scripts: "cs*",
     language: "en",

--- a/examples/webcam1.html
+++ b/examples/webcam1.html
@@ -14,7 +14,7 @@ if (image ready(video),
 );
 </script>
 <script type="text/javascript">
-var cdy = createCindy({
+var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform:[{visibleRect:[-0.1,30.1,40.1,-0.1]}]}],
   scripts: "cs*",
   language: "en",

--- a/make/build.js
+++ b/make/build.js
@@ -156,6 +156,9 @@ module.exports = function build(settings, task) {
         this.forbidden("ref/**/*.md", [
             /^#.*`.*<[A-Za-z0-9]+>.*?`/mg, // use ‹…› instead
         ]);
+        this.forbidden(null, [
+            /createCind[y](?!\.md[)#])[.(]/g, // use CindyJS instead
+        ]);
     });
 
     //////////////////////////////////////////////////////////////////////

--- a/plugins/cindy3d/src/js/Interface.js
+++ b/plugins/cindy3d/src/js/Interface.js
@@ -4,20 +4,20 @@
 let coerce = {};
 
 /**
- * @param {createCindy.anyval} arg
- * @param {Array.<createCindy.anyval>=} def
- * @return {Array.<createCindy.anyval>}
+ * @param {CindyJS.anyval} arg
+ * @param {Array.<CindyJS.anyval>=} def
+ * @return {Array.<CindyJS.anyval>}
  */
 coerce.toList = function(arg, def=null) {
   if (arg["ctype"] !== "list") {
     console.log("argument is not a list");
     return def;
   }
-  return /** @type {Array.<createCindy.anyval>} */(arg["value"]);
+  return /** @type {Array.<CindyJS.anyval>} */(arg["value"]);
 };
 
 /**
- * @param {createCindy.anyval} arg
+ * @param {CindyJS.anyval} arg
  * @param {Array.<number>=} def
  * @return {Array.<number>}
  */
@@ -38,7 +38,7 @@ coerce.toHomog = function(arg, def=[0,0,0,0]) {
 };
 
 /**
- * @param {createCindy.anyval} arg
+ * @param {CindyJS.anyval} arg
  * @param {Array.<number>=} def
  * @return {Array.<number>}
  */
@@ -57,7 +57,7 @@ coerce.toDirection = function(arg, def=[0,0,0]) {
 };
 
 /**
- * @param {createCindy.anyval} arg
+ * @param {CindyJS.anyval} arg
  * @param {Array.<number>=} def
  * @return {Array.<number>}
  */
@@ -78,7 +78,7 @@ coerce.toColor = function(arg, def=[0.5,0.5,0.5]) {
 };
 
 /**
- * @param {createCindy.anyval} arg
+ * @param {CindyJS.anyval} arg
  * @param {number=} def
  * @return {number}
  */
@@ -94,7 +94,7 @@ coerce.toReal = function(arg, def=Number.NaN) {
 };
 
 /**
- * @param {createCindy.anyval} arg
+ * @param {CindyJS.anyval} arg
  * @param {number=} def
  * @return {number}
  */
@@ -125,7 +125,7 @@ coerce.clamp = function(min, max, arg) {
 /**
  * @param {number} min
  * @param {number} max
- * @param {createCindy.anyval} arg
+ * @param {CindyJS.anyval} arg
  * @param {number=} def
  * @return {number}
  */
@@ -134,7 +134,7 @@ coerce.toInterval = function(min, max, arg, def=Number.NaN) {
 };
 
 /**
- * @param {createCindy.anyval} arg
+ * @param {CindyJS.anyval} arg
  * @param {?string=} def
  * @return {?string}
  */
@@ -146,7 +146,7 @@ coerce.toString = function(arg, def=null) {
 };
 
 /**
- * @param {createCindy.anyval} arg
+ * @param {CindyJS.anyval} arg
  * @param {?boolean} def
  * @return {?boolean}
  */

--- a/plugins/cindy3d/src/js/Ops3D.js
+++ b/plugins/cindy3d/src/js/Ops3D.js
@@ -1,15 +1,15 @@
-createCindy.registerPlugin(1, "Cindy3D", function(api) {
+CindyJS.registerPlugin(1, "Cindy3D", function(api) {
 
   //////////////////////////////////////////////////////////////////////
   // API bindings
 
-  /** @type {createCindy.anyval} */
+  /** @type {CindyJS.anyval} */
   let nada = api.nada;
 
-  /** @type {function(createCindy.anyval):createCindy.anyval} */
+  /** @type {function(CindyJS.anyval):CindyJS.anyval} */
   let evaluate = api.evaluate;
 
-  /** @type {function(string,number,createCindy.op)} */
+  /** @type {function(string,number,CindyJS.op)} */
   let defOp = api.defineFunction;
 
   //////////////////////////////////////////////////////////////////////

--- a/plugins/cindygl/src/js/CanvasWrapper.js
+++ b/plugins/cindygl/src/js/CanvasWrapper.js
@@ -1,6 +1,6 @@
 /**
  * adds a canvasWrapper to an image object for reading access. A reference will in the 'readcanvaswrappers' list. If argument is an image that was not loaded, this will be done as onload-event.
- * @param {createCindy.image} imageobject
+ * @param {CindyJS.image} imageobject
  * @return {CanvasWrapper}
  */
 function generateReadCanvasWrapperIfRequired(imageobject, api, properties) {
@@ -25,7 +25,7 @@ function generateReadCanvasWrapperIfRequired(imageobject, api, properties) {
 
 /**
  * adds a canvasWrapper that is supposed to be written to an image object. A reference 'writecanvaswrapper' will be added to imageobject. If it already exists, take it. If none exists, try to find the canvaswrapper of some existing texturereader
- * @param {createCindy.image} imageobject
+ * @param {CindyJS.image} imageobject
  * @return {CanvasWrapper}
  */
 function generateWriteCanvasWrapperIfRequired(imageobject, api) {
@@ -54,7 +54,7 @@ function generateWriteCanvasWrapperIfRequired(imageobject, api) {
 /**
  * Note that CanvasWrapper might also wrap an image instead of a canvas
  * @constructor
- * @param canvas {createCindy.image}
+ * @param canvas {CindyJS.image}
  */
 function CanvasWrapper(canvas, properties) {
     this.canvas = canvas;
@@ -133,7 +133,7 @@ CanvasWrapper.prototype.sizeY;
 /** @type {number} */
 CanvasWrapper.prototype.ratio;
 
-/** @type {createCindy.image} */
+/** @type {CindyJS.image} */
 CanvasWrapper.prototype.canvas;
 
 /**

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -51,7 +51,7 @@ CodeBuilder.prototype.hasbeenincluded;
 /**  @type {Array.<string>} */
 CodeBuilder.prototype.includedfunctions;
 
-/** @type {createCindy.pluginApi} */
+/** @type {CindyJS.pluginApi} */
 CodeBuilder.prototype.api;
 
 /** @type {Object.<TextureReader>} */

--- a/plugins/cindygl/src/js/Plugin.js
+++ b/plugins/cindygl/src/js/Plugin.js
@@ -1,4 +1,4 @@
-createCindy.registerPlugin(1, "CindyGL", function(api) {
+CindyJS.registerPlugin(1, "CindyGL", function(api) {
 
     //////////////////////////////////////////////////////////////////////
     // API bindings

--- a/plugins/cindygl/src/js/Renderer.js
+++ b/plugins/cindygl/src/js/Renderer.js
@@ -75,7 +75,7 @@ Renderer.prototype.fragmentShaderCode;
 /** @type {ShaderProgram} */
 Renderer.prototype.shaderProgram;
 
-/** @type {createCindy.pluginApi} */
+/** @type {CindyJS.pluginApi} */
 Renderer.prototype.api;
 
 /** @type {CanvasWrapper} */

--- a/plugins/cindygl/src/js/TextureReader.js
+++ b/plugins/cindygl/src/js/TextureReader.js
@@ -98,7 +98,7 @@ TextureReader.prototype.returnCanvaswrapper = function(properties) {
 
 /**
  * Either takes original name of the image or generates a new unique name for the image for nameless imageobjects.
- * @type {createCindy.image|string} image
+ * @type {CindyJS.image|string} image
  */
 function getNameFromImage(image) {
     if (typeof image === "string") {

--- a/plugins/cindyjs.externs
+++ b/plugins/cindyjs.externs
@@ -12,14 +12,14 @@ td.EventManager;
 //////////////////////////////////////////////////////////////////////
 // Externs for CindyJS bindings
 
-function createCindy() {}
+function CindyJS() {}
 
 /** @typedef {{ctype:string}} */
-createCindy.anyval;
+CindyJS.anyval;
 
-/** @typedef {function(Array.<createCindy.anyval>, Object):
- *            createCindy.anyval} */
-createCindy.op;
+/** @typedef {function(Array.<CindyJS.anyval>, Object):
+ *            CindyJS.anyval} */
+CindyJS.op;
 
 /** @typedef {{
  *    img: (HTMLImageElement|HTMLCanvasElement|HTMLVideoElement),
@@ -32,30 +32,30 @@ createCindy.op;
  *    drawTo: (undefined|function(CanvasRenderingContext2D,number,number))
  *  }}
  */
-createCindy.image;
+CindyJS.image;
 
 /** @typedef {{
  *    instance: Object,
  *    config: Object,
- *    nada: createCindy.anyval,
- *    evaluate: function(createCindy.anyval):createCindy.anyval,
- *    extractPoint: function(createCindy.anyval):{ok: boolean, x:number, y:number},
- *    evaluateAndVal: function(createCindy.anyval):createCindy.anyval,
- *    defineFunction: function(string,number,createCindy.op),
+ *    nada: CindyJS.anyval,
+ *    evaluate: function(CindyJS.anyval):CindyJS.anyval,
+ *    extractPoint: function(CindyJS.anyval):{ok: boolean, x:number, y:number},
+ *    evaluateAndVal: function(CindyJS.anyval):CindyJS.anyval,
+ *    defineFunction: function(string,number,CindyJS.op),
  *    addShutdownHook: function(function()),
  *    addAutoCleaningEventListener: td.EventManager,
- *    getVariable: function(string):createCindy.anyval,
+ *    getVariable: function(string):CindyJS.anyval,
  *    getInitialMatrix: function():{a:number,b:number,c:number,d:number,
  *      tx:number,ty:number,det:number,sdet:number},
- *    getImage: function((string|createCindy.anyval),boolean=):createCindy.image,
+ *    getImage: function((string|CindyJS.anyval),boolean=):CindyJS.image,
  *    getMyfunction: function(string)
  *  }}
  */
-createCindy.pluginApi;
+CindyJS.pluginApi;
 
 /**
  * @param {number} apiVersion
  * @param {string} pluginName
- * @param {function(createCindy.pluginApi)} initCallback
+ * @param {function(CindyJS.pluginApi)} initCallback
  */
-createCindy.registerPlugin;
+CindyJS.registerPlugin;

--- a/plugins/katex/src/js/katex-plugin.js
+++ b/plugins/katex/src/js/katex-plugin.js
@@ -11,8 +11,8 @@
     var WebFontLoader = null;
     var katex = null;
 
-    createCindy.loadScript("WebFont", "webfont.js", fontLoaderReady);
-    createCindy.loadScript("katex", "katex/katex.min.js", katexReady);
+    CindyJS.loadScript("WebFont", "webfont.js", fontLoaderReady);
+    CindyJS.loadScript("katex", "katex/katex.min.js", katexReady);
 
     function fontLoaderReady() {
         log("WebFontLoader is now available.");
@@ -52,7 +52,7 @@
                   "KaTeX_Size3": "()[]",
                   "KaTeX_Size4": "()[]"
                 },
-                urls: [createCindy.getBaseDir() + "katex/katex.min.css"]
+                urls: [CindyJS.getBaseDir() + "katex/katex.min.css"]
             },
             fontactive: fontActive
         });
@@ -86,7 +86,7 @@
 
     // Plugin API
 
-    createCindy.registerPlugin(1, "katex", plugin);
+    CindyJS.registerPlugin(1, "katex", plugin);
 
     function plugin(api) {
         var storage = {instance: api.instance, cache: {}, misses:0};

--- a/ref/createCindy.md
+++ b/ref/createCindy.md
@@ -6,9 +6,9 @@ This method expects a single object as an argument, which in turn contains vario
 Example:
 
     J CindyJS({ports:[{id:"CindyCanvas"}],
-    J              scripts:"cs*",
-    J              csconsole:null
-    J             });
+    J          scripts:"cs*",
+    J          csconsole:null
+    J         });
 
 ## Parameters
 

--- a/ref/createCindy.md
+++ b/ref/createCindy.md
@@ -1,11 +1,11 @@
 # The public interface to CindyJS
 
-Except for some legacy stuff which is now deprecated, CindyJS exports a single object into the global namespace, which is called `createCindy`.
+Except for some legacy stuff which is now deprecated, CindyJS exports a single object into the global namespace, which is called `CindyJS`.
 This method expects a single object as an argument, which in turn contains various parameters.
 
 Example:
 
-    J createCindy({ports:[{id:"CindyCanvas"}],
+    J CindyJS({ports:[{id:"CindyCanvas"}],
     J              scripts:"cs*",
     J              csconsole:null
     J             });
@@ -183,7 +183,7 @@ If set to `true`, this will cause all previous instances of the application to b
 
 ### plugins
 
-An object providing plugins in addition to those registered by `createCindy.registerPlugin`.
+An object providing plugins in addition to those registered by `CindyJS.registerPlugin`.
 The key is the plugin name, the value a plugin initialization callback.
 
 ### language
@@ -215,7 +215,7 @@ you can enter `°` as `\u00b0` and `π` as `\u03c0`.
 
 ## Instance Methods
 
-The object returned from a call to `createCindy` has a number of methods which may be of use.
+The object returned from a call to `CindyJS` has a number of methods which may be of use.
 
 ### startup
 
@@ -255,16 +255,16 @@ The configuration will be reset to the situation where `play` was invoked.
 
 ## Static Functions
 
-The `createCindy` function has a number of additional functions defined as its members.
+The `CindyJS` function has a number of additional functions defined as its members.
 
 ### newInstance
 
-The `createCindy.newInstance` function behaves mostly like `createCindy` itself, but it will not automatically invoke the `startup` method of the newly created instance.
+The `CindyJS.newInstance` function behaves mostly like `CindyJS` itself, but it will not automatically invoke the `startup` method of the newly created instance.
 Use this in special cases where custom control over startup and shutdown is required.
 
 ### waitFor
 
-The `createCindy.waitFor` function will return a function which can be used as a callback.
+The `CindyJS.waitFor` function will return a function which can be used as a callback.
 Created instances will only be started automatically after all callbacks created in this way have been executed.
 This method must be called in the header of the HTML document, before the `DOMContentLoaded` event has been triggered.
 That is because internally there is one such wait for that event, and once all events have been waited for it is an error to specify additional waiting conditions.

--- a/ref/js/runtests.js
+++ b/ref/js/runtests.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var fs = require("fs"), path = require("path");
-var createCindy = require("../../build/js/Cindy.plain.js");
+var CindyJS = require("../../build/js/Cindy.plain.js");
 
 var refdir = path.dirname(__dirname);
 var println = console.log.bind(console);
@@ -36,7 +36,7 @@ function runTestFile(filename) {
   // println("File: " + filename);
   // println("");
   fakeCanvas = new FakeCanvas();
-  cjs = createCindy({
+  cjs = CindyJS({
     "isNode": true,
     "csconsole": null,
     "canvas": fakeCanvas,

--- a/src/java/cindyjs/quickhull3d/JavaScriptBindings.java
+++ b/src/java/cindyjs/quickhull3d/JavaScriptBindings.java
@@ -19,7 +19,7 @@ public class JavaScriptBindings implements EntryPoint {
     }
 
     private native void register() /*-{
-        $wnd.createCindy.registerPlugin(1, "quickhull3d", function(api) {
+        $wnd.CindyJS.registerPlugin(1, "quickhull3d", function(api) {
             var impl = $entry(@cindyjs.quickhull3d.JavaScriptBindings::convexhull(Lcindyjs/CjsValue;));
             api.defineFunction("convexhull3d", 1, function(args, modifs) {
                 var v0 = api.evaluate(args[0]);

--- a/src/js/Head.js
+++ b/src/js/Head.js
@@ -1,4 +1,4 @@
-var createCindy = (function() {
+var CindyJS = (function() {
             "use strict";
 
             var debugStartup = false;
@@ -43,8 +43,8 @@ var createCindy = (function() {
                 document.addEventListener("DOMContentLoaded", waitFor("DOMContentLoaded"));
             }
 
-            function createCindy(data) {
-                var instance = createCindy.newInstance(data);
+            function CindyJS(data) {
+                var instance = CindyJS.newInstance(data);
                 if (waitCount <= 0) instance.startup();
                 else if (data.autostart !== false) toStart.push(instance);
                 return instance;
@@ -54,7 +54,7 @@ var createCindy = (function() {
             var cindyJsScriptElement = null;
             var waitingForLoad = {};
 
-            createCindy.getBaseDir = function() {
+            CindyJS.getBaseDir = function() {
                 if (baseDir !== null)
                     return baseDir;
                 var scripts = document.getElementsByTagName("script");
@@ -75,9 +75,9 @@ var createCindy = (function() {
                 return baseDir;
             };
 
-            createCindy.addNewScript = function(path, onerror) {
+            CindyJS.addNewScript = function(path, onerror) {
                 if (!onerror) onerror = console.error.bind(console);
-                var baseDir = createCindy.getBaseDir();
+                var baseDir = CindyJS.getBaseDir();
                 if (baseDir === false) {
                     return false;
                 }
@@ -92,7 +92,7 @@ var createCindy = (function() {
                 return elt;
             };
 
-            createCindy.loadScript = function(name, path, onload, onerror) {
+            CindyJS.loadScript = function(name, path, onload, onerror) {
                 if (window[name]) {
                     onload();
                     return true;
@@ -100,7 +100,7 @@ var createCindy = (function() {
                 if (!onerror) onerror = console.error.bind(console);
                 var elt = waitingForLoad[name];
                 if (!elt) {
-                    elt = createCindy.addNewScript(path, onerror);
+                    elt = CindyJS.addNewScript(path, onerror);
                     if (elt === false) {
                         onerror("Can't load additional components.");
                         return false;
@@ -112,18 +112,18 @@ var createCindy = (function() {
                 return null;
             };
 
-            createCindy._autoLoadingPlugin = {};
+            CindyJS._autoLoadingPlugin = {};
 
-            createCindy.autoLoadPlugin = function(name, path, onload) {
-                if (createCindy._pluginRegistry[name]) {
+            CindyJS.autoLoadPlugin = function(name, path, onload) {
+                if (CindyJS._pluginRegistry[name]) {
                     onload();
                     return true;
                 }
-                var listeners = createCindy._autoLoadingPlugin[name];
+                var listeners = CindyJS._autoLoadingPlugin[name];
                 if (!listeners) {
                     if (!path) path = name + "-plugin.js";
-                    listeners = createCindy._autoLoadingPlugin[name] = [];
-                    var elt = createCindy.addNewScript(path);
+                    listeners = CindyJS._autoLoadingPlugin[name] = [];
+                    var elt = CindyJS.addNewScript(path);
                     if (elt === false) {
                         return false;
                     }
@@ -137,24 +137,24 @@ var createCindy = (function() {
                 ctype: 'undefined'
             };
 
-            createCindy.waitFor = waitFor;
-            createCindy._pluginRegistry = {};
-            createCindy.instances = [];
-            createCindy.registerPlugin = function(apiVersion, pluginName, initCallback) {
+            CindyJS.waitFor = waitFor;
+            CindyJS._pluginRegistry = {};
+            CindyJS.instances = [];
+            CindyJS.registerPlugin = function(apiVersion, pluginName, initCallback) {
                 if (apiVersion !== 1) {
                     console.error("Plugin API version " + apiVersion + " not supported");
                     return false;
                 }
-                createCindy._pluginRegistry[pluginName] = initCallback;
-                var listeners = createCindy._autoLoadingPlugin[pluginName] || [];
+                CindyJS._pluginRegistry[pluginName] = initCallback;
+                var listeners = CindyJS._autoLoadingPlugin[pluginName] || [];
                 listeners.forEach(function(callback) {
                     callback();
                 });
             };
-            createCindy.dumpState = function(index) {
+            CindyJS.dumpState = function(index) {
                 // Call this if you find a rendering bug you'd like to reproduce.
                 // The save the printed JSON to a file and include it in your report.
-                var state = createCindy.instances[index || 0].saveState();
+                var state = CindyJS.instances[index || 0].saveState();
                 console.log(JSON.stringify(state));
             };
-            createCindy.newInstance = function(instanceInvocationArguments) {
+            CindyJS.newInstance = function(instanceInvocationArguments) {

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -1,4 +1,4 @@
-var createCindy = this; // since this will be turned into a method
+var CindyJS = this; // since this will be turned into a method
 
 var csconsole;
 var cslib;
@@ -159,9 +159,9 @@ function createCindyNow() {
 
     var data = instanceInvocationArguments;
     if (data.exclusive) {
-        i = createCindy.instances.length;
+        i = CindyJS.instances.length;
         while (i > 0)
-            createCindy.instances[--i].shutdown();
+            CindyJS.instances[--i].shutdown();
     }
 
     if (data.csconsole !== undefined)
@@ -294,7 +294,7 @@ function createCindyNow() {
     if (data.oninit)
         data.oninit(globalInstance);
 
-    createCindy.instances.push(globalInstance);
+    CindyJS.instances.push(globalInstance);
     if (instanceInvocationArguments.use)
         instanceInvocationArguments.use.forEach(function(name) {
             evaluator.use$1([General.wrap(name)], {});
@@ -396,13 +396,13 @@ function loadExtraPlugin(name, path) {
     if (instanceInvocationArguments.plugins)
         cb = instanceInvocationArguments.plugins[name];
     if (!cb)
-        cb = createCindy._pluginRegistry[name];
+        cb = CindyJS._pluginRegistry[name];
     if (cb) {
         evaluator.use$1([General.wrap(name)], {});
         return;
     }
     ++modulesToLoad;
-    createCindy.autoLoadPlugin(name, path, function() {
+    CindyJS.autoLoadPlugin(name, path, function() {
         evaluator.use$1([General.wrap(name)], {});
         doneLoadingModule();
     });
@@ -410,7 +410,7 @@ function loadExtraPlugin(name, path) {
 
 function loadExtraModule(name, path) {
     ++modulesToLoad;
-    createCindy.loadScript(name, path, doneLoadingModule, function() {
+    CindyJS.loadScript(name, path, doneLoadingModule, function() {
         console.error(
             "Failed to load " + path + ", can't start CindyJS instance");
         shutdown();
@@ -519,10 +519,10 @@ function shutdown() {
     // console.log("Shutting down");
 
     // Remove this from the list of all running instances
-    var n = createCindy.instances.length;
+    var n = CindyJS.instances.length;
     while (n > 0) {
-        if (createCindy.instances[--n] === globalInstance) {
-            createCindy.instances.splice(n, 1);
+        if (CindyJS.instances[--n] === globalInstance) {
+            CindyJS.instances.splice(n, 1);
             break;
         }
     }
@@ -538,7 +538,7 @@ function shutdown() {
     }
 }
 
-// The following object will be returned from the public createCindy function.
+// The following object will be returned from the public CindyJS function.
 // Its startup method will be called automatically unless specified otherwise.
 var globalInstance = {
     "config": instanceInvocationArguments,
@@ -566,11 +566,11 @@ if (instanceInvocationArguments.use) {
         if (instanceInvocationArguments.plugins)
             cb = instanceInvocationArguments.plugins[name];
         if (!cb)
-            cb = createCindy._pluginRegistry[name];
+            cb = CindyJS._pluginRegistry[name];
         if (!cb) {
             ++waitForPlugins;
             console.log("Loading script for plugin " + name);
-            createCindy.loadScript(name + "-plugin", name + "-plugin.js", function() {
+            CindyJS.loadScript(name + "-plugin", name + "-plugin.js", function() {
                 console.log("Successfully loaded plugin " + name);
                 if (--waitForPlugins === 0 && startupCalled) createCindyNow();
             }, function() {

--- a/src/js/Tail.js
+++ b/src/js/Tail.js
@@ -1,10 +1,10 @@
     return globalInstance;
     }; // end newInstance method
 
-    return createCindy;
+    return CindyJS;
     })();
     if (typeof process !== "undefined" &&
         typeof module !== "undefined" &&
         typeof module.exports !== "undefined" &&
         typeof window === "undefined")
-        module.exports = createCindy;
+        module.exports = CindyJS;

--- a/src/js/Tail.js
+++ b/src/js/Tail.js
@@ -3,6 +3,7 @@
 
     return CindyJS;
     })();
+    var createCindy = CindyJS; // backwards compatibility, deprecated!
     if (typeof process !== "undefined" &&
         typeof module !== "undefined" &&
         typeof module.exports !== "undefined" &&

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3851,7 +3851,7 @@ evaluator.use$1 = function(args, modifs) {
         if (instanceInvocationArguments.plugins)
             cb = instanceInvocationArguments.plugins[name];
         if (!cb)
-            cb = createCindy._pluginRegistry[name];
+            cb = CindyJS._pluginRegistry[name];
         if (cb) {
             /* The following object constitutes API for third-party plugins.
              * We should feel committed to maintaining this API.
@@ -4423,7 +4423,7 @@ function addTool(name) {
     }
 
     var button = document.createElement("button");
-    button.innerHTML = "<img src='" + createCindy.getBaseDir() + "images/" + name + ".png'>";
+    button.innerHTML = "<img src='" + CindyJS.getBaseDir() + "images/" + name + ".png'>";
     button.onclick = function() {
         if (typeof activeButton !== "undefined") {
             activeButton.style.border = "";

--- a/src/js/libcs/RenderBackends.js
+++ b/src/js/libcs/RenderBackends.js
@@ -864,7 +864,7 @@ globalInstance.exportSVG = function() {
 
 globalInstance.exportPDF = function() {
     var wnd = window.open('about:blank', '_blank');
-    createCindy.loadScript('pako', 'pako.min.js', function() {
+    CindyJS.loadScript('pako', 'pako.min.js', function() {
         exportWith(PdfWriterContext, wnd);
     });
 };

--- a/tests/GeoFuncs_tests.js
+++ b/tests/GeoFuncs_tests.js
@@ -1,7 +1,7 @@
 var should = require("chai").should();
 var rewire = require("rewire");
 
-var createCindy = require("../build/js/Cindy.plain.js");
+var CindyJS = require("../build/js/Cindy.plain.js");
 
 function FakeCanvas() {
   this.width = 640;
@@ -44,7 +44,7 @@ describe("all* operations", function() {
 
     before(function() {
         // See examples/114_allops.html
-        cdy = createCindy({
+        cdy = CindyJS({
             isNode: true,
             csconsole: null,
             canvas: new FakeCanvas(),
@@ -107,7 +107,7 @@ describe("all* operations", function() {
 describe("toString as a name", function() {
 
     before(function() {
-        cdy = createCindy({
+        cdy = CindyJS({
             isNode: true,
             csconsole: null,
             geometry: [
@@ -125,7 +125,7 @@ describe("toString as a name", function() {
 describe("==", function() {
 
     before(function() {
-        cdy = createCindy({
+        cdy = CindyJS({
             isNode: true,
             csconsole: null,
             geometry: [
@@ -144,7 +144,7 @@ describe("==", function() {
 describe("element(‹string›)", function() {
 
     before(function() {
-        cdy = createCindy({
+        cdy = CindyJS({
             isNode: true,
             csconsole: null,
             geometry: [

--- a/tests/GeoOps_tests.js
+++ b/tests/GeoOps_tests.js
@@ -1,7 +1,7 @@
 var should = require("chai").should();
 var rewire = require("rewire");
 
-var createCindy = require("../build/js/Cindy.plain.js");
+var CindyJS = require("../build/js/Cindy.plain.js");
 var cindyJS = rewire("../build/js/exposed.js");
 
 var List = cindyJS.__get__("List");
@@ -61,7 +61,7 @@ function testGeo(geometry, verifier, done) {
     scripts: { init: initscript },
     plugins: { verify: plugin }
   };
-  createCindy(data);
+  CindyJS(data);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/tools/exampleScripts.js
+++ b/tools/exampleScripts.js
@@ -3,8 +3,8 @@
 const fs = require("fs");
 const glob = require("glob");
 const reftests = require("../ref/js/runtests.js");
-const createCindy = require("../build/js/Cindy.js");
-const cdy = createCindy({isNode: true});
+const CindyJS = require("../build/js/Cindy.js");
+const cdy = CindyJS({isNode: true});
 const parse = cdy.parse;
 
 let countdown = 2;

--- a/tools/html2json.js
+++ b/tools/html2json.js
@@ -30,7 +30,7 @@ function addToBuffer(data) {
 
 function transform() {
     var reScript = /<script([^>]*)>([^]*?)<\/script>/ig;
-    var reCindy = /createCindy/;
+    var reCindy = /CindyJS/;
     var reId = /\sid\s*=\s*["']([^"']+)["']/;
     var byId = {};
     var cindys = [];
@@ -48,13 +48,13 @@ function transform() {
     }
     if (cindys.length === 1) {
         var fun = Function(
-            "createCindy", "defaultAppearance", // passed below
+            "CindyJS", "defaultAppearance", // passed below
             "require", "module", // undefined for SOME security
             cindys[0]);
         var params = null, defaultAppearance = {};
         fun(function(arg) { params = arg; }, defaultAppearance);
         if (!params) {
-            console.error("createCindy not called");
+            console.error("CindyJS not called");
             process.exit(1);
         }
         if (params.defaultAppearance === null)
@@ -82,7 +82,7 @@ function transform() {
         console.log(JSON.stringify(params));
     }
     else {
-        console.error(cindys.length + " createCindy invocations found");
+        console.error(cindys.length + " CindyJS invocations found");
         process.exit(1);
     }
 }

--- a/tools/html2json.js
+++ b/tools/html2json.js
@@ -30,7 +30,7 @@ function addToBuffer(data) {
 
 function transform() {
     var reScript = /<script([^>]*)>([^]*?)<\/script>/ig;
-    var reCindy = /CindyJS/;
+    var reCindy = /CindyJS|createCindy/;
     var reId = /\sid\s*=\s*["']([^"']+)["']/;
     var byId = {};
     var cindys = [];
@@ -48,11 +48,12 @@ function transform() {
     }
     if (cindys.length === 1) {
         var fun = Function(
-            "CindyJS", "defaultAppearance", // passed below
+            "CindyJS", "createCindy", "defaultAppearance", // passed below
             "require", "module", // undefined for SOME security
             cindys[0]);
         var params = null, defaultAppearance = {};
-        fun(function(arg) { params = arg; }, defaultAppearance);
+        function dummyCindyJS(arg) { params = arg; }
+        fun(dummyCindyJS, dummyCindyJS, defaultAppearance);
         if (!params) {
             console.error("CindyJS not called");
             process.exit(1);

--- a/tools/reformatCreateCindy.js
+++ b/tools/reformatCreateCindy.js
@@ -3,7 +3,7 @@
 require("./processFiles")(processFileData);
 
 var reScript = /(<script[^>]*>)([^]*?)(<\/script>)/img;
-var reCreateCindy = /CindyJS\(/m;
+var reCreateCindy = /(CindyJS|createCindy)\(/m;
 
 function CindyJSDummy(constr, data) {
     constr.data = data;
@@ -30,10 +30,11 @@ function processFileData(path, str) {
             continue;
         var constr = {attrs: {}};
         var defaultAppearance = {}
+        var dummy = CindyJSDummy.bind(null, constr);
         var f = new Function(
-            "CindyJS", "document", "$", "defaultAppearance",
+            "CindyJS", "createCindy", "document", "$", "defaultAppearance",
             script[2]);
-        f(CindyJSDummy.bind(null, constr),
+        f(dummy, dummy,
           "document", jsQueryDummy.bind(null, constr),
           defaultAppearance);
         var data = constr.data;

--- a/tools/reformatCreateCindy.js
+++ b/tools/reformatCreateCindy.js
@@ -3,9 +3,9 @@
 require("./processFiles")(processFileData);
 
 var reScript = /(<script[^>]*>)([^]*?)(<\/script>)/img;
-var reCreateCindy = /createCindy\(/m;
+var reCreateCindy = /CindyJS\(/m;
 
-function createCindyDummy(constr, data) {
+function CindyJSDummy(constr, data) {
     constr.data = data;
 }
 
@@ -31,9 +31,9 @@ function processFileData(path, str) {
         var constr = {attrs: {}};
         var defaultAppearance = {}
         var f = new Function(
-            "createCindy", "document", "$", "defaultAppearance",
+            "CindyJS", "document", "$", "defaultAppearance",
             script[2]);
-        f(createCindyDummy.bind(null, constr),
+        f(CindyJSDummy.bind(null, constr),
           "document", jsQueryDummy.bind(null, constr),
           defaultAppearance);
         var data = constr.data;
@@ -93,7 +93,7 @@ function processFileData(path, str) {
             });
         }
         var res = myStringify(data, "top");
-        res = "\nvar cdy = createCindy(" + res + ");\n";
+        res = "\nvar cdy = CindyJS(" + res + ");\n";
         if (res === script[2])
             continue;
         str = str.substr(0, script.index) + script[1] + res + script[3] +

--- a/tools/updateSyntax.js
+++ b/tools/updateSyntax.js
@@ -32,14 +32,14 @@ function jsQueryDummy() {
 }
 
 //                   1             123    3 4   45     526   6
-var reCreateCindy = /(createCindy\()((.*\n)?(\s*)([^;]*))(\);)/;
+var reCreateCindy = /(CindyJS\()((.*\n)?(\s*)([^;]*))(\);)/;
 
 function updateDefaultAppearance(path, str) {
     var match = reCreateCindy.exec(str);
     if (!match) {
-        if (str.indexOf("createCindy") === -1)
+        if (str.indexOf("CindyJS") === -1)
             return;
-        throw new Error("No createCindy found");
+        throw new Error("No CindyJS found");
     }
     if (match[2].indexOf("defaultAppearance") >= 0)
         return;
@@ -48,7 +48,7 @@ function updateDefaultAppearance(path, str) {
     start = str.indexOf(">", start) + 1;
     var defaultAppearance = {};
     var f = new Function(
-        "createCindy", "csplay", "defaultAppearance", "document", "$",
+        "CindyJS", "csplay", "defaultAppearance", "document", "$",
         str.substring(start, end)
     );
     f(noop, noop, defaultAppearance, "document", jsQueryDummy);
@@ -73,9 +73,9 @@ function updateEvokeCS(path, str) {
     var orig = str;
     if (!reMethods.test(str))
         return;
-    var match = /(?:var\s+([A-Za-z0-9_]+)\s*=\s*)?createCindy\s*\(/.exec(str);
+    var match = /(?:var\s+([A-Za-z0-9_]+)\s*=\s*)?CindyJS\s*\(/.exec(str);
     if (!match)
-        throw error("No createCindy found");
+        throw error("No CindyJS found");
     var v = match[1];
     if (!v) {
         str = str.substr(0, match.index) + "var cdy = " + str.substr(match.index);

--- a/tools/updateSyntax.js
+++ b/tools/updateSyntax.js
@@ -31,7 +31,7 @@ function jsQueryDummy() {
     };
 }
 
-//                   1             123    3 4   45     526   6
+//                   1         123    3 4   45     526   6
 var reCreateCindy = /(CindyJS\()((.*\n)?(\s*)([^;]*))(\);)/;
 
 function updateDefaultAppearance(path, str) {


### PR DESCRIPTION
This implements #322. It's mostly a bulk rename, but I checked the diff of that rename manually, to make sure it doesn't do anything unintended. Nevertheless, it doesn't hurt if a second person has a look at this, too.

This is not an incompatible change, since the `createCindy` name is preserved for the time being. It's deprecated, though, and should be removed once we can be reasonably sure that all users of that old name have made the transition. Of course we'll need to adapt Cinderella first, to make sure that we won't be creating new uses of this deprecated name.

Some outstanding pull requests and other work in progress may be using the old name. Hopefully the forbidden pattern I introduced into the build system will spot such uses and pervent us from merging the branches in question until they have been adjusted.

The file name `ref/createCindy.md` was preserved for now. In the long run, we might want to change that to something better, but at the moment I don't have a good idea for this yet. The current name is as good as all the other bad ideas I had, so I'll keep it for now.