### PR TITLE
Use latest closure compiler (v20160619)

### DIFF
--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160517",
+        closure_version: "20160619",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",

--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160315",
+        closure_version: "20160517",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",


### PR DESCRIPTION
Among the benefits are ES6 library polyfills that improve transpilation of ES6 to ES5.

See https://github.com/google/closure-compiler/wiki/Releases#may-17-2016-v20160517.