### PR TITLE
Make st a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ There is also [an `examples` directory]
 (https://github.com/CindyJS/CindyJS/tree/master/examples)
 inside the repository, demonstrating individual functions and operations.
 
+Developers can run these examples from their local development copy.
+Some examples may require a webserver-like environment to avoid
+triggering browser security measures associated with local files.
+To do so, one can run <code>npm_modules/.bin/st -nc</code>
+in the root of the development tree, and then visit
+[the local copy of the examples directory](http://127.0.0.1:1337/examples/).
+
 ## Building
 
 If you have `npm` installed, running `npm install`

--- a/examples/katex1.html
+++ b/examples/katex1.html
@@ -42,7 +42,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 <body style="font-family:Arial;">
   <canvas id="CSCanvas" width="500" height="500"
           style="border:2px solid black"></canvas>
-  <p id="nofonts">If you don't see any labels, and are using Firefox, please enable the <a href="http://kb.mozillazine.org/Security.fileuri.strict_origin_policy">security.fileuri.strict_origin_policy setting</a> to allow local access to the required fonts.</p>
+  <p id="nofonts">If you don't see any labels, and are using Firefox, please enable the <a href="http://kb.mozillazine.org/Security.fileuri.strict_origin_policy">security.fileuri.strict_origin_policy setting</a> to allow local access to the required fonts.  Or use the <code>st</code> module to serve the example via HTTP, as described in the README.</p>
 </body>
 
 </html>

--- a/examples/webcam1.html
+++ b/examples/webcam1.html
@@ -31,11 +31,15 @@ var cdy = createCindy({
 <body style="font-family:Arial;">
   <canvas id="CSCanvas" width="804" height="604"
           style="border:2px solid black"></canvas>
-  <p> Note if running from a local machine chromium/chrome are preventing camera access due to security concerns.</p> 
-  <p>You can work around this with "npm install st" followed by "./node_modules/.bin/st -nc".</p>
-  <p> Then visit http://127.0.0.1:1337/examples/webcam1.html.</p>
-  <p> Alternatively, you can also run chrome with the --allow-file-access-from-files flag. </p>
-  <p> This shouldn't be necessary if the example runs on a webserver. </p>
+  <p>
+    Note if running from a local machine Chromium/Chrome are preventing camera access due to security concerns.<br>
+    You can work around this by launching
+    <code>./node_modules/.bin/st -nc</code>
+    and then visiting
+    <a href="http://127.0.0.1:1337/examples/webcam1.html">http://127.0.0.1:1337/examples/webcam1.html</a>.<br>
+    Alternatively, you can also run Chrome with the <code>--allow-file-access-from-files</code> flag.<br>
+    This shouldn't be necessary if the example runs on a webserver.
+  </p>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "rimraf": "^2.4.4",
     "source-map": "^0.5.1",
     "source-map-dummy": "^1.0.0",
+    "st": "^1.1.0",
     "touch": "^1.0.0",
     "unzip": "^0.1.11",
     "whole-line-stream": "^0.1.0"
@@ -49,7 +50,7 @@
   "author": "Jürgen Richter-Gebert <richter@ma.tum.de>",
   "contributors": [
     "Aaron Montag <aaron.montag@tum.de>",
-    "Alexander Elkins",  
+    "Alexander Elkins",
     "Martin von Gagern <gagern@ma.tum.de>",
     "Ulrich Kortenkamp <kortenkamp@cinderella.de>",
     "Stefan Kranich <stefan.kranich@ma.tum.de>",


### PR DESCRIPTION
This makes st a dev dependency, and suggests its use in some appropriate locations: README, KaTeX and Webcam examples.