### PR TITLE
Defer definition of build tasks

### DIFF
--- a/make/Task.js
+++ b/make/Task.js
@@ -20,11 +20,12 @@ module.exports = Task;
 
 /* Constructor for task objects.
  */
-function Task(settings, tasks, name, deps) {
+function Task(settings, tasks, name, deps, definition) {
     this.settings = settings;
     this.tasks = tasks;
     this.name = name;
     this.deps = deps;
+    this.definition = definition;
     this.outputs = [];
     this.inputs = [];
     this.mySettings = {};

--- a/make/Tasks.js
+++ b/make/Tasks.js
@@ -28,17 +28,22 @@ module.exports = function Tasks(settings) {
             throw Error("Invalid arguments for " + name);
         if (tasks.hasOwnProperty(name))
             throw Error("Dulicate name " + name);
-        var res = currentTask = new Task(settings, self, name, deps);
-        if (definition)
-            definition.call(res);
+        var res = new Task(settings, self, name, deps, definition);
         tasks[name] = res;
-        currentTask = null;
         return res;
     };
 
     /* Called when all tasks have been defined.
      */
     this.complete = function() {
+        for (name in tasks) {
+            if (tasks.hasOwnProperty(name)) {
+                currentTask = tasks[name];
+                if (currentTask.definition)
+                    currentTask.definition();
+                currentTask = null;
+            }
+        }
         if (settings.get("logprefix") === "true") {
             var name;
             var len = 0;

--- a/make/Tasks.js
+++ b/make/Tasks.js
@@ -66,6 +66,12 @@ module.exports = function Tasks(settings) {
     this.get = function(name) {
         if(tasks.hasOwnProperty(name))
             return tasks[name];
+        var names = Object.keys(tasks);
+        names.sort();
+        console.log("Valid task names:");
+        names.forEach(function(name) {
+            console.log("- " + name);
+        });
         throw new BuildError("No task named " + name);
     };
 


### PR DESCRIPTION
This allows task definitions to make use of variables defined later in the source code, which allows for less worries while writing build code, e.g. in the context of #355. Furthermore, build targets are printed if an invalid target name is encountered.