### PR TITLE
Added workaround for iPhone/iPad.

### DIFF
--- a/plugins/cindygl/src/js/Init.js
+++ b/plugins/cindygl/src/js/Init.js
@@ -81,8 +81,15 @@ function initGLIfRequired() {
     }
 
     if (navigator.userAgent.match(/(iPad|iPhone)/i)) { //TODO: detect this better by checking wheather building a toy shader fails...
-        console.log("You are  using an iPhone/iPad, hence we will use 8-bit textures.");
+        console.log("You are  using an iPhone/iPad.");
         can_use_texture_float = can_use_texture_half_float = false;
+        if (gl.getExtension('OES_texture_half_float') && gl.getExtension('OES_texture_half_float_linear') && gl.getExtension('EXT_color_buffer_half_float')) {
+            can_use_texture_half_float = true;
+        } else {
+            console.error("Your browser does not suppert writing to half_float textures, we will use 8-bit textures.");
+        }
+
+
     }
 
     isinitialized = true;

--- a/plugins/cindygl/src/js/Init.js
+++ b/plugins/cindygl/src/js/Init.js
@@ -71,7 +71,6 @@ function initGLIfRequired() {
         "webglcontextcreationerror",
         onContextCreationError, false);
 
-
     can_use_texture_float = gl.getExtension('OES_texture_float') && gl.getExtension('OES_texture_float_linear');
     if (!can_use_texture_float) {
         console.error("Your browser does not suppert OES_texture_float, trying OES_texture_half_float...");
@@ -80,5 +79,11 @@ function initGLIfRequired() {
         if (!can_use_texture_half_float)
             console.error("Your browser does not suppert OES_texture_half_float, will use 8-bit textures.");
     }
+
+    if (navigator.userAgent.match(/(iPad|iPhone)/i)) { //TODO: detect this better by checking wheather building a toy shader fails...
+        console.log("You are  using an iPhone/iPad, hence we will use 8-bit textures.");
+        can_use_texture_float = can_use_texture_half_float = false;
+    }
+
     isinitialized = true;
 }


### PR DESCRIPTION
This is a more a fix than a proper solution. In order to deal properly with this situation, one has to build a little toy example for writing to float textures and finding out whether it fails.