### PR TITLE
Allow for mixed case when defining functions

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3842,7 +3842,7 @@ evaluator.javascript$1 = function(args, modifs) {
 
 evaluator.use$1 = function(args, modifs) {
     function defineFunction(name, arity, impl) {
-        evaluator[name + "$" + arity] = impl;
+        evaluator[name.toLowerCase() + "$" + arity] = impl;
     }
     var v0 = evaluate(args[0]);
     if (v0.ctype === "string") {


### PR DESCRIPTION
Function names are case insensitive, and our internal implementations should always make use of the lower case names.  However, it makes sense to allow plugins to write their function names using the case they document for their users.  Particularly for plugins which also support old case-sensitive versions of CindyJS.  So we map to lower case when defining a function.