### PR TITLE
Implement field accessors for the drawtrace property

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ and installed inside the project directory tree.
 One exception is a Java Runtime Environment, which has to be installed before
 (because users have to manually accept the terms and conditions before
 being allowed to download a JRE).
+
 If `npm` resp. `make` terminated successfully, then `build/js` will contain
 the artefacts which you'd likely want to include in your web site.
 If you are building from an official commit, then `make build=release deploy`

--- a/examples/drawtraceField.html
+++ b/examples/drawtraceField.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Toggeling trace drawing dynamically</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+toggle(elt) := (elt.trace = !elt.trace);
+</script>
+<script type="text/javascript">
+
+var gslp = [
+    {name:"A", type:"Free", pos:[-5,0], color:[0,1,1], labeled:true, drawtrace:true},
+    {name:"B", type:"Free", pos:[5,0], color:[1,0,1], labeled:true}
+  ];
+var cdy = createCindy({
+  ports: [{id: "CSCanvas"}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {},
+  geometry: gslp
+});
+
+function toggle(name) {
+  cdy.evokeCS("toggle(" + name + ")");
+}
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <canvas id="CSCanvas" width="500" height="500"
+          style="border:2px solid black"></canvas>
+  <p>
+    <button onclick="toggle('A')">Toggle A</button>
+    <button onclick="toggle('B')">Toggle B</button>
+  </p>
+</body>
+
+</html>

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -13,7 +13,7 @@ Accessor.generalFields = { //Übersetungstafel der Feldnamen
     visible: "visible",
     name: "name",
     caption: "caption",
-    trace: "trace",
+    trace: "",
     tracelength: "",
     selected: ""
 };
@@ -107,6 +107,9 @@ Accessor.getField = function(geo, field) {
             return List.normalizeMax(List.adjoint3(geo.matrix));
         }
     }
+    if (field === "trace") {
+        return General.bool(!!geo.drawtrace);
+    }
 
     if (Accessor.generalFields[field]) { //must be defined an an actual string
         erg = geo[Accessor.generalFields[field]];
@@ -181,6 +184,16 @@ Accessor.setField = function(geo, field, value) {
     }
     if (field === "printlabel") {
         geo.printname = niceprint(value);
+    }
+    if (field === "trace") {
+        if (value.ctype === "boolean") {
+            if (value.value && !geo.drawtrace) {
+                geo.drawtrace = true;
+                setupTraceDrawing(geo);
+            } else {
+                geo.drawtrace = value.value;
+            }
+        }
     }
 
     if (field === "xy" && geo.kind === "P" && geo.movable && List._helper.isNumberVecN(value, 2)) {

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -59,6 +59,15 @@ function csinit(gslp) {
 
 // Setzen der Default appearance
 
+function setupTraceDrawing(el) {
+    if (typeof el.tracedim === "undefined") el.tracedim = 1;
+    if (typeof el.tracelength === "undefined") el.tracelength = 100;
+    if (typeof el.traceskip === "undefined") el.traceskip = 1;
+    el._traces = new Array(el.tracelength);
+    el._traces_index = 0;
+    el._traces_tick = 0;
+}
+
 function pointDefault(el) {
 
     if (el.size === undefined) el.size = defaultAppearance.pointSize;
@@ -73,12 +82,7 @@ function pointDefault(el) {
     el.alpha = CSNumber.real(el.alpha);
 
     if (el.drawtrace) {
-        if (typeof el.tracedim === "undefined") el.tracedim = 1;
-        if (typeof el.tracelength === "undefined") el.tracelength = 100;
-        if (typeof el.traceskip === "undefined") el.traceskip = 1;
-        el._traces = new Array(el.tracelength);
-        el._traces_index = 0;
-        el._traces_tick = 0;
+        setupTraceDrawing(el);
     }
 }
 


### PR DESCRIPTION
The getter was broken, since it did access the wrong property name, and since it failed to convert unset values to boolean false. The setter is completely new, and makes use of a refactored piece of tracing setup code. Disabling and re-enabling tracing will clean all existing traces. This is consistent with what Cinderella does.