### PR TITLE
Dynamic resize

### DIFF
--- a/examples/00_Playground.html
+++ b/examples/00_Playground.html
@@ -20,7 +20,7 @@
 
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/01_sunflower.html
+++ b/examples/01_sunflower.html
@@ -25,7 +25,7 @@
 
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/02_ComplexSpiral.html
+++ b/examples/02_ComplexSpiral.html
@@ -32,7 +32,7 @@
 
 
 
-        <canvas  id="CSCanvas" width=600 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/03_ParabolaEnvelope.html
+++ b/examples/03_ParabolaEnvelope.html
@@ -39,7 +39,7 @@
 
 
 
-        <canvas  id="CSCanvas" width=600 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
             var gslp=[

--- a/examples/04_SimpleGeo.html
+++ b/examples/04_SimpleGeo.html
@@ -33,7 +33,7 @@
 
 
 
-        <canvas  id="CSCanvas" width=600 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/05_SinCaustic.html
+++ b/examples/05_SinCaustic.html
@@ -49,7 +49,7 @@
             </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/06_ConvexHull.html
+++ b/examples/06_ConvexHull.html
@@ -25,7 +25,7 @@
             </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/07_Feldlinien.html
+++ b/examples/07_Feldlinien.html
@@ -43,7 +43,7 @@
 
             </script>
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/07_Feldlinien_newarrows.html
+++ b/examples/07_Feldlinien_newarrows.html
@@ -44,7 +44,7 @@
 
             </script>
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/08_zHochAlpha.html
+++ b/examples/08_zHochAlpha.html
@@ -103,7 +103,7 @@ javascript("document.onkeydown={}");
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/08a_zHochAlpha.html
+++ b/examples/08a_zHochAlpha.html
@@ -150,7 +150,7 @@ drawtext((33,6),"scale");
 </script>
 
 
-<canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/08cont_zHochAlpha.html
+++ b/examples/08cont_zHochAlpha.html
@@ -178,7 +178,7 @@ drawtext((28,1),"gamma="+format(gamma,2));
 </script>
 
 
-<canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/08contb_zHochAlpha.html
+++ b/examples/08contb_zHochAlpha.html
@@ -202,7 +202,7 @@ drawtext((28,1),"γ="+format(gamma,2));
 </script>
 
 
-<canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/08d_zHochAlpha.html
+++ b/examples/08d_zHochAlpha.html
@@ -282,7 +282,7 @@ drawtext((27.5,-2+2),"use asymptotics");
 </script>
 
 
-<canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/09_Regression.html
+++ b/examples/09_Regression.html
@@ -41,7 +41,7 @@
 
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
            	var gslp=[

--- a/examples/100_PointMirror.html
+++ b/examples/100_PointMirror.html
@@ -387,6 +387,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/100_ScreenResolution.html
+++ b/examples/100_ScreenResolution.html
@@ -119,6 +119,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/101_PolarOperations.html
+++ b/examples/101_PolarOperations.html
@@ -49,6 +49,6 @@ var cdy = createCindy({
 </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/102_Slider.html
+++ b/examples/102_Slider.html
@@ -31,8 +31,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="100"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:100px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/103_BadElements.html
+++ b/examples/103_BadElements.html
@@ -26,8 +26,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p>You should see two free points. Unknown operations should be
   automatically removed from the construction, and that fact should be
   logged to the development console.</p>

--- a/examples/104_arcppp.html
+++ b/examples/104_arcppp.html
@@ -40,8 +40,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/104_isOperations.html
+++ b/examples/104_isOperations.html
@@ -115,6 +115,6 @@ var cdy = createCindy({
 </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/104b_arcfill.html
+++ b/examples/104b_arcfill.html
@@ -40,8 +40,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/104c_arc_gslp.html
+++ b/examples/104c_arc_gslp.html
@@ -44,8 +44,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/105_LineWidth.html
+++ b/examples/105_LineWidth.html
@@ -50,7 +50,7 @@ createCindy({csconsole:true,
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
     <p>There should be three times the same figure, consisting of
     a circle, four lines through it, an arc and a polygon.
     All strokes of each figure should have the same width, color and alpha.

--- a/examples/106_DrawTrace1.html
+++ b/examples/106_DrawTrace1.html
@@ -30,6 +30,6 @@ var cdy = createCindy({
         </script>
     </head>
     <body>
-        <canvas id="CSCanvas"></canvas>
+        <div id="CSCanvas"></div>
     </body>
 </html>

--- a/examples/106_DrawTrace2.html
+++ b/examples/106_DrawTrace2.html
@@ -34,6 +34,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/107_Overhang.html
+++ b/examples/107_Overhang.html
@@ -38,6 +38,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/108_DashType.html
+++ b/examples/108_DashType.html
@@ -47,6 +47,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/109_CenterOfConic.html
+++ b/examples/109_CenterOfConic.html
@@ -41,8 +41,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/109_xyAccessors.html
+++ b/examples/109_xyAccessors.html
@@ -64,8 +64,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/110_ConicInSquare.html
+++ b/examples/110_ConicInSquare.html
@@ -42,6 +42,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas><p>Each of the dotted red lines are expected to be tangent to the conic at a single point.</p>
+    <div id="CSCanvas"></div><p>Each of the dotted red lines are expected to be tangent to the conic at a single point.</p>
 </body>
 </html>

--- a/examples/111_Moebius.html
+++ b/examples/111_Moebius.html
@@ -36,8 +36,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/111_Moebius_Arc.html
+++ b/examples/111_Moebius_Arc.html
@@ -37,8 +37,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/111_Moebius_CinderellaExportTest.html
+++ b/examples/111_Moebius_CinderellaExportTest.html
@@ -48,6 +48,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/111_Moebius_It.html
+++ b/examples/111_Moebius_It.html
@@ -79,6 +79,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/111_Moebius_Line.html
+++ b/examples/111_Moebius_Line.html
@@ -33,8 +33,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/111_VeryDegenerateICC.html
+++ b/examples/111_VeryDegenerateICC.html
@@ -30,8 +30,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-    <canvas id="CSCanvas" width="500" height="500"
-            style="border:2px solid black"></canvas>
+    <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
     <p>
       The initial situation shows some <em>very</em> degenerate situation
       for the intersection of two conics, where both the conics involved are

--- a/examples/112_TrAffine.html
+++ b/examples/112_TrAffine.html
@@ -62,6 +62,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/112_TrSimilarity.html
+++ b/examples/112_TrSimilarity.html
@@ -54,6 +54,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/112_TrTranslation.html
+++ b/examples/112_TrTranslation.html
@@ -47,6 +47,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/113_ReflectionInCircle.html
+++ b/examples/113_ReflectionInCircle.html
@@ -52,6 +52,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/113_ReflectionInLine.html
+++ b/examples/113_ReflectionInLine.html
@@ -51,6 +51,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/113_ReflectionInPoint.html
+++ b/examples/113_ReflectionInPoint.html
@@ -51,6 +51,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/113_ReflectionInSegment.html
+++ b/examples/113_ReflectionInSegment.html
@@ -53,6 +53,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/113_ReflectionInThreePointCircle.html
+++ b/examples/113_ReflectionInThreePointCircle.html
@@ -54,6 +54,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/114_ParallelSegments.html
+++ b/examples/114_ParallelSegments.html
@@ -89,6 +89,6 @@ var g,cdy=createCindy({ csconsole:true,
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/114_allops.html
+++ b/examples/114_allops.html
@@ -116,7 +116,7 @@ var cdy = createCindy({
 
 
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
     <br>
                <button onclick="cdy.play()" type="button" >Play</button>
         <button onclick="cdy.pause()" type="button" >Pause</button>

--- a/examples/12_L-System.html
+++ b/examples/12_L-System.html
@@ -63,7 +63,7 @@
 
         </script>
 
-        <canvas  id="CSCanvas" width=600 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/133_TransformC.html
+++ b/examples/133_TransformC.html
@@ -54,6 +54,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/134_LineCap.html
+++ b/examples/134_LineCap.html
@@ -25,8 +25,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/135_LineJoin.html
+++ b/examples/135_LineJoin.html
@@ -25,8 +25,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/136_MiterLimit.html
+++ b/examples/136_MiterLimit.html
@@ -23,8 +23,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/137_FreeLine.html
+++ b/examples/137_FreeLine.html
@@ -23,8 +23,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/138_Through.html
+++ b/examples/138_Through.html
@@ -26,8 +26,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/139_LineHomogSetter.html
+++ b/examples/139_LineHomogSetter.html
@@ -38,8 +38,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/13_PlotSingularity.html
+++ b/examples/13_PlotSingularity.html
@@ -27,7 +27,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/140_radius.html
+++ b/examples/140_radius.html
@@ -26,8 +26,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p>
     <button onclick="cdy.evokeCS('C.radius=3')">r=3</button>
     <button onclick="cdy.evokeCS('C.radius=5')">r=5</button>

--- a/examples/141_fileDrop.html
+++ b/examples/141_fileDrop.html
@@ -48,8 +48,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 

--- a/examples/142_kaleido.html
+++ b/examples/142_kaleido.html
@@ -122,6 +122,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/143_assoc_mult_compare_geoops.html
+++ b/examples/143_assoc_mult_compare_geoops.html
@@ -90,6 +90,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/144_randomtree.html
+++ b/examples/144_randomtree.html
@@ -65,7 +65,7 @@
       drawimage(L, R, "out" + (1-m), alpha -> (1-f));
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         var gslp=[];

--- a/examples/14_ImageSpiral.html
+++ b/examples/14_ImageSpiral.html
@@ -40,7 +40,7 @@
             draw(C,color->(1,0,0));
         </script>
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
 

--- a/examples/15_ProjectiveGrid.html
+++ b/examples/15_ProjectiveGrid.html
@@ -37,7 +37,7 @@
 
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/16_DMSpiral.html
+++ b/examples/16_DMSpiral.html
@@ -32,7 +32,7 @@
 
         </script>
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/17_ShapeOperations.html
+++ b/examples/17_ShapeOperations.html
@@ -39,7 +39,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
 

--- a/examples/18_CompleteGraph.html
+++ b/examples/18_CompleteGraph.html
@@ -27,7 +27,7 @@ n=round(|(B.x+10)*5|);
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
 

--- a/examples/19_EuclidsAlg.html
+++ b/examples/19_EuclidsAlg.html
@@ -105,7 +105,7 @@ A.xy=(a/nn-10,b/nn-10);
         </script>
 
 
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
 
 

--- a/examples/19_EuclidsAlgX.html
+++ b/examples/19_EuclidsAlgX.html
@@ -134,7 +134,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
 
 

--- a/examples/19_EuclidsAlgX2.html
+++ b/examples/19_EuclidsAlgX2.html
@@ -170,7 +170,7 @@ t=t+"$";
         </script>
 
 
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
         <div style="position:absolute; top:200px; left:570px; display:inline;z-index:4">
          <div id="tex" style="font-size: 140%;" ></div>

--- a/examples/20_Pappos.html
+++ b/examples/20_Pappos.html
@@ -19,7 +19,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/21_EulerLine.html
+++ b/examples/21_EulerLine.html
@@ -20,7 +20,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/22_AngleBisector.html
+++ b/examples/22_AngleBisector.html
@@ -19,7 +19,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/23_Mirrors.html
+++ b/examples/23_Mirrors.html
@@ -79,7 +79,7 @@
             prt(seq2,h2,h1);
             </script>
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
 

--- a/examples/24_SimpleTree.html
+++ b/examples/24_SimpleTree.html
@@ -35,7 +35,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/25_Lagrange.html
+++ b/examples/25_Lagrange.html
@@ -36,7 +36,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/26_Kaleido.html
+++ b/examples/26_Kaleido.html
@@ -88,7 +88,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/27_AllpointsAllLines.html
+++ b/examples/27_AllpointsAllLines.html
@@ -21,7 +21,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/28_Schleppkurve.html
+++ b/examples/28_Schleppkurve.html
@@ -132,7 +132,7 @@ connect(pts,color->(1,1,1)*0,size->3);
 </script>
 
 
-<canvas  id="CSCanvas" width="500" height="500" style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 <script>
 

--- a/examples/28b_SchleppkurveTrans.html
+++ b/examples/28b_SchleppkurveTrans.html
@@ -156,7 +156,7 @@ drawtext((-9,-9),"Reset");
 </script>
 
 
-<canvas  id="CSCanvas"  width=500 height=500  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas"  style="width:500px; height:500px; border:2px solid #000000"></div>
 
 <script>
 

--- a/examples/28c_Antiprism.html
+++ b/examples/28c_Antiprism.html
@@ -113,7 +113,7 @@ drawtext((-9,-2.5),"Move F, F1, F2, F3",size->18);
 </script>
 
 
-<canvas  id="CSCanvas" width="800" height="500"  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
 <script>
 

--- a/examples/29_fact.html
+++ b/examples/29_fact.html
@@ -87,7 +87,7 @@
             </script>
 
 
-        <canvas  id="CSCanvas" width="500" height="500"  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script>
 

--- a/examples/30_C-Test.html
+++ b/examples/30_C-Test.html
@@ -331,7 +331,7 @@ drawing();
 
 
 <div onkeyup="displayunicode(event)">
-        <canvas  id="CSCanvas" width="700" height="500"  style="border:2px solid #000000" ></canvas>
+        <div  id="CSCanvas" style="width:700px; height:500px; border:2px solid #000000" ></div>
 </div>
         <script>
 

--- a/examples/31_EventTest.html
+++ b/examples/31_EventTest.html
@@ -66,7 +66,7 @@
 
 
 <div onkeyup="displayunicode(event)">
-        <canvas  id="CSCanvas" width="700" height="500"  style="border:2px solid #000000" ></canvas>
+        <div  id="CSCanvas" style="width:700px; height:500px; border:2px solid #000000" ></div>
 </div>
         <script>
 

--- a/examples/34_Suns.html
+++ b/examples/34_Suns.html
@@ -36,7 +36,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/34_SunsT.html
+++ b/examples/34_SunsT.html
@@ -37,7 +37,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/35_Springs.html
+++ b/examples/35_Springs.html
@@ -26,7 +26,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/36_Springs2.html
+++ b/examples/36_Springs2.html
@@ -26,7 +26,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/37_Bouncer.html
+++ b/examples/37_Bouncer.html
@@ -32,7 +32,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/38_ManyParticles.html
+++ b/examples/38_ManyParticles.html
@@ -24,7 +24,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/39_ManyBalls.html
+++ b/examples/39_ManyBalls.html
@@ -63,7 +63,7 @@ mat=mmmx*mmmy*mat;
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/39_ManyBallsExplorer.html
+++ b/examples/39_ManyBallsExplorer.html
@@ -174,7 +174,7 @@ forall(pairs,s,
         </script>
 
 
-        <canvas  id="CSCanvas" width=870 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:870px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/39_ManyBallsX.html
+++ b/examples/39_ManyBallsX.html
@@ -27,7 +27,7 @@ masses=allmasses();
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/39_ManyBallsY.html
+++ b/examples/39_ManyBallsY.html
@@ -40,7 +40,7 @@ forall(pairs,s,
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/39_ManyBalls_1_1.html
+++ b/examples/39_ManyBalls_1_1.html
@@ -38,7 +38,7 @@ forall(pairs,s,
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/39_ManyBalls_1_2.html
+++ b/examples/39_ManyBalls_1_2.html
@@ -38,7 +38,7 @@ forall(pairs,s,
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/39_ManyBalls_1_3_a.html
+++ b/examples/39_ManyBalls_1_3_a.html
@@ -38,7 +38,7 @@ forall(pairs,s,
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/40_Swarm.html
+++ b/examples/40_Swarm.html
@@ -56,7 +56,7 @@ drawimage(p,"fishb",angle->ang,scale->sizes_#*.3,alpha->1-colors_#);
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/40_SwarmExplorer.html
+++ b/examples/40_SwarmExplorer.html
@@ -123,7 +123,7 @@ drawtext(T+(0,.7),format(anz,0),size->14);
         </script>
 
 
-        <canvas  id="CSCanvas" width=850 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:850px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/40_SwarmExplorerX.html
+++ b/examples/40_SwarmExplorerX.html
@@ -87,7 +87,7 @@ L.v=(0,0);
         </script>
 
 
-        <canvas  id="CSCanvas" width=850 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:850px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/50_ConvexHull3D.html
+++ b/examples/50_ConvexHull3D.html
@@ -179,7 +179,7 @@ nn=nn/|nn|;
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/51_Archimedean.html
+++ b/examples/51_Archimedean.html
@@ -417,7 +417,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
         </script>
 
-        <canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/51_ArchimedeanX.html
+++ b/examples/51_ArchimedeanX.html
@@ -372,7 +372,7 @@ drawtext(spos2-(.5,.7),5,size->45);
         </script>
 
 
-        <canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/52_Rays.html
+++ b/examples/52_Rays.html
@@ -127,7 +127,7 @@ while(count<n & !stop,
         </script>
 
 
-        <canvas  id="CSCanvas" width=700 height=700  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:700px; height:700px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/54_Soddy1.html
+++ b/examples/54_Soddy1.html
@@ -133,7 +133,7 @@ drawlie(ce,(0,0,0),3);
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/55_Soddy2.html
+++ b/examples/55_Soddy2.html
@@ -343,7 +343,7 @@ translate(-(off+Pos.xy-loc));
         </script>
 
 
-        <canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/56_Ford.html
+++ b/examples/56_Ford.html
@@ -354,7 +354,7 @@ apply(seq,f,ff=f*zoom*2;
         </script>
 
 
-        <canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
         <br>
         <br>
         <br>

--- a/examples/57_SnapAndGrid.html
+++ b/examples/57_SnapAndGrid.html
@@ -20,7 +20,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/58_Interpolation.html
+++ b/examples/58_Interpolation.html
@@ -72,7 +72,7 @@ plot[x^3*a_9+x^2*a_10+x*a_11+a_12,start->3,stop->4,size->3];
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/59_Equilibrium.html
+++ b/examples/59_Equilibrium.html
@@ -93,7 +93,7 @@ renderEq(inpa, inpb, inpc);
         <script type="text/javascript">
         </script>
         <div style="position:relative">
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;position:absolute; top:0px; left:0px;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;position:absolute; top:0px; left:0px;"></div>
 <div style="position:absolute; top:80px; left:450px; display:inline;z-index:4">
          <div id="tex" style="font-size: 110%;" ></div>
 </div>

--- a/examples/60_Rotation.html
+++ b/examples/60_Rotation.html
@@ -151,7 +151,7 @@ if (b==0,pb="+0";mb="+0");
         </script>
 
         <div style="position:relative">
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;position:absolute; top:0px; left:0px;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;position:absolute; top:0px; left:0px;"></div>
 <div style="position:absolute; top:400px; left:30px; display:inline;z-index:4">
 </div>
 </div>

--- a/examples/62_ProjTransform.html
+++ b/examples/62_ProjTransform.html
@@ -54,6 +54,6 @@ createCindy({
 });
 </script>
 <body>
-<canvas id="CSCanvas" width="500" height="500" style="border:2px solid black"></canvas>
+<div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 </html>

--- a/examples/63_Conic.html
+++ b/examples/63_Conic.html
@@ -22,7 +22,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/63_Conic_from_Script.html
+++ b/examples/63_Conic_from_Script.html
@@ -57,8 +57,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/63_PizzaTeilen.html
+++ b/examples/63_PizzaTeilen.html
@@ -79,7 +79,7 @@
 
 
 
-        <canvas  id="CSCanvas" width=700 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:700px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/63_PointLabels.html
+++ b/examples/63_PointLabels.html
@@ -23,6 +23,6 @@ createCindy({
 });
 </script>
 <body>
-<canvas id="CSCanvas" width="482" height="133" style="border:2px solid black; background: #a8b0c0"></canvas>
+<div id="CSCanvas" style="width:482px; height:133px; border:2px solid black; background: #a8b0c0"></div>
 </body>
 </html>

--- a/examples/64_Many_Conics.html
+++ b/examples/64_Many_Conics.html
@@ -18,7 +18,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/65_Conic_4P_1l.html
+++ b/examples/65_Conic_4P_1l.html
@@ -18,7 +18,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/65a_Conic_3P_2l.html
+++ b/examples/65a_Conic_3P_2l.html
@@ -37,8 +37,7 @@ createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/65b_Conic_2P_3l.html
+++ b/examples/65b_Conic_2P_3l.html
@@ -37,8 +37,7 @@ createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/65c_Conic_2P_3l.html
+++ b/examples/65c_Conic_2P_3l.html
@@ -53,8 +53,7 @@ createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/66_Conic_5lines.html
+++ b/examples/66_Conic_5lines.html
@@ -18,7 +18,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/67_Conic_1P_4l.html
+++ b/examples/67_Conic_1P_4l.html
@@ -18,7 +18,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/68_Surface1.html
+++ b/examples/68_Surface1.html
@@ -515,7 +515,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68_Surface2.html
+++ b/examples/68_Surface2.html
@@ -516,7 +516,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68_Surface3.html
+++ b/examples/68_Surface3.html
@@ -516,7 +516,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68_Surface4.html
+++ b/examples/68_Surface4.html
@@ -663,7 +663,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68_Surface5.html
+++ b/examples/68_Surface5.html
@@ -1285,7 +1285,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68_Surface6.html
+++ b/examples/68_Surface6.html
@@ -663,7 +663,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68_Surface7.html
+++ b/examples/68_Surface7.html
@@ -500,7 +500,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68_Surface8.html
+++ b/examples/68_Surface8.html
@@ -256,7 +256,7 @@ mmmy=[
 mat=mmmx*mmmy*mat;
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68a_MixedSurfaces.html
+++ b/examples/68a_MixedSurfaces.html
@@ -1203,7 +1203,7 @@ drawtext(T1-(1,1),size->16,"alpha");
 
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/68b_MixedSurfaces.html
+++ b/examples/68b_MixedSurfaces.html
@@ -2583,7 +2583,7 @@ drawtext(T1-(1,1),size->16,"alpha");
 
 </script>
 
-<canvas  id="CSCanvas" width=800 height=600  style="border:2px solid #000000"></canvas>
+<div  id="CSCanvas" style="width:800px; height:600px; border:2px solid #000000"></div>
 
 <script type="text/javascript">
 

--- a/examples/69_Intersection_Conic_Conic.html
+++ b/examples/69_Intersection_Conic_Conic.html
@@ -18,7 +18,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/69_tracing4.html
+++ b/examples/69_tracing4.html
@@ -15,7 +15,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/69_tracing4_many.html
+++ b/examples/69_tracing4_many.html
@@ -15,7 +15,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/70_DownClock.html
+++ b/examples/70_DownClock.html
@@ -71,7 +71,7 @@ drawtext((1,-8.5),"Reset",size->30);
         </script>
 
 
-        <canvas  id="CSCanvas" width=800 height=500 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/70_TwoInstances.html
+++ b/examples/70_TwoInstances.html
@@ -16,7 +16,7 @@
         draw(p,size->sqrt(i)*.4,color->hue(i/34));
       );
     </script>
-    <canvas  id="sunflowerCanvas" width="500" height="500" style="border:2px solid #000000"></canvas>
+    <div  id="sunflowerCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
     <script type="text/javascript">
       createCindy({
@@ -31,7 +31,7 @@
 
     <h1>CindyJS: Complex Spiral</h1>
 
-    <canvas id="spiral" width="600" height="600" style="border:2px solid #000000"></canvas>
+    <div id="spiral" style="width:600px; height:600px; border:2px solid #000000"></div>
 
     <script type="text/javascript">
 var gslp=[

--- a/examples/71_InstanceSwappingExclusive.html
+++ b/examples/71_InstanceSwappingExclusive.html
@@ -47,6 +47,6 @@
     <h1>CindyJS: Swapping between instances</h1>
     <p><a href="javascript:sunflower()">Sunflower</a>
     <a href="javascript:spiral()">Spiral</a></p>
-    <canvas id="canvas" width="600" height="600" style="border:2px solid #000000"></canvas>
+    <div id="canvas" style="width:600px; height:600px; border:2px solid #000000"></div>
   </body>
 </html>

--- a/examples/74_CSad_exp_div_x.html
+++ b/examples/74_CSad_exp_div_x.html
@@ -36,7 +36,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
 
 
         </script>
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;"></div>
         <script type="text/javascript">
 
             var gslp=[

--- a/examples/74_CSad_quadratic.html
+++ b/examples/74_CSad_quadratic.html
@@ -34,7 +34,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
 
 
         </script>
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;"></div>
         <script type="text/javascript">
 
             var gslp=[

--- a/examples/74_CSad_rational.html
+++ b/examples/74_CSad_rational.html
@@ -37,7 +37,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
 
         </script>
 
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;"></div>
         <script type="text/javascript">
 
             var gslp=[

--- a/examples/74_CSad_root.html
+++ b/examples/74_CSad_root.html
@@ -35,7 +35,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
 
         </script>
 
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;"></div>
         <script type="text/javascript">
 
             var gslp=[

--- a/examples/74_CSad_sin.html
+++ b/examples/74_CSad_sin.html
@@ -33,7 +33,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
 
 
         </script>
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;"></div>
         <script type="text/javascript">
 
             var gslp=[

--- a/examples/74_CSad_sin_div_x.html
+++ b/examples/74_CSad_sin_div_x.html
@@ -39,7 +39,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
 
         </script>
 
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;"></div>
         <script type="text/javascript">
 
             var gslp=[

--- a/examples/74_CSad_sincos.html
+++ b/examples/74_CSad_sincos.html
@@ -33,7 +33,7 @@ draw([[a_i,erg_i_j],[a_(i+1), erg_(i+1)_j]]);
 
 
         </script>
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000;"></div>
         <script type="text/javascript">
 
             var gslp=[

--- a/examples/74_Focus.html
+++ b/examples/74_Focus.html
@@ -50,7 +50,7 @@
   <body style="font-family:Arial;">
     <h1>CindyJS: Focus behavior</h1>
     <div>
-      <canvas  id="CSCanvas" width="500" height="500" tabindex="0"></canvas>
+      <div  id="CSCanvas" style="width:500px; height:500px;" tabindex="0"></div>
     </div>
     <p>Text: <input type="text"></p>
   </body>

--- a/examples/75_DrawModifs.html
+++ b/examples/75_DrawModifs.html
@@ -178,7 +178,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 </head>
 
 <body>
-  <canvas id="CSCanvas" width="640" height="480" style="border:1px solid black"></canvas>
+  <div id="CSCanvas" style="width:640px; height:480px; border:1px solid black"></div>
 </body>
 
 </html>

--- a/examples/76_I18n.html
+++ b/examples/76_I18n.html
@@ -39,12 +39,10 @@ createCindy({
 
 <body style="font-family:Arial;">
   <pre>
-    <canvas id="enCindy" width="500" height="200"
-            style="border:2px solid black"></canvas>
+    <div id="enCindy" style="width:500px; height:200px; border:2px solid black"></div>
   </pre>
   <pre>
-    <canvas id="deCindy" width="500" height="200"
-            style="border:2px solid black"></canvas>
+    <div id="deCindy" style="width:500px; height:200px; border:2px solid black"></div>
   </pre>
 </body>
 

--- a/examples/77_Plurals.html
+++ b/examples/77_Plurals.html
@@ -42,12 +42,10 @@ createCindy({
 
 <body style="font-family:Arial;">
   <pre>
-    <canvas id="enCindy" width="500" height="300"
-            style="border:2px solid black"></canvas>
+    <div id="enCindy" style="width:500px; height:300px; border:2px solid black"></div>
   </pre>
   <pre>
-    <canvas id="deCindy" width="500" height="300"
-            style="border:2px solid black"></canvas>
+    <div id="deCindy" style="width:500px; height:300px; border:2px solid black"></div>
   </pre>
 </body>
 

--- a/examples/78_Yahtzee.html
+++ b/examples/78_Yahtzee.html
@@ -160,8 +160,7 @@ var cdy = createCindy({
 <body style="font-family:Arial;">
   <p>Based on <a href="http://uva.onlinejudge.org/external/101/10149.pdf">this
       problem</a>.</p>
-  <canvas id="CSCanvas" width="700" height="700"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:700px; height:700px; border:2px solid black"></div>
   <p>Use number keys to enter dice, or click die to modify it.</p>
   <p><button onclick="cdy.evokeCS('dice=example2;recompute()')" type="button">Example 2</button></p>
 </body>

--- a/examples/79_Couples.html
+++ b/examples/79_Couples.html
@@ -95,8 +95,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p><button onclick="cdy.evokeCS('randomize()')" type="button">Randomize</button></p>
 </body>
 

--- a/examples/80_Conic_by_2Foci_1P.html
+++ b/examples/80_Conic_by_2Foci_1P.html
@@ -44,8 +44,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/81_Clock.html
+++ b/examples/81_Clock.html
@@ -47,8 +47,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/81_Polar.html
+++ b/examples/81_Polar.html
@@ -18,7 +18,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/81_Polar_angular_bisect.html
+++ b/examples/81_Polar_angular_bisect.html
@@ -18,7 +18,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=600 height=600 style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
 
         <script type="text/javascript">

--- a/examples/81_Wait.html
+++ b/examples/81_Wait.html
@@ -39,8 +39,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/82_angle_bisector.html
+++ b/examples/82_angle_bisector.html
@@ -50,8 +50,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/85_Createimage.html
+++ b/examples/85_Createimage.html
@@ -68,8 +68,7 @@ createCindy({
 
 <body style="font-family:Arial;">
   <pre>
-    <canvas id="cindy" width="500" height="500"
-            style="border:2px solid black"></canvas>
+    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
   </pre>
 </body>
 

--- a/examples/85a_CreateimageAff.html
+++ b/examples/85a_CreateimageAff.html
@@ -70,8 +70,7 @@ createCindy({
 
 <body style="font-family:Arial;">
   <pre>
-    <canvas id="cindy" width="500" height="500"
-            style="border:2px solid black"></canvas>
+    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
   </pre>
 </body>
 

--- a/examples/86_IFS.html
+++ b/examples/86_IFS.html
@@ -90,8 +90,7 @@ createCindy({
 
 <body style="font-family:Arial;">
   <pre>
-    <canvas id="cindy" width="500" height="500"
-            style="border:2px solid black"></canvas>
+    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
   </pre>
 </body>
 

--- a/examples/87_IFSIm.html
+++ b/examples/87_IFSIm.html
@@ -138,8 +138,7 @@ createCindy({
 
 <body style="font-family:Arial;">
   <pre>
-    <canvas id="cindy" width="500" height="500"
-            style="border:2px solid black"></canvas>
+    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
   </pre>
 </body>
 

--- a/examples/87_IFSIm2.html
+++ b/examples/87_IFSIm2.html
@@ -110,8 +110,7 @@ createCindy({
 
 <body style="font-family:Arial;">
   <pre>
-    <canvas id="cindy" width="500" height="500"
-            style="border:2px solid black"></canvas>
+    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
   </pre>
 </body>
 

--- a/examples/88_Eigenvalues.html
+++ b/examples/88_Eigenvalues.html
@@ -406,6 +406,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/88_LA_Tests.html
+++ b/examples/88_LA_Tests.html
@@ -73,7 +73,7 @@
 
 
         <div style="position:relative">
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000; top:0px; left:0px;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000; top:0px; left:0px;"></div>
 </div>
 
         <script type="text/javascript">

--- a/examples/88_QR.html
+++ b/examples/88_QR.html
@@ -124,7 +124,7 @@ println(|AA*transpose(kernel(AA))_1|)
 
 
         <div style="position:relative">
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000; top:0px; left:0px;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000; top:0px; left:0px;"></div>
 </div>
 
         <script type="text/javascript">

--- a/examples/88_TracingVis1.html
+++ b/examples/88_TracingVis1.html
@@ -81,10 +81,8 @@ forall(log, mouseAndScripts,
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas1" width="500" height="500"
-          style="border:2px solid black"></canvas>
-  <canvas id="CSCanvas2" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas1" style="width:500px; height:500px; border:2px solid black"></div>
+  <div id="CSCanvas2" style="width:500px; height:500px; border:2px solid black"></div>
   <p>
     <button onclick="location.href=cdy1.formatTraceLog(false)">View log</button>
     <button onclick="location.href=cdy1.formatTraceLog(true)">Save log</button>

--- a/examples/88_TracingVis2.html
+++ b/examples/88_TracingVis2.html
@@ -113,10 +113,8 @@ if(tracingX_6 >0.001,CCost.xy=[0, scale*3*tracingX_6],);
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas1" width="500" height="500"
-          style="border:2px solid black"></canvas>
-  <canvas id="CSCanvas2" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas1" style="width:500px; height:500px; border:2px solid black"></div>
+  <div id="CSCanvas2" style="width:500px; height:500px; border:2px solid black"></div>
   <p>
     <button onclick="location.href=cdy1.formatTraceLog(false)">View log</button>
     <button onclick="location.href=cdy1.formatTraceLog(true)">Save log</button>

--- a/examples/88_Vectorfield.html
+++ b/examples/88_Vectorfield.html
@@ -108,8 +108,7 @@ createCindy({
 
 <body style="font-family:Arial;">
   <pre>
-    <canvas id="cindy" width="500" height="500"
-            style="border:2px solid black"></canvas>
+    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
   </pre>
 </body>
 

--- a/examples/89_MousePos.html
+++ b/examples/89_MousePos.html
@@ -29,8 +29,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:20px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:20px solid black"></div>
 </body>
 
 </html>

--- a/examples/90_Tracing1.html
+++ b/examples/90_Tracing1.html
@@ -35,8 +35,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p>
     <button onclick="location.href=cdy.formatTraceLog(false)">View log</button>
     <button onclick="location.href=cdy.formatTraceLog(true)">Save log</button>

--- a/examples/90_Tracing2.html
+++ b/examples/90_Tracing2.html
@@ -28,8 +28,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p>
     <button onclick="location.href=cdy.formatTraceLog(false)">View log</button>
     <button onclick="location.href=cdy.formatTraceLog(true)">Save log</button>

--- a/examples/90_Tracing3.html
+++ b/examples/90_Tracing3.html
@@ -37,8 +37,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="543" height="424"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:543px; height:424px; border:2px solid black"></div>
   <p>
     <button onclick="location.href=cdy.formatTraceLog(false)">View log</button>
     <button onclick="location.href=cdy.formatTraceLog(true)">Save log</button>

--- a/examples/90_Tracing4.html
+++ b/examples/90_Tracing4.html
@@ -39,8 +39,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p>
     <button onclick="location.href=cdy.formatTraceLog(false)">View log</button>
     <button onclick="location.href=cdy.formatTraceLog(true)">Save log</button>

--- a/examples/90_Tracing5.html
+++ b/examples/90_Tracing5.html
@@ -47,8 +47,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p>
     <button onclick="location.href=cdy.formatTraceLog(false)">View log</button>
     <button onclick="location.href=cdy.formatTraceLog(true)">Save log</button>

--- a/examples/96_OtherIntersection.html
+++ b/examples/96_OtherIntersection.html
@@ -293,6 +293,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/97_OtherIntersectionCL.html
+++ b/examples/97_OtherIntersectionCL.html
@@ -152,7 +152,7 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>
 

--- a/examples/98_Compass.html
+++ b/examples/98_Compass.html
@@ -130,6 +130,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/99_LineMirror.html
+++ b/examples/99_LineMirror.html
@@ -513,6 +513,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/Bastelbogen.html
+++ b/examples/Bastelbogen.html
@@ -257,8 +257,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="850" height="600"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:850px; height:600px; border:2px solid black"></div>
  <button onclick="cdy.exportSVG()" type="button" >SVG</button>
         <button onclick="cdy.exportPDF()" type="button" >PDF</button>
 </body>

--- a/examples/ConstructionConicFromPrincipalDirections.html
+++ b/examples/ConstructionConicFromPrincipalDirections.html
@@ -37,6 +37,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/ConstructionFreeLine.html
+++ b/examples/ConstructionFreeLine.html
@@ -32,6 +32,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/ConstructionHorizontalAndVerticalLines.html
+++ b/examples/ConstructionHorizontalAndVerticalLines.html
@@ -33,6 +33,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/ConstructionLineByFixedAngle.html
+++ b/examples/ConstructionLineByFixedAngle.html
@@ -36,6 +36,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/ConstructionParabolaPL.html
+++ b/examples/ConstructionParabolaPL.html
@@ -36,6 +36,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/ConstructionRadicalAxisApart-complex.html
+++ b/examples/ConstructionRadicalAxisApart-complex.html
@@ -39,6 +39,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/Life2.html
+++ b/examples/Life2.html
@@ -88,8 +88,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="705" height="507"
-          style="border:2px solid black; background-color:rgb(168,176,192)"></canvas>
+  <div id="CSCanvas" style="width:705px; height:507px; border:2px solid black; background-color:rgb(168,176,192)"></div>
   <p>
     <button onclick="cdy.play()" type="button">Play</button>
     <button onclick="cdy.stop()" type="button">Stop</button>

--- a/examples/Life2a.html
+++ b/examples/Life2a.html
@@ -71,8 +71,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="705" height="507"
-          style="border:2px solid black; background-color:rgb(168,176,192)"></canvas>
+  <div id="CSCanvas" style="width:705px; height:507px; border:2px solid black; background-color:rgb(168,176,192)"></div>
   <p>
     <button onclick="cdy.play()" type="button">Play</button>
     <button onclick="cdy.stop()" type="button">Stop</button>

--- a/examples/Life2b.html
+++ b/examples/Life2b.html
@@ -71,8 +71,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="705" height="507"
-          style="border:2px solid black; background-color:rgb(168,176,192)"></canvas>
+  <div id="CSCanvas" style="width:705px; height:507px; border:2px solid black; background-color:rgb(168,176,192)"></div>
   <p>
     <button onclick="cdy.play()" type="button">Play</button>
     <button onclick="cdy.stop()" type="button">Stop</button>

--- a/examples/Parabel.html
+++ b/examples/Parabel.html
@@ -95,7 +95,7 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas" style="border:2px solid #000000" ></canvas>
+    <div id="CSCanvas" style="border:2px solid #000000" ></div>
 
 </body>
 </html>

--- a/examples/RegressionTests/86_ScriptCoSy.html
+++ b/examples/RegressionTests/86_ScriptCoSy.html
@@ -31,8 +31,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p>The three yellow dots should be horizontally aligned. Don't expect anything movable.</p>
 </body>
 

--- a/examples/Text1.html
+++ b/examples/Text1.html
@@ -58,6 +58,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/arrow_playground.html
+++ b/examples/arrow_playground.html
@@ -85,7 +85,7 @@ draw(H,K,size->2,alpha->0.5, arrow->true, arrowshape->"full", arrowsides->"==>",
 
 
         <div style="position:relative">
-        <canvas  id="CSCanvas" width=800 height=500  style="border:2px solid #000000; top:0px; left:0px;"></canvas>
+        <div  id="CSCanvas" style="width:800px; height:500px; border:2px solid #000000; top:0px; left:0px;"></div>
 </div>
 
         <script type="text/javascript">

--- a/examples/bugs/0259a_ChromeArc.html
+++ b/examples/bugs/0259a_ChromeArc.html
@@ -31,7 +31,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="border:2px solid black"></div>
   <p>Chrome in HiDPI mode used to draw the two large circles as
     rotated squares until we changed the linejoin to miter and closed
     the path.</p>

--- a/examples/cassin.html
+++ b/examples/cassin.html
@@ -15,10 +15,10 @@
 
 
 <div style="position:relative">
-<canvas  id="CSCanvasB" width=500 height=500  style="border:2px solid #000000;position:absolute; top:0px; left:0px; z-index:1"></canvas>
+<div  id="CSCanvasB" style="width:500px; height:500px; border:2px solid #000000;position:absolute; top:0px; left:0px; z-index:1"></div>
 
 
-<canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000;position:absolute; top:0px; left:0px;z-index:2"></canvas>
+<div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000;position:absolute; top:0px; left:0px;z-index:2"></div>
 
 </div>
 

--- a/examples/cindy3d/01_ThreeSpheres.html
+++ b/examples/cindy3d/01_ThreeSpheres.html
@@ -23,7 +23,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/02_Torus.html
+++ b/examples/cindy3d/02_Torus.html
@@ -29,7 +29,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/03_Rod.html
+++ b/examples/cindy3d/03_Rod.html
@@ -20,7 +20,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/04_Torus.html
+++ b/examples/cindy3d/04_Torus.html
@@ -32,7 +32,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/05_FishEye.html
+++ b/examples/cindy3d/05_FishEye.html
@@ -34,7 +34,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/06_DrawPoly.html
+++ b/examples/cindy3d/06_DrawPoly.html
@@ -27,7 +27,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/07_Quad.html
+++ b/examples/cindy3d/07_Quad.html
@@ -20,7 +20,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/08_EnneperWithDots.html
+++ b/examples/cindy3d/08_EnneperWithDots.html
@@ -36,7 +36,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/09_EnneperWithDotsSS.html
+++ b/examples/cindy3d/09_EnneperWithDotsSS.html
@@ -36,7 +36,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/10_EnneperWithDotsLights.html
+++ b/examples/cindy3d/10_EnneperWithDotsLights.html
@@ -39,7 +39,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/11_EnneperWithLights.html
+++ b/examples/cindy3d/11_EnneperWithLights.html
@@ -40,7 +40,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/12_Polygons.html
+++ b/examples/cindy3d/12_Polygons.html
@@ -21,7 +21,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
   <p>Polygons should look smooth even if they are in fact bent.</p>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/13_Cylinder.html
+++ b/examples/cindy3d/13_Cylinder.html
@@ -23,7 +23,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/14_Cylinder2.html
+++ b/examples/cindy3d/14_Cylinder2.html
@@ -23,7 +23,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/15_Torus.html
+++ b/examples/cindy3d/15_Torus.html
@@ -29,7 +29,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/16_Interaction.html
+++ b/examples/cindy3d/16_Interaction.html
@@ -26,7 +26,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*",  geometry:gslp});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="400" height="400" style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:400px; height:400px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/16_MeshNormals.html
+++ b/examples/cindy3d/16_MeshNormals.html
@@ -42,7 +42,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/17_ColorsMesh.html
+++ b/examples/cindy3d/17_ColorsMesh.html
@@ -30,7 +30,7 @@ createCindy({canvasname:"CSCanvas",scripts:"cs*"});
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
-  <canvas id="CSCanvas" width="50" height="50" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindy3d/68_Surface1.html
+++ b/examples/cindy3d/68_Surface1.html
@@ -466,7 +466,7 @@ end3d();
 
 </script>
 
-<canvas  id="CSCanvas" width=8 height=6  style="border:none"></canvas>
+<div  id="CSCanvas" style="width:8px; height:6px; border:none"></div>
   <canvas id="Cindy3D" style="border:2px solid #000000" width="800" height="600"></canvas>
 
 <script type="text/javascript">

--- a/examples/cindy3d/68_Surface2.html
+++ b/examples/cindy3d/68_Surface2.html
@@ -466,7 +466,7 @@ end3d();
 
 </script>
 
-<canvas  id="CSCanvas" width=8 height=6  style="border:none"></canvas>
+<div  id="CSCanvas" style="width:8px; height:6px; border:none"></div>
   <canvas id="Cindy3D" style="border:2px solid #000000" width="800" height="600"></canvas>
 
 <script type="text/javascript">

--- a/examples/cindy3d/68_Surface3.html
+++ b/examples/cindy3d/68_Surface3.html
@@ -467,7 +467,7 @@ end3d();
 
 </script>
 
-<canvas  id="CSCanvas" width=8 height=6  style="border:none"></canvas>
+<div  id="CSCanvas" style="width:8px; height:6px; border:none"></div>
   <canvas id="Cindy3D" style="border:2px solid #000000" width="800" height="600"></canvas>
 
 <script type="text/javascript">

--- a/examples/cindy3d/68_Surface4.html
+++ b/examples/cindy3d/68_Surface4.html
@@ -614,7 +614,7 @@ end3d();
 
 </script>
 
-<canvas  id="CSCanvas" width=8 height=6  style="border:none"></canvas>
+<div  id="CSCanvas" style="width:8px; height:6px; border:none"></div>
   <canvas id="Cindy3D" style="border:2px solid #000000" width="800" height="600"></canvas>
 
 <script type="text/javascript">

--- a/examples/cindy3d/68_Surface5.html
+++ b/examples/cindy3d/68_Surface5.html
@@ -1239,7 +1239,7 @@ end3d();
 
 </script>
 
-<canvas  id="CSCanvas" width=8 height=6  style="border:none"></canvas>
+<div  id="CSCanvas" style="width:8px; height:6px; border:none"></div>
   <canvas id="Cindy3D" style="border:2px solid #000000" width="800" height="600"></canvas>
 
 <script type="text/javascript">

--- a/examples/cindy3d/68_Surface6.html
+++ b/examples/cindy3d/68_Surface6.html
@@ -617,7 +617,7 @@ end3d();
 
 </script>
 
-<canvas  id="CSCanvas" width=8 height=6  style="border:none"></canvas>
+<div  id="CSCanvas" style="width:8px; height:6px; border:none"></div>
   <canvas id="Cindy3D" style="border:2px solid #000000" width="800" height="600"></canvas>
 
 <script type="text/javascript">

--- a/examples/cindy3d/68_Surface7.html
+++ b/examples/cindy3d/68_Surface7.html
@@ -454,7 +454,7 @@ end3d();
 
 </script>
 
-<canvas  id="CSCanvas" width=8 height=6  style="border:none"></canvas>
+<div  id="CSCanvas" style="width:8px; height:6px; border:none"></div>
   <canvas id="Cindy3D" style="border:2px solid #000000" width="800" height="600"></canvas>
 
 <script type="text/javascript">

--- a/examples/cindy3d/68_Surface8.html
+++ b/examples/cindy3d/68_Surface8.html
@@ -210,7 +210,7 @@ end3d();
 
 </script>
 
-<canvas  id="CSCanvas" width=8 height=6  style="border:none"></canvas>
+<div  id="CSCanvas" style="width:8px; height:6px; border:none"></div>
   <canvas id="Cindy3D" style="border:2px solid #000000" width="800" height="600"></canvas>
 
 <script type="text/javascript">

--- a/examples/cindy3d/Klein.html
+++ b/examples/cindy3d/Klein.html
@@ -193,7 +193,7 @@ createCindy({
 
 <body>
   <canvas id="Cindy3D" style="border: none;" width="800" height="600"></canvas>
-  <canvas id="CSCanvas" width="800" height="40" style="border:none"></canvas>
+  <div id="CSCanvas" style="width:800px; height:40px; border:none"></div>
 </body>
 
 </html>

--- a/examples/cindygl/01_colorplot.html
+++ b/examples/cindygl/01_colorplot.html
@@ -24,7 +24,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" width=600 height=600  style="border:2px solid #000000"></canvas>
+    <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/02_mandelbrot.html
+++ b/examples/cindygl/02_mandelbrot.html
@@ -53,7 +53,7 @@
       drawimage(m0, m1, "mandel");
       drawimage(j0, j1, "julia");
     </script>
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/02_mandelbrot_3d.html
+++ b/examples/cindygl/02_mandelbrot_3d.html
@@ -74,7 +74,7 @@
       drawimage(m0, m1, "mandel");
       drawimage(j0, j1, "julia");
     </script>
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/02_mandelbrot_cubic.html
+++ b/examples/cindygl/02_mandelbrot_cubic.html
@@ -53,7 +53,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/03_complexplot.html
+++ b/examples/cindygl/03_complexplot.html
@@ -28,7 +28,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" width="500" height="400"></canvas>
+    <div  id="CSCanvas" style="width:500px; height:400px;"></div>
     
     <script type="text/javascript">
         var gslp=[

--- a/examples/cindygl/04_movingplot.html
+++ b/examples/cindygl/04_movingplot.html
@@ -31,7 +31,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/05_pixelinterference.html
+++ b/examples/cindygl/05_pixelinterference.html
@@ -28,7 +28,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/06_raytracer_bisection.html
+++ b/examples/cindygl/06_raytracer_bisection.html
@@ -179,7 +179,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" style="border:0px"></canvas>
+    <div  id="CSCanvas" style="border:0px"></div>
     
     <script type="text/javascript">
         createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/06_raytracer_homotopy.html
+++ b/examples/cindygl/06_raytracer_homotopy.html
@@ -181,7 +181,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+    <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
     
     <script type="text/javascript">
         createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/07_diffusion.html
+++ b/examples/cindygl/07_diffusion.html
@@ -46,7 +46,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" onclick="cdy.evokeCS('t0 = seconds();')"></canvas>
+    <div  id="CSCanvas" onclick="cdy.evokeCS('t0 = seconds();')"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/08_julia.html
+++ b/examples/cindygl/08_julia.html
@@ -36,7 +36,7 @@
       drawimage([-1.5,-1.5], [1.5,-1.5], "julia");
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         var gslp=[];

--- a/examples/cindygl/08_julia_advanced.html
+++ b/examples/cindygl/08_julia_advanced.html
@@ -64,7 +64,7 @@
       colorplot(timetocolor(imagergb("julia", #).b));   
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         var gslp=[];

--- a/examples/cindygl/08_julia_conjugated.html
+++ b/examples/cindygl/08_julia_conjugated.html
@@ -59,7 +59,7 @@
       draw([1.5,-1.5],[1.5,1.5], color->(1,1,1));
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         var gslp=[];

--- a/examples/cindygl/08_julia_explanation.html
+++ b/examples/cindygl/08_julia_explanation.html
@@ -53,7 +53,7 @@ tp(a) := (re(a), im(a));
     
 
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         var gslp=[];

--- a/examples/cindygl/08_julia_nointerpolation.html
+++ b/examples/cindygl/08_julia_nointerpolation.html
@@ -36,7 +36,7 @@
       drawimage([-1.5,-1.5], [1.5,-1.5], "julia");
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         var gslp=[];

--- a/examples/cindygl/09_ifs.html
+++ b/examples/cindygl/09_ifs.html
@@ -36,7 +36,7 @@
       drawimage(L, R, "ifs");
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         var gslp=[

--- a/examples/cindygl/09_ifs_barnsley.html
+++ b/examples/cindygl/09_ifs_barnsley.html
@@ -80,7 +80,7 @@
       fillpoly([A0, B0, C0], color->[1,.2,.3], alpha->al);
     </script>
 
-    <canvas  id="CSCanvas" style="border:2px solid black"></canvas>
+    <div  id="CSCanvas" style="border:2px solid black"></div>
     <script type="text/javascript">
         
         var gslp=[

--- a/examples/cindygl/09_ifs_sierpinski.html
+++ b/examples/cindygl/09_ifs_sierpinski.html
@@ -51,7 +51,7 @@
       drawimage((-10,-10), (10,-10), "ifs");
     </script>
 
-    <canvas  id="CSCanvas" style="border:2px solid black"></canvas>
+    <div  id="CSCanvas" style="border:2px solid black"></div>
     <script type="text/javascript">
         
         var gslp=[

--- a/examples/cindygl/10_gol.html
+++ b/examples/cindygl/10_gol.html
@@ -77,7 +77,7 @@
     Press SPACE to reset to blank configuration.
       </li>
     </list>
-  <canvas id="CSCanvas" style="position:relative; top:10px;"></canvas>
+  <div id="CSCanvas" style="position:relative; top:10px;"></div>
     
 
     

--- a/examples/cindygl/11_tilings.html
+++ b/examples/cindygl/11_tilings.html
@@ -134,7 +134,7 @@
       );
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/11_tilings_kaleidoscope.html
+++ b/examples/cindygl/11_tilings_kaleidoscope.html
@@ -134,7 +134,7 @@
       );
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/12_kleinian.html
+++ b/examples/cindygl/12_kleinian.html
@@ -98,7 +98,7 @@
       drawtext(TB+(.01,.01), tb, color->[0,0,1]);
     </script>
 
-    <canvas  id="CSCanvas" style="position:relative; top:10px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/12_kleinian2.html
+++ b/examples/cindygl/12_kleinian2.html
@@ -110,7 +110,7 @@
     
     </script>
 
-    <canvas  id="CSCanvas" style="position:relative; top:10px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/12_kleinian2_conjugated.html
+++ b/examples/cindygl/12_kleinian2_conjugated.html
@@ -125,7 +125,7 @@
       draw((4,0), (4,4), color->(1,1,1));
     </script>
 
-    <canvas  id="CSCanvas" style="position:relative; top:10px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/12_kleinian_explanation.html
+++ b/examples/cindygl/12_kleinian_explanation.html
@@ -132,7 +132,7 @@
         
     </script>
     
-    <canvas  id="CSCanvas" style="border:2px solid black"></canvas>
+    <div  id="CSCanvas" style="border:2px solid black"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/13_random.html
+++ b/examples/cindygl/13_random.html
@@ -21,7 +21,7 @@
       colorplot(random());
     </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         
         var gslp=[];

--- a/examples/cindygl/14_reactiondiffusion.html
+++ b/examples/cindygl/14_reactiondiffusion.html
@@ -66,7 +66,7 @@
         draw((500,200),(500,450),color->(0,0,0),size->2);
       </script>
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     <script type="text/javascript">
         cdy = createCindy({canvasname:"CSCanvas",
           scripts: "cs*",

--- a/examples/cindygl/15_lic.html
+++ b/examples/cindygl/15_lic.html
@@ -90,7 +90,7 @@
       drawimage([-2, -2], [2, -2], "LIC");
     </script>
 
-    <canvas  id="CSCanvas" style="position:relative; top:10px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/15_lic2.html
+++ b/examples/cindygl/15_lic2.html
@@ -72,7 +72,7 @@
       
     </script>
 
-    <canvas  id="CSCanvas" style="position:relative; top:10px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/15_lic3.html
+++ b/examples/cindygl/15_lic3.html
@@ -92,7 +92,7 @@
       drawimage([-2, -2], [2, -2], "Nb");
     </script>
 
-    <canvas  id="CSCanvas" style="position:relative; top:10px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/16_userinput.html
+++ b/examples/cindygl/16_userinput.html
@@ -27,7 +27,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" width="500" height="400" style="position:relative; top:0px;"></canvas>
+    <div  id="CSCanvas" style="width:500px; height:400px; position:relative; top:0px;"></div>
     
     <script type="text/javascript">
         var gslp=[{name:"A", kind:"P", type:"Free", pos:[-2,2]}];

--- a/examples/cindygl/16_userinput_lic.html
+++ b/examples/cindygl/16_userinput_lic.html
@@ -72,7 +72,7 @@
       
     </script>
 
-    <canvas  id="CSCanvas" style="position:relative; top:10px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:10px;"></div>
     <script type="text/javascript">
         
         cdy = createCindy({canvasname:"CSCanvas",

--- a/examples/cindygl/17_images.html
+++ b/examples/cindygl/17_images.html
@@ -26,7 +26,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" style="position:relative; top:0px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:0px;"></div>
     
     <script type="text/javascript">
         var gslp=[{name:"A", kind:"P", type:"Free", pos:[0.1, 0.1]}];

--- a/examples/cindygl/17_images_blur.html
+++ b/examples/cindygl/17_images_blur.html
@@ -34,7 +34,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" style="position:relative; top:0px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:0px;"></div>
     
     <script type="text/javascript">
         var gslp=[];

--- a/examples/cindygl/18_hidpitest.html
+++ b/examples/cindygl/18_hidpitest.html
@@ -48,7 +48,7 @@
     </script>
     
     The two leftimages should have a resolution higher than 128x128 on HiDPI-displays.
-    <canvas  id="CSCanvas" style="position:relative; top:0px;"></canvas>
+    <div  id="CSCanvas" style="position:relative; top:0px;"></div>
     
     <script type="text/javascript">
         var gslp=[];

--- a/examples/cindygl/19_colorplot3.html
+++ b/examples/cindygl/19_colorplot3.html
@@ -20,7 +20,7 @@
       colorplot(sin(#*#)+random(), A, B);
     </script>
 
-    <canvas  id="CSCanvas" width=600 height=600  style="border:2px solid #000000"></canvas>
+    <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/20_arctan2.html
+++ b/examples/cindygl/20_arctan2.html
@@ -20,7 +20,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas" width="500" height="400"></canvas>
+    <div  id="CSCanvas" style="width:500px; height:400px;"></div>
     
     <script type="text/javascript">
         var gslp=[

--- a/examples/cindygl/21_pickit.html
+++ b/examples/cindygl/21_pickit.html
@@ -133,8 +133,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 <div><button onclick="cdy.evokeCS('solve()')" type="button">Solve</button></div>
 </body>
 

--- a/examples/cindygl/22_explorer.html
+++ b/examples/cindygl/22_explorer.html
@@ -283,7 +283,7 @@ between $-1$ and $+1$.
 
 </div>
 
-  <canvas id="CSCanvas" style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="border:2px solid black"></div>
 <div style="position:absolute; top:815px;left:10px">
   <input id="ch1" onclick="check1()" checked=true type="checkbox" >angles&nbsp;&nbsp;&nbsp;
   <input id="ch2" onclick="check2()" checked=true type="checkbox" >radii&nbsp;&nbsp;&nbsp;

--- a/examples/cindygl/23_infix_dist.html
+++ b/examples/cindygl/23_infix_dist.html
@@ -24,7 +24,7 @@
     </script>
     
 
-    <canvas  id="CSCanvas"></canvas>
+    <div  id="CSCanvas"></div>
     
     <script type="text/javascript">
         

--- a/examples/cindygl/24_webcam.html
+++ b/examples/cindygl/24_webcam.html
@@ -33,8 +33,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="804" height="604"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:804px; height:604px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/cindygl/24_webcam_blur.html
+++ b/examples/cindygl/24_webcam_blur.html
@@ -40,8 +40,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="800" height="600"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:800px; height:600px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/cindygl/24_webcam_julia.html
+++ b/examples/cindygl/24_webcam_julia.html
@@ -43,7 +43,7 @@ if (image ready(video),
 
 <body>
   
-  <canvas id="CSCanvas"></canvas>
+  <div id="CSCanvas"></div>
   
   <script type="text/javascript">
   

--- a/examples/cindygl/24_webcam_sierpinski.html
+++ b/examples/cindygl/24_webcam_sierpinski.html
@@ -50,7 +50,7 @@ h = .05*(10.1+mouse().y);
 
 <body>
   
-  <canvas id="CSCanvas"></canvas>
+  <div id="CSCanvas"></div>
   
   <script type="text/javascript">
   

--- a/examples/cindygl/25_dragdrop.html
+++ b/examples/cindygl/25_dragdrop.html
@@ -43,8 +43,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 

--- a/examples/cindygl/26_readcanvasimage.html
+++ b/examples/cindygl/26_readcanvasimage.html
@@ -48,8 +48,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 

--- a/examples/cindygl/27_changingimages.html
+++ b/examples/cindygl/27_changingimages.html
@@ -54,8 +54,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 

--- a/examples/cindygl/28_apollian_gasket.html
+++ b/examples/cindygl/28_apollian_gasket.html
@@ -97,7 +97,7 @@ drawcircle(D, c4r);
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500 style="border:2px solid black"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
 
         <script type="text/javascript">
 

--- a/examples/cindygl/29_modifiers_tunnel.html
+++ b/examples/cindygl/29_modifiers_tunnel.html
@@ -65,8 +65,7 @@ var check2=function(){
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="800" height="800"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:800px; height:800px; border:2px solid black"></div>
   <p>
     <input id="ch1" onclick="check1()" checked=true type="checkbox" >interpolate linear&nbsp;&nbsp;&nbsp;
     <input id="ch2" onclick="check2()" checked=true type="checkbox" >mipmap 

--- a/examples/cmdline.html
+++ b/examples/cmdline.html
@@ -39,6 +39,6 @@
     <span id="log"></span>
     <input id="inp" type="text">
     <input id="do" type="button" value="DO">
-    <canvas id="Cindy" style="display:none" width="1" height="1"></canvas>
+    <div id="Cindy" style="display:none" style="width:1px; height:1px;"></div>
   </body>
 </html>

--- a/examples/createtool/createtool.html
+++ b/examples/createtool/createtool.html
@@ -30,6 +30,6 @@
             createtool("Meet", 0, 0);
             //createtool("Delete");
         </script>
-        <canvas id="CSCanvas" width="500" height="500"></canvas>
+        <div id="CSCanvas" style="width:500px; height:500px;"></div>
 	</body>
 </html>

--- a/examples/drag.html
+++ b/examples/drag.html
@@ -7,7 +7,7 @@
 
 	<body style="font-family:Arial;">
 
-         <canvas  id="CSCanvas" width=600 height=600  style="border:1px solid #000000"></canvas>
+         <div  id="CSCanvas" style="width:600px; height:600px; border:1px solid #000000"></div>
         <script type="text/javascript">
             var size=6;
             var mouse={};

--- a/examples/fullsize.html
+++ b/examples/fullsize.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Widget filling whole window</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<style type="text/css">
+  html,body { margin: 0px; padding: 0px; }
+</style>
+<script type="text/javascript">
+
+var cdy = createCindy({
+  ports: [{
+    id: "CSCanvas",
+    transform:[{visibleRect:[-1,1,1,-1]}]
+  }],
+  scripts: "cs*",
+  language: "en",
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0]},
+    {name:"B", type:"Free", pos:[0.7071,0.7071]},
+    {name:"C", type:"CircleMP", args:["A","B"]}
+  ]
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial; ">
+  <div id="CSCanvas" style="width:100vw; height:100vh"></div>
+</body>
+
+</html>

--- a/examples/katex1.html
+++ b/examples/katex1.html
@@ -40,8 +40,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
   <p id="nofonts">If you don't see any labels, and are using Firefox, please enable the <a href="http://kb.mozillazine.org/Security.fileuri.strict_origin_policy">security.fileuri.strict_origin_policy setting</a> to allow local access to the required fonts.  Or use the <code>st</code> module to serve the example via HTTP, as described in the README.</p>
 </body>
 

--- a/examples/template.html
+++ b/examples/template.html
@@ -18,7 +18,7 @@
 <script type="text/javascript">
 
 var cdy = createCindy({ // See ref/createCindy documentation for details.
-  ports: [{id: "CSCanvas"}],
+  ports: [{id: "CSCanvas", width: 500, height: 500}],
   scripts: "cs*",
   language: "en",
   defaultAppearance: {
@@ -37,8 +37,7 @@ var cdy = createCindy({ // See ref/createCindy documentation for details.
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="500" height="500"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/test.html
+++ b/examples/test.html
@@ -20,7 +20,7 @@
             </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/test0.html
+++ b/examples/test0.html
@@ -19,7 +19,7 @@
         </script>
 
 
-        <canvas  id="CSCanvas" width=500 height=500  style="border:2px solid #000000"></canvas>
+        <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
 
         <script type="text/javascript">
 

--- a/examples/test_create.html
+++ b/examples/test_create.html
@@ -30,7 +30,7 @@
             create(["d"], "Para", ["a", "C"]);
             createpoint("A", [10,0,1]);
         </script>
-        <canvas id="CSCanvas" width="500" height="500"></canvas>        
+        <div id="CSCanvas" style="width:500px; height:500px;"></div>        
         <!--
             create(["A"], "Free", [[1, 1, 1]]);
             create(["B"], "Free", [[4, 3, 1]]);

--- a/examples/webcam1.html
+++ b/examples/webcam1.html
@@ -29,8 +29,7 @@ var cdy = createCindy({
 </head>
 
 <body style="font-family:Arial;">
-  <canvas id="CSCanvas" width="804" height="604"
-          style="border:2px solid black"></canvas>
+  <div id="CSCanvas" style="width:804px; height:604px; border:2px solid black"></div>
   <p>
     Note if running from a local machine Chromium/Chrome are preventing camera access due to security concerns.<br>
     You can work around this by launching

--- a/make/build.js
+++ b/make/build.js
@@ -151,6 +151,7 @@ module.exports = function build(settings, task) {
             /<script[^>]*type *= *["']text\/cindyscript["']/g, // requires x-
             /.*firstDrawing.*/g, // excessive copy & paste of old example
             /.*(cinderella\.de|cindyjs\.org)\/.*\/Cindy.*\.js.*/g, // remote
+            /<canvas[^>]+id=['"]CSCanvas/g,                    // use <div>
         ]);
         this.forbidden("ref/**/*.md", [
             /^#.*`.*<[A-Za-z0-9]+>.*?`/mg, // use ‹…› instead

--- a/ref/js/runtests.js
+++ b/ref/js/runtests.js
@@ -332,10 +332,14 @@ TestCase.prototype.asJSON = function() {
 };
 
 function FakeCanvas() {
-  this.width = 640;
-  this.height = 480;
+  this.width = this.clientWidth = this.scrollWidth = 640;
+  this.height = this.clientHeight = this.scrollHeight = 480;
   this._log = [];
-  this._unchanged = {width: this.width, height: this.height};
+  this._unchanged = {}
+  Object.keys(this).forEach(function(k) {
+    if (k.substr(0,1) !== "_")
+      this._unchanged[k] = this[k];
+  }, this);
 };
 FakeCanvas.prototype.addEventListener = function() { };
 FakeCanvas.prototype.removeEventListener = function() { };
@@ -367,6 +371,7 @@ FakeCanvas.prototype.measureText = function(txt) {
   "moveTo",
   "restore",
   "save",
+  "setTransform",
   "stroke",
   "strokeText",
   "fillText",

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -273,12 +273,14 @@ function setuplisteners(canvas, data) {
         // addAutoCleaningEventListener(document.body, "mouseup", mouseUp, false);
     }
 
-    addAutoCleaningEventListener(window, "resize", function() {
-        requestAnimFrame(function() {
-            updateCanvasDimensions();
-            updateCindy();
-        });
-    }, false);
+    if (typeof window !== "undefined") {
+        addAutoCleaningEventListener(window, "resize", function() {
+            requestAnimFrame(function() {
+                updateCanvasDimensions();
+                updateCindy();
+            });
+        }, false);
+    }
 
     updateCindy();
 }

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -273,6 +273,13 @@ function setuplisteners(canvas, data) {
         // addAutoCleaningEventListener(document.body, "mouseup", mouseUp, false);
     }
 
+    addAutoCleaningEventListener(window, "resize", function() {
+        requestAnimFrame(function() {
+            updateCanvasDimensions();
+            updateCindy();
+        });
+    }, false);
+
     updateCindy();
 }
 

--- a/tests/GeoFuncs_tests.js
+++ b/tests/GeoFuncs_tests.js
@@ -24,6 +24,7 @@ function dummy() { return this; }
     "moveTo",
     "restore",
     "save",
+    "setTransform",
     "stroke",
     "strokeText",
     "fillText",

--- a/tools/updateSyntax.js
+++ b/tools/updateSyntax.js
@@ -12,6 +12,9 @@ case "-evokeCS":
 case "-sx":
     processFiles(updateSx, process.argv.slice(3));
     break;
+case "-div":
+    processFiles(updateToDiv, process.argv.slice(3));
+    break;
 default:
     console.error("No such mode: " + process.argv[2]);
     process.exit(2);
@@ -89,6 +92,23 @@ var reSxy = /sx: *([^:};]+), *sy: *([^:};]+)/g;
 function updateSx(path, str) {
     var res = str.replace(reSxyz, "pos:[$1,$2,$3]");
     res = res.replace(reSxy, "pos:[$1,$2]");
+    if (res !== str)
+        return res;
+}
+
+function updateToDiv(path, str) {
+    var res = str.replace(/<canvas[^>]*>\s*<\/canvas>/ig, function(canvas) {
+        if (canvas.indexOf('id="Cindy3D"') >= 0) return canvas;
+        var div = canvas
+            .replace(/width="?(\d+)"?\s+height="?(\d+)"?\s+style="/,
+                     'style="width:$1px; height:$2px; ')
+            .replace(/width="?(\d+)"?\s+height="?(\d+)"?/,
+                     'style="width:$1px; height:$2px;"')
+            .replace(/(<\/?)canvas/ig, '$1div');
+        if (/(width|height)\s*(=|:[^]*\1:)/.test(div))
+            throw error("Could not convert dimensions for " + canvas);
+        return div;
+    });
     if (res !== str)
         return res;
 }


### PR DESCRIPTION
This is one step along the way towards buttons (#14) since it introduces a `<div>` around our `<canvas>` which can then be used to put in HTML elements. This requires some work to get the size of the `<div>` and the `<canvas>` synchronized properly. That felt like a good opportunity to make that synchronization work not only at initialization time, but also dynamically when the size gets updated.

This is a breaking change, since it is quite possible to specify CSS style sheets where the new DOM tree will render differently than the old one. Some care should be taken when updating to a version including this change, but sane content should be working all right or, in the worst case, quite easy to fix.