### PR TITLE
CindyGL: automatic rescaling of images if dimensions are to huge

### DIFF
--- a/examples/cindygl/29_modifiers_tunnel.html
+++ b/examples/cindygl/29_modifiers_tunnel.html
@@ -26,7 +26,18 @@
 <script id="csondrop" type="text/x-cindyscript">
   dropped = dropped();
   dump(dropped);
-  if (!isundefined(dropped_1_1), image = dropped_1_1; dump(image););
+  if (!isundefined(dropped_1_1),
+    image = dropped_1_1;
+    maxpixel = 2048*2048;
+    curpixel = imagesize(image).x*imagesize(image).y;
+    if(curpixel>maxpixel,
+      s = 0;
+      while(curpixel>maxpixel*(2^s), s=s+1);
+      createimage("smallimage", imagesize(image).x/(2^s), imagesize(image).y/(2^s));
+      canvas((0,0),(1,0), "smallimage", drawimage((0,0),(1,0), image));
+      image = "smallimage";
+    );
+  );
 </script>
 <script type="text/javascript">
 


### PR DESCRIPTION
I think it is better to deal with to large textures in CindyScript instead of letting CindyJS decide whether a texture is too large for the GPU. At least, I have no idea how to find about the size of the texture memory in WebGL.
The method `gl.getParameter(gl.MAX_TEXTURE_SIZE)` gives very high values, which might be used for narrow textures. 