### PR TITLE
Set travis node version to 6.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - node
+  - "6.2.0"
   - "0.12"
 script: node make build=release alltests
 sudo: false


### PR DESCRIPTION
This avoids a bug with node 6.2.1 where the forbidden check will cause the following strange error:

    _stream_readable.js:65
      // not happen before the first write call.

    RangeError: out of range index
        at RangeError (native)
        at StringDecoder.fillLast (string_decoder.js:94:9)
        at StringDecoder.write (string_decoder.js:73:14)
        at readableAddChunk (_stream_readable.js:160:31)
        at ReadStream.Readable.push (_stream_readable.js:130:10)
        at onread (fs.js:1774:12)
        at FSReqWrap.wrapper [as oncomplete] (fs.js:675:17)

This change should be changed back once the problem has been analyzed and addressed in a better way.