### PR TITLE
Added an verbatimglsl function to inject arbitrary GLSL code.

### DIFF
--- a/plugins/cindygl/src/js/TypeInference.js
+++ b/plugins/cindygl/src/js/TypeInference.js
@@ -1,5 +1,6 @@
 function issubtypeof(a, b) { //TODO: what if b is template?
     if (a === b) return true;
+    if (a === type.anytype) return true;
 
     if (isprimitive(a) && isprimitive(b)) {
         if (subtype[a] === undefined) return false;

--- a/plugins/cindygl/src/js/Types.js
+++ b/plugins/cindygl/src/js/Types.js
@@ -17,9 +17,10 @@ const type = { //assert all indices are different
     image: 14,
     coordinate2d: 15, //for accessing 2D textures
     vec2complex: 16,
-    mat2complex: 17
-        // positivefloat: 14 //@TODO: positive int < int, positive real < real. positivefloat+ positivefloat = positivefloat...
-        // nonnegativefloat: 15 //@TODO: negative float...
+    mat2complex: 17,
+    anytype: 18, // is subtype of any other type
+    // positivefloat: 14 //@TODO: positive int < int, positive real < real. positivefloat+ positivefloat = positivefloat...
+    // nonnegativefloat: 15 //@TODO: negative float...
 };
 Object.freeze(type);
 
@@ -41,7 +42,8 @@ function typeToString(t) {
         'image',
         '2D-Coordinate',
         'complex[2]',
-        'complex[2,2]'
+        'complex[2,2]',
+        'anytype'
         //'positive float',
         //'non-negative float'
     ];


### PR DESCRIPTION
This adds an `verbatimglsl` function which advanced users can use to write plain glsl-code. The glsl-code might be generated as a string within CindyScript. It will be inserted at compile time, i.e. the first time the colorplot command is called.