### PR TITLE
Warn developers about node 6.2.1

### DIFF
--- a/make/check-node-version.js
+++ b/make/check-node-version.js
@@ -6,8 +6,15 @@ v = v.split(".");
 v = v.map(function(s){
   return parseInt(s);
 });
-if (v[0] == 0 && v[1] < 12) {
+var a = v[0], b = v[1], c = v[2];
+if (a == 0 && b < 12) {
   console.error("Node 0.12 or later required. Version " +
                 process.version + " found");
   process.exit(1);
+}
+if (a > 6 || (a == 6 && (b > 2 || (b == 2 && c >= 1)))) {
+  console.error("Node versions starting at 6.2.1 have a bug,");
+  console.error("likely causing the “forbidden” check to fail.");
+  console.error("See https://github.com/nodejs/node/issues/7308");
+  console.error("and https://github.com/CindyJS/CindyJS/pull/378 for details.");
 }


### PR DESCRIPTION
I've analyzed the [node 6.2.1 breakage](https://github.com/CindyJS/CindyJS/pull/374) some more, and decided that it's indeed a bug in their code, to be tracked at nodejs/node#7308. I think (and hope) that their next release will likely fix things. So I don't see much reason to add a README paragraph about problems with 6.2.1. But if developers should happen to use just that version, I'd like to warn them about the cause of their problem. So I added a warning message to the version check. It will not abort the build, since most aspects of the build procedure will work just fine anyway.