### PR TITLE
Fix mouseupbug #249 on iOS

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -265,9 +265,9 @@ function setuplisteners(canvas, data) {
         mouse.down = false;
         cindy_cancelmove();
         stateContinueFromHere();
-        updateCindy();
         cs_mouseup();
         manage("mouseup");
+        updateCindy();
         e.preventDefault();
     }
 


### PR DESCRIPTION
This fixes #249. All it required was a reording of function calls in touchUp, such that the function body equaled that of mouseUp.

I hope I got this PR-thingy correctly.