### PR TITLE
Switch from unzip to yauzl

### DIFF
--- a/make/build.js
+++ b/make/build.js
@@ -417,7 +417,7 @@ module.exports = function build(settings, task) {
         "validation-api-1.0.0.GA-sources",
     ];
     var gwt_jars = gwt_parts.map(function(name) {
-        return "download/gwt-" + settings.get("gwt_version") + "/" +
+        return "gwt-" + settings.get("gwt_version") + "/" +
             name + ".jar";
     });
     var gwt_modules = glob.sync("src/java/cindyjs/*.gwt.xml")
@@ -430,12 +430,7 @@ module.exports = function build(settings, task) {
     });
 
     task("gwt-jars", ["gwt-zip"], function() {
-        this.unzip(gwt_archive, "download");
-        this.parallel(function() {
-            gwt_jars.forEach(function(name) {
-                this.touch(name);
-            }, this);
-        });
+        this.unzip(gwt_archive, "download", gwt_jars);
     });
 
     function extra_args(args) {
@@ -450,7 +445,9 @@ module.exports = function build(settings, task) {
                 gwt_module + ".nocache.js";
             this.delete("build/js/" + gwt_module);
             this.output(mainFile);
-            var cp = ["src/java/"].concat(gwt_jars).join(path.delimiter);
+            var cp = ["src/java/"].concat(gwt_jars.map(function(name) {
+                return "download/" + name;
+            })).join(path.delimiter);
             this.java(
                 "-cp", cp,
                 "com.google.gwt.dev.Compiler",

--- a/make/util.js
+++ b/make/util.js
@@ -1,0 +1,10 @@
+"use strict";
+
+var Q = require("q");
+
+exports.qpipe = function(src, dst) {
+    return Q.Promise(function(resolve, reject) {
+        src.on("error", reject).pipe(
+            dst.on("error", reject).on("finish", resolve));
+    });
+}

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "source-map-dummy": "^1.0.0",
     "st": "^1.1.0",
     "touch": "^1.0.0",
-    "unzip": "^0.1.11",
-    "whole-line-stream": "^0.1.0"
+    "whole-line-stream": "^0.1.0",
+    "yauzl": "^2.6.0"
   },
   "scripts": {
     "prepublish": "$NODE make/index.js call_npm=false parallel=true build=release all",


### PR DESCRIPTION
The node package “[unzip](https://github.com/EvanOxfeld/node-unzip)” appears to be pretty much [unmaintained](https://github.com/EvanOxfeld/node-unzip/issues/95), and it has [problem with the more recent versions of node](https://github.com/EvanOxfeld/node-unzip/issues/97).  The package “[yauzl](https://github.com/thejoshwolfe/yauzl)” (Yet Another UnZip Library) appears to be the most suitable [replacement](https://github.com/EvanOxfeld/node-unzip/issues/98).