### PR TITLE
Fix cmdline reporting for build tasks

### DIFF
--- a/make/commands.js
+++ b/make/commands.js
@@ -17,6 +17,8 @@ var util = require("./util");
 
 function cmdImpl(task, opts, command, args) {
     return Q.Promise(function(resolve, reject) {
+        var cmdline = [command || "node"].concat(args).join(" ");
+        task.log(cmdline);
         var spawnOpts = { stdio: ["ignore", "pipe", "pipe"] };
         if (!command) command = process.argv[0]; // node
         var child = cp.spawn(command, args, spawnOpts);
@@ -84,8 +86,6 @@ exports.cmd = function(command) {
     args = Array.prototype.concat.apply([], args); // flatten one level
     args = Array.prototype.concat.apply([], args); // flatten a second level
     this.addJob(function() {
-        var cmdline = [command || "node"].concat(args).join(" ");
-        task.log(cmdline);
         return cmdImpl(task, {}, command, args);
     });
 };


### PR DESCRIPTION
This fixes an error introduced in dc39e0f8d17170ae622b7fff203fd4a1e828e3fb, causing problems like

    cindyjs/make/commands.js:55
                        cmdline + " exited with code " + code));
                        ^
    ReferenceError: cmdline is not defined

I originally committed this as a drive-by fix in https://github.com/CindyJS/CindyJS/pull/382/commits/d8355918dc675cbf8465db0c4b6d437d03abab8d, then cherry-picked it to https://github.com/CindyJS/CindyJS/pull/386/commits/d9d957e84c9fa2dfd4c2a076e2fc9167a75da1ed as well. But https://github.com/CindyJS/CindyJS/pull/173#issuecomment-227859796 makes me think that this should get fixed even while those pull requests are still under review, so here it is cherry-picked into a branch of its own.