### PR TITLE
conic4p1l: add tracing and remove random factor

### DIFF
--- a/examples/65_Conic_4P_1l.html
+++ b/examples/65_Conic_4P_1l.html
@@ -14,12 +14,25 @@
         <h1>Conic by 4 points and 1 line</h1>
 
 
-        <script id='csmove' type='text/x-cindyscript'>
+        <script id='csinit' type='text/x-cindyscript'>
+          example1():=(
+            A.homog = [0.34653465346534656,1,0.24752475247524758];
+            B.homog = [1,-0.35460992907801425,-0.17730496453900713];
+            C.homog = [-0.3,1,0.125];
+            D.homog = [-0.9705882352941176,1,0.7352941176470587];
+            X.homog = [1,0.8333333333333333,0.16666666666666666];
+            Y.homog = [1,0,0.16666666666666666];
+          );
+          //{"geometry":[{"alpha":1,"color":[1,0,0],"name":"A","size":5,"type":"Free","pos":[0.34653465346534656,1,0.24752475247524758]},{"alpha":1,"color":[1,0,0],"name":"B","size":5,"type":"Free","pos":[1,-0.35460992907801425,-0.17730496453900713]},{"alpha":1,"color":[1,0,0],"name":"C","size":5,"type":"Free","pos":[-0.3,1,0.125]},{"alpha":1,"color":[1,0,0],"name":"D","size":5,"type":"Free","pos":[-0.9705882352941176,1,0.7352941176470587]},{"alpha":1,"color":[1,0,0],"name":"X","size":5,"type":"Free","pos":[1,0.8333333333333333,0.16666666666666666]},{"alpha":1,"color":[1,0,0],"name":"Y","size":5,"type":"Free","pos":[1,0,0.16666666666666666]},{"alpha":1,"args":["X","Y"],"clip":"none","color":[0,0,1],"name":"l","overhang":1.1,"size":1,"type":"Join"},{"args":["A","B","C","D","l"],"name":"CoT","type":"ConicBy4p1l"},{"alpha":1,"args":["CoT"],"clip":"none","color":[1,0,1],"name":"Co1","overhang":1.1,"size":1,"type":"SelectConic","pos":{"xx":0.02431214616590816,"yy":0.15535274705466007,"zz":1,"xy":0.1841185689664879,"xz":-0.31130379709496026,"yz":-1.0368332952856512}},{"alpha":1,"args":["CoT"],"clip":"none","color":[0,0.5,0.5],"name":"Co2","overhang":1.1,"size":1,"type":"SelectConic","pos":{"xx":0.05358047574465267,"yy":0.03641252240672584,"zz":1,"xy":-0.07230220577985288,"xz":0.4779336588784801,"yz":-0.4850233179980595}}]}
         </script>
 
 
         <div  id="CSCanvas" style="width:600px; height:600px; border:2px solid #000000"></div>
 
+        <p>Navigating to
+          <button onclick="cdy.evokeCS('example1()')">Example 1</button>
+          and moving the bottom-most point D used to cause the colored
+          conics to change their roles in past versions without tracing.</p>
 
         <script type="text/javascript">
 
@@ -35,8 +48,8 @@
 		      {name:"Co1", type:"SelectConic", args:["CoT"], color:[1,0,1], pos:{xx:0.06,yy:0.003,zz:1,xy:0.02,xz:-0.5,yz:-0.07}},
 		      {name:"Co2", type:"SelectConic", args:["CoT"], color:[0,.5,.5], pos:{xx:0.04,yy:0.04,zz:1,xy:0.0007,xz:-0.4,yz:-0.2}}
                       ];
-            CindyJS({canvasname:"CSCanvas",
-                        movescript:"csmove",
+            var cdy = CindyJS({canvasname:"CSCanvas",
+                        scripts:"cs*",
                         grid:1,
                         snap:true,
                         geometry:gslp});

--- a/examples/65_Conic_4P_1l.html
+++ b/examples/65_Conic_4P_1l.html
@@ -32,8 +32,8 @@
                       {name:"Y", type:"Free", pos:[6,0]},
 		      {name:"l", type:"Join", args:["X", "Y"] },
 		      {name:"CoT", type:"ConicBy4p1l", args:["A","B","C","D","l"]},
-		      {name:"Co1", type:"SelectConic", args:["CoT"], index:1},
-		      {name:"Co2", type:"SelectConic", args:["CoT"], index:2},
+		      {name:"Co1", type:"SelectConic", args:["CoT"], color:[1,0,1], pos:{xx:0.06,yy:0.003,zz:1,xy:0.02,xz:-0.5,yz:-0.07}},
+		      {name:"Co2", type:"SelectConic", args:["CoT"], color:[0,.5,.5], pos:{xx:0.04,yy:0.04,zz:1,xy:0.0007,xz:-0.4,yz:-0.2}}
                       ];
             CindyJS({canvasname:"CSCanvas",
                         movescript:"csmove",

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -961,11 +961,12 @@ geoOps._helper.ConicBy4p1l = function(el, a, b, c, d, l) {
     var a2 = List.cross(List.cross(b, d), l);
     var k1 = List.scalmult(r1, a1);
     var k2 = List.scalmult(r2, a2);
-    var x = List.add(k1, k2);
-    var y = List.sub(k1, k2);
-    var t1 = geoOps._helper.ConicBy5(el, a, b, c, d, x);
-    var t2 = geoOps._helper.ConicBy5(el, a, b, c, d, y);
-    return [t1, t2];
+    var x = List.normalizeMax(List.add(k1, k2));
+    var y = List.normalizeMax(List.sub(k1, k2));
+    var xy = tracing2(x, y);
+    var t1 = geoOps._helper.ConicBy5(el, a, b, c, d, xy.value[0]);
+    var t2 = geoOps._helper.ConicBy5(el, a, b, c, d, xy.value[1]);
+    return [List.normalizeMax(t1), List.normalizeMax(t2)];
 };
 
 geoOps.ConicBy4p1l = {};
@@ -984,6 +985,7 @@ geoOps.ConicBy4p1l.updatePosition = function(el) {
     el.results = erg;
 
 };
+geoOps.ConicBy4p1l.stateSize = tracing2.stateSize;
 
 
 geoOps._helper.ConicBy3p2l = function(a, b, c, g, h) {
@@ -1126,6 +1128,7 @@ geoOps.ConicBy1p4l.updatePosition = function(el) {
     el.results = erg;
 
 };
+geoOps.ConicBy1p4l.stateSize = tracing2.stateSize;
 
 geoOps.ConicParabolaPL = {};
 geoOps.ConicParabolaPL.kind = "C";

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -946,26 +946,25 @@ geoOps.SelectConic.updatePosition = function(el) {
 
 // conic by 4 Points and 1 line
 geoOps._helper.ConicBy4p1l = function(el, a, b, c, d, l) {
+    var al = List.scalproduct(a, l);
+    var bl = List.scalproduct(b, l);
+    var cl = List.scalproduct(c, l);
+    var dl = List.scalproduct(d, l);
+    var bcd = List.det3(b, c, d);
+    var abd = List.det3(a, b, d);
+    var acd = List.det3(a, c, d);
+    var abc = List.det3(a, b, c);
+    var mul = CSNumber.mult;
+    var r1 = CSNumber.sqrt(mul(mul(bl, dl), mul(bcd, abd)));
+    var r2 = CSNumber.sqrt(mul(mul(al, cl), mul(acd, abc)));
     var a1 = List.cross(List.cross(a, c), l);
     var a2 = List.cross(List.cross(b, d), l);
-    var b1 = List.cross(List.cross(a, b), l);
-    var b2 = List.cross(List.cross(c, d), l);
-    var o = List.realVector(csport.to(100 * Math.random(), 100 * Math.random()));
-
-    var r1 = CSNumber.mult(List.det3(o, a2, b1), List.det3(o, a2, b2));
-    r1 = CSNumber.sqrt(r1);
-    var r2 = CSNumber.mult(List.det3(o, a1, b1), List.det3(o, a1, b2));
-    r2 = CSNumber.sqrt(r2);
-
     var k1 = List.scalmult(r1, a1);
     var k2 = List.scalmult(r2, a2);
-
     var x = List.add(k1, k2);
     var y = List.sub(k1, k2);
-
     var t1 = geoOps._helper.ConicBy5(el, a, b, c, d, x);
     var t2 = geoOps._helper.ConicBy5(el, a, b, c, d, y);
-
     return [t1, t2];
 };
 


### PR DESCRIPTION
This improves the ConicBy4p1l and ConicBy1p4l operations by removing a random factor and adding tracing code. I'm a bit surprised how stable the operation is in the absence of tracing, but nevertheless I found (after much searching) a configuration which reliably exhibited flipping with the old code, and thus allowed me to verify tracing for the new code. I added a button to the example to make that configuration available.

This fixes #101 (assuming that one really was about 4P1L).

I would have liked to check my algorithm for avoidable singularities, but when I tried to eliminate the square root using a resultant, I ran out of memory. So I still don't know whether this implementation has any common factors.

*Note:* For some reason the conics coming out of this example appear to be particularly problematic for the current conic drawing algorithm. I see a lot of rather coarse polygonal approximations. Might be worth remembering when evaluating #280.