### PR TITLE
Bind development webserver to localhost only

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ inside the repository, demonstrating individual functions and operations.
 Developers can run these examples from their local development copy.
 Some examples may require a webserver-like environment to avoid
 triggering browser security measures associated with local files.
-To do so, one can run <code>npm_modules/.bin/st -nc</code>
+To do so, one can run <code>npm_modules/.bin/st -l -nc</code>
 in the root of the development tree, and then visit
 [the local copy of the examples directory](http://127.0.0.1:1337/examples/).
 

--- a/examples/webcam1.html
+++ b/examples/webcam1.html
@@ -33,7 +33,7 @@ var cdy = CindyJS({
   <p>
     Note if running from a local machine Chromium/Chrome are preventing camera access due to security concerns.<br>
     You can work around this by launching
-    <code>./node_modules/.bin/st -nc</code>
+    <code>./node_modules/.bin/st -l -nc</code>
     and then visiting
     <a href="http://127.0.0.1:1337/examples/webcam1.html">http://127.0.0.1:1337/examples/webcam1.html</a>.<br>
     Alternatively, you can also run Chrome with the <code>--allow-file-access-from-files</code> flag.<br>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "rimraf": "^2.4.4",
     "source-map": "^0.5.1",
     "source-map-dummy": "^1.0.0",
-    "st": "^1.1.0",
+    "st": "^1.2.0",
     "touch": "^1.0.0",
     "whole-line-stream": "^0.1.0",
     "yauzl": "^2.6.0"


### PR DESCRIPTION
This was made possible by https://github.com/isaacs/st/pull/74 and is good for security since it reduces the risk of accidentially exposing sensitive information.