### PR TITLE
Implement live build mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ fwdtargets = \
 	forbidden \
 	jshint \
 	katex \
+	live \
 	nodetest \
 	proxy \
 	ref \

--- a/make/README.md
+++ b/make/README.md
@@ -52,9 +52,14 @@ Contributors are encouraged to run these before creating a pull request.
 Travis CI will run the same tests on every pull requests,
 so addressing any issues before will save some time for everybody involved.
 
-There is also ca task called **clean** which removes the `build` directory.
+There is also a task called **clean** which removes the `build` directory.
 It is somewhat special because it will get executed first,
 no matter the order of tasks on the command line.
+
+Another special task is called **live**.
+It will open a browser at startup,
+rebuild the named targets on every change to one of the source files,
+and reload all connected browser windows in case of a successful build.
 
 ## Internals
 
@@ -111,10 +116,17 @@ The file [`cli.js`](cli.js) is responsible for command line parsing.
 
 It also ties in most of the other parts of the system:
 it instantiates a [`Settings`](Settings.js) object
-and configures it with the settings given on the command line,
-it instantiates a [`Tasks`](Tasks.js) registry and
-calls to [`build.js`](build.js) to fill it with task definitions
-before delegating to [`make.js`](make.js) to run the selected tasks.
+and configures it with the settings given on the command line.
+It also sets up some machinery to ensure the correct exit code.
+It then delegates to either [`make.js`](make.js) to run the selected tasks
+or to [`watch.js`](watch.js) to repeatedly run selected tasks.
+
+### Live reloading
+
+If the **live** target was named on the command line,
+its functionality is implemented by the file [`watch.js`](watch.js).
+It handles watching source files for changes, triggering a rebuild,
+and reloading browser windows after a successful build.
 
 ### Handling of settings
 
@@ -288,10 +300,13 @@ and a command (since it adds a job to the current task).
 
 ### Build logic
 
-Once all tasks have been defined, [`make.js`](make.js)
-controls the overall logic of the build.
+Once all settings and the build description have been loaded,
+[`make.js`](make.js) controls the overall logic of the build.
+
 It performs the following steps in order:
 
+* Instantiate a [`Tasks`](Tasks.js) registry and populate it
+  by executing the code from [`build.js`](build.js).
 * Execute the `clean` target (i.e. remove the `build` directory) if requested.
 * Make sure the `build` directory exists,
   since that is where we will try to save our settings at the end.
@@ -299,6 +314,10 @@ It performs the following steps in order:
 * Report the final result of the build.
 * Save the settings.
 * Ensure an appropriate return value.
+
+In live mode, these are the steps which will be repeated for every reload.
+So a change to e.g. [`build.js`](build.js) may trigger a recompile,
+but that will still use the previously loaded build script and settings.
 
 ### Task logic
 

--- a/make/Task.js
+++ b/make/Task.js
@@ -93,7 +93,7 @@ Task.prototype.parallel = function(callback) {
  */
 Task.prototype.input = function(file) {
     if (Array.isArray(file)) {
-        file.forEach(this.input.bind(this));
+        file.forEach(this.input, this);
     } else if (this.outputs.indexOf(file) === -1) {
         this.inputs.push(file);
     }
@@ -105,7 +105,7 @@ Task.prototype.input = function(file) {
  */
 Task.prototype.output = function(file) {
     if (Array.isArray(file)) {
-        file.forEach(this.output.bind(this));
+        file.forEach(this.output, this);
     } else {
         this.outputs.push(file);
     }

--- a/make/Tasks.js
+++ b/make/Tasks.js
@@ -103,4 +103,17 @@ module.exports = function Tasks(settings) {
         }
     };
 
+    this.allInputs = function() {
+        var inputs = [];
+        for (var name in tasks) {
+            if (tasks.hasOwnProperty(name)) {
+                tasks[name].inputs.forEach(function(input) {
+                    if (inputs.indexOf(input) === -1)
+                        inputs.push(input);
+                });
+            }
+        }
+        return inputs;
+    };
+
 };

--- a/make/Tasks.js
+++ b/make/Tasks.js
@@ -103,17 +103,4 @@ module.exports = function Tasks(settings) {
         }
     };
 
-    this.allInputs = function() {
-        var inputs = [];
-        for (var name in tasks) {
-            if (tasks.hasOwnProperty(name)) {
-                tasks[name].inputs.forEach(function(input) {
-                    if (inputs.indexOf(input) === -1)
-                        inputs.push(input);
-                });
-            }
-        }
-        return inputs;
-    };
-
 };

--- a/make/Tasks.js
+++ b/make/Tasks.js
@@ -17,8 +17,6 @@ module.exports = function Tasks(settings) {
 
     var tasks = {};
 
-    var currentTask = null;
-
     /* Define a new task. The definition is a function which describes the
      * task, without executing it yet. It should call the addJob method
      * and may also call input and output methods.
@@ -38,10 +36,9 @@ module.exports = function Tasks(settings) {
     this.complete = function() {
         for (name in tasks) {
             if (tasks.hasOwnProperty(name)) {
-                currentTask = tasks[name];
-                if (currentTask.definition)
-                    currentTask.definition();
-                currentTask = null;
+                var current = tasks[name];
+                if (current.definition)
+                    current.definition();
             }
         }
         if (settings.get("logprefix") === "true") {
@@ -78,12 +75,6 @@ module.exports = function Tasks(settings) {
             console.log("- " + name);
         });
         throw new BuildError("No task named " + name);
-    };
-
-    /* Identify the task currently being defined.
-     */
-    this.current = function() {
-        return currentTask;
     };
 
     /* Execute the named tasks sequentially or in parallel

--- a/make/cli.js
+++ b/make/cli.js
@@ -6,20 +6,26 @@
  * and execute requested tasks.
  */
 
+var chalk = require("chalk");
+var path = require("path");
 var Q = require("q");
 Q.longStackSupport = true;
 
 var Settings = require("./Settings");
-var Tasks = require("./Tasks");
-var buildRules = require("./build");
 var make = require("./make");
+
+function addNodePath() {
+    process.env.PATH =
+        path.resolve(path.join("node_modules", ".bin")) +
+        path.delimiter + process.env.PATH;
+}
 
 function main(args) {
 
     var settings = new Settings();
-    var tasks = new Tasks();
     var tasksToRun = [];
     var doClean = false;
+    var watch = false;
 
     args.forEach(function(arg) {
         var pos = arg.indexOf("=");
@@ -27,6 +33,8 @@ function main(args) {
             settings.set(arg.substr(0, pos), arg.substr(pos + 1));
         } else if (arg === "clean") {
             doClean = true;
+        } else if (arg === "live") {
+            watch = true;
         } else {
             tasksToRun.push(arg);
         }
@@ -40,12 +48,36 @@ function main(args) {
     }
     settings.set = null; // Safety precaution against later modification
 
-    var tasks = new Tasks(settings);
-    buildRules(settings, tasks.task); // Execute task definitions
-    tasks.complete();
+    var makeOnce = make.bind(null, settings, tasksToRun);
 
-    // Now run the selected tasks
-    process.nextTick(make.bind(null, settings, tasks, tasksToRun, doClean));
+    addNodePath();
+    var exitStatus = 3;
+    process.once('beforeExit', function() {
+        if (exitStatus === 3)
+            console.error(chalk.bold.red(
+                "Event loop drained unexpectedly!"));
+        process.exit(exitStatus);
+    });
+    var promise;
+    if (watch) {
+        promise = require("./watch")(makeOnce, doClean);
+    } else {
+        promise = makeOnce(doClean);
+    }
+    promise.then(function(result) {
+        exitStatus = result.success ? 0 : 1;
+    }, function(err) {
+        var str = err.toString(), stack = err.stack;
+        if (stack.substr(0, str.length) === str)
+            stack = stack.substr(str.length);
+        console.error(chalk.bold.red(str) + stack);
+        return 2;
+    })
+    .catch(function(err) {
+        // Failed to print the error above
+        process.exit(2);
+    })
+    .done();
 }
 
 if (require.main === module)

--- a/make/commands.js
+++ b/make/commands.js
@@ -168,10 +168,12 @@ exports.applySourceMap = function(maps, dst) {
 };
 
 exports.sass = function(src, dst) {
+    var task = this;
     this.input(src);
     this.output(dst);
     this.output(dst + ".map");
     this.addJob(function() {
+        task.log(src + " \u219d " + dst);
         var basename = path.basename(dst);
         return Q.ninvoke(require("node-sass"), "render", {
             file: src,
@@ -183,6 +185,9 @@ exports.sass = function(src, dst) {
                 qfs.write(dst, res.css),
                 qfs.write(dst + ".map", res.map)
             ]);
+        }, function(err) {
+            throw new BuildError(
+                "Error applying SASS to " + src + ": " + err.message);
         });
     });
 }

--- a/make/watch.js
+++ b/make/watch.js
@@ -1,0 +1,105 @@
+"use strict";
+
+/* File watching for the CindyJS build system.
+ *
+ * This code implements the “live” view, where any change to one of
+ * the source files triggers a recompile and, in case of success, a
+ * reload of connected browsers.
+ */
+
+var Q = require("q");
+var chalk = require("chalk");
+var chokidar = require("chokidar");
+var browserSync = require("browser-sync");
+
+module.exports = function watch(makeOnce, doClean) {
+    var deferred = Q.defer();
+    var inputs, watcher;
+
+    var bs = browserSync.create("CindyJS");
+    bs.init({
+        server: {
+            baseDir: ".",
+            directory: true,
+        },
+        port: 1337,
+        startPath: "/examples/",
+        files: [ // watch these in addition to source files
+            "examples",
+            "private_examples",
+        ],
+    }, function(err, instance) {
+        if (err) return deferred.reject(err);
+    });
+
+    var building = 1;
+    make(doClean);
+    return deferred.promise;
+
+    function make(doClean) {
+        console.log(chalk.yellow("Starting build"));
+        makeOnce(doClean).then(gotResult).catch(fail).done();
+    }
+
+    function fail(err) {
+        bs.exit();
+        if (watcher) watcher.close();
+        deferred.reject(err);
+    }
+
+    function gotResult(result) {
+        if (!watcher) {
+            inputs = result.tasks.allInputs();
+            watcher = chokidar.watch(inputs, {
+                ignoreInitial: true,
+            });
+            watcher.on("error", deferred.reject);
+            watcher.on("all", onChange);
+            watcher.once("ready", function() {
+                console.log(chalk.yellow(
+                    "Watching " + inputs.length + " items"));
+            });
+        } else {
+            result.tasks.allInputs().forEach(function(path) {
+                if (inputs.indexOf(path) !== -1) return;
+                inputs.push(path);
+                watcher.add(path);
+            });
+        }
+        if (bs) {
+            if (result.success) {
+                bs.reload();
+            } else {
+                var msg = String(result.error)
+                    .replace(/\n[^]*/, "")
+                    .replace(/\x1b\[[0-9,;]*m/g, "")
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .substr(0, 80);
+                bs.notify("Build failed: " + msg);
+            }
+        }
+        if (building > 1) {
+            building = 1;
+            console.log(chalk.yellow("Performing scheduled build"));
+            make(false);
+        } else {
+            building = 0;
+            console.log(chalk.yellow("Watching for changes"));
+        }
+    }
+
+    function onChange(event, path) {
+        console.log(chalk.yellow(event + " " + path));
+        if (building === 0) { // need to trigger a build
+            building = 1;
+            console.log(chalk.yellow("Build triggered"));
+            make(false);
+        } else {
+            console.log(chalk.yellow("Already building, build scheduled"));
+            building = 2;
+        }
+    };
+
+};

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "test": "tests"
   },
   "devDependencies": {
+    "browser-sync": "^2.13.0",
     "chai": "^3.5.0",
     "chalk": "^1.1.1",
+    "chokidar": "^1.6.0",
     "concat-with-sourcemaps": "^1.0.4",
     "glob": "^7.0.3",
     "http-proxy": "^1.11.2",


### PR DESCRIPTION
In this mode, sources are watched for changes, triggering a build.
If such a build is successful, then browser windows reloaded.

I've been wanting to do this for quite some time now, and finally got round to it. Or in other words, been sufficiently annoyed by the old state of affairs. Ideally, you'd just need two windows: editor and browser. If everything works as expected, then you can ignore the console window after executing `node make live` since it will take care of everything in the background.

I'm using the [BrowserSync](https://www.browsersync.io/) to serve files and handle the reload machinery, and [chokidar](https://github.com/paulmillr/chokidar#readme) to watch for changes. Both of these are very powerful and used in a number of projects. We might find more lightweight solutions that satisfy our needs, but I doubt they'd see the same kind of maturity as these two heavily used packages.

I do notice that BrowserSync apparently does not provide an option to just bind to localhost. So I guess I'll make a similar request for that project as I did for st.

I'd like to see the live mode in action for a few weeks before documenting it in the README.

I also haven't included the `live` target in the `Makefile`. Perhaps I should? I'd welcome opinions on this. One problem is that the combination of `live` with other targets won't work with make since `live` is in fact more of a switch than an actual target, and make will delegate targets to the build system one at a time anyway. So `make live …` and `node make live …` would behave fundamentally different for non-empty `…` which might be somewhat confusing.