### PR TITLE
Show animation controls if requested

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,7 @@
 *.py            text
 *.scss          text
 *.sh            text
+*.svg           text
 *.taskpaper     text
 *.ttf           -text
 *.txt           text

--- a/examples/animcontrols.html
+++ b/examples/animcontrols.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script type="text/javascript">
+
+var cdy = CindyJS({
+  ports: [{id: "CSCanvas", width: 500, height: 500}],
+  scripts: "cs*",
+  language: "en",
+  animcontrols: true,
+  defaultAppearance: {
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[-5,2], color:[1,.5,.5]},
+    {name:"B", type:"Free", pos:[2,1], color:[1,.8,0], size:9}
+  ],
+  behavior: [
+    {type:"Environment", deltat:.2, accuracy:10},
+    {type:"Mass", geo:["A"], vy:.7},
+    {type:"Sun", geo:["B"]}
+  ]
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+</body>
+
+</html>

--- a/images/Icons.svg
+++ b/images/Icons.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ This file is meant to be viewed in Inkscape but edited by hand.
+ Feel free to edit in Inkscape, too, but then copy only the relevant changes.
+ We don't want IDs and similar cruft all over the file after every change.
+ Plus we need the stylesheet to control layer visibility.
+-->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32"
+   height="24"
+   viewBox="-16 -12 32 24"
+   id="svg2"
+   version="1.1">
+  <title>CindyJS Icons</title>
+  <metadata>
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>CindyJS Icons</dc:title>
+        <cc:license
+            rdf:resource="http://www.apache.org/licenses/LICENSE-2.0.html"/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs>
+    <filter
+        id="raised"
+        style="color-interpolation-filters:sRGB"
+        filterUnits="userSpaceOnUse"
+        x="-18" y="-14" width="36" height="28">
+      <feMorphology in="SourceAlpha" radius="0.3"/>
+      <feGaussianBlur stdDeviation="0.5"/>
+      <feDiffuseLighting
+          surfaceScale="2"
+          lighting-color="rgb(255,255,255)"
+          diffuseConstant="0.8">
+        <feDistantLight azimuth="230" elevation="25"/>
+      </feDiffuseLighting>
+      <feGaussianBlur stdDeviation="0.1" result="lighting"/>
+      <feColorMatrix
+          in="lighting"
+          type="matrix"
+          values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0.5 0.5 0.5 0 -0.5 "
+          result="light"/>
+      <feColorMatrix
+          in="lighting"
+          type="matrix"
+          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -1 -1 -1 0 0.8 "
+          result="dark"/>
+      <feMerge>
+        <feMergeNode in="light"/>
+        <feMergeNode in="dark"/>
+      </feMerge>
+      <feComposite in2="SourceGraphic" operator="atop"/>
+    </filter>
+  </defs>
+  <style type="text/css">
+    /* <![CDATA[ */
+
+    svg > g { display: none; }    /* hide layers…                 */
+    g:target { display: inline; } /* … except for the #named one. */
+
+    .raised { fill: #dfdfdf; stroke: none; filter:url(#raised); }
+
+    /* ]]> */
+  </style>
+  <sodipodi:namedview
+      pagecolor="#bfc4d0"
+      bordercolor="#666666"
+      borderopacity="1.0"
+      inkscape:document-units="px"
+      showgrid="true"
+      units="px"
+      inkscape:snap-global="true">
+    <inkscape:grid type="xygrid" empspacing="4"/>
+  </sodipodi:namedview>
+  <g inkscape:groupmode="layer" id="pause">
+    <rect class="raised" width="6" height="16" x="-8" y="-8"/>
+    <rect class="raised" width="6" height="16" x="2" y="-8"/>
+  </g>
+  <g inkscape:groupmode="layer" id="play">
+    <path class="raised" d="M 8,0 -8,6 -8,-6 Z"/>
+  </g>
+  <g inkscape:groupmode="layer" id="stop">
+    <rect class="raised" width="16" height="16" x="-8" y="-8"/>
+  </g>
+</svg>

--- a/make/build.js
+++ b/make/build.js
@@ -515,7 +515,7 @@ module.exports = function build(settings, task) {
     // Copy images to build directory
     //////////////////////////////////////////////////////////////////////
 
-    var images = glob.sync("images/*.{png,jpg}");
+    var images = glob.sync("images/*.{png,jpg,svg}");
 
     task("images", [], function() {
         this.parallel(function() {

--- a/ref/createCindy.md
+++ b/ref/createCindy.md
@@ -171,6 +171,10 @@ Whenever an image is ready, it can be used in the application instance.
 
 Setting this to true indicates that the animation should start immediately after startup of the instance.
 
+### animcontrols
+
+When set to true, buttons to control animations will be shown.
+
 ### oninit
 
 A JavaScript function to be called when the application instance is ready.

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -215,6 +215,7 @@ function createCindyNow() {
         updateCanvasDimensions();
         if (!csctx.setLineDash)
             csctx.setLineDash = function() {};
+        if (data.animcontrols) setupAnimControls();
     }
     if (data.statusbar) {
         if (typeof data.statusbar === "string") {
@@ -388,6 +389,37 @@ function loadImage(obj) {
     };
 }
 
+var animcontrols = {
+    play: noop,
+    pause: noop,
+    stop: noop
+};
+
+function setupAnimControls() {
+    var animContainer = document.createElement("div");
+    animContainer.className = "CindyJS-animcontrols";
+    canvas.parentNode.appendChild(animContainer);
+    setupAnimButton("play", csplay);
+    setupAnimButton("pause", cspause);
+    setupAnimButton("stop", csstop);
+    animcontrols.stop(true);
+
+    function setupAnimButton(id, ctrl) {
+        var button = document.createElement("button");
+        var img = document.createElement("img");
+        button.appendChild(img);
+        animContainer.appendChild(button);
+        img.src = CindyJS.getBaseDir() + "images/Icons.svg#" + id;
+        button.addEventListener("click", ctrl);
+        animcontrols[id] = setActive;
+
+        function setActive(active) {
+            if (active) button.classList.add("CindyJS-active");
+            else button.classList.remove("CindyJS-active");
+        }
+    }
+}
+
 function callFunctionNow(f) {
     return f();
 }
@@ -487,7 +519,11 @@ function csplay() {
         if (csstopped) { // stop state
             backupGeo();
             csstopped = false;
+            animcontrols.stop(false);
+        } else {
+            animcontrols.pause(false);
         }
+        animcontrols.play(true);
         if (typeof csinitphys === 'function') {
             if (csPhysicsInited) {
                 csresetphys();
@@ -502,6 +538,8 @@ function csplay() {
 
 function cspause() {
     if (csanimating) {
+        animcontrols.play(false);
+        animcontrols.pause(true);
         csanimating = false;
     }
 }
@@ -511,7 +549,11 @@ function csstop() {
         if (csanimating) {
             cs_simulationstop();
             csanimating = false;
+            animcontrols.play(false);
+        } else {
+            animcontrols.pause(false);
         }
+        animcontrols.stop(true);
         csstopped = true;
         restoreGeo();
     }

--- a/src/scss/CindyJS.scss
+++ b/src/scss/CindyJS.scss
@@ -2,6 +2,9 @@
 // functionality of the CindyJS user interface.
 // See http://sass-lang.com/ for SASS language documentation.
 
+//////////////////////////////////////////////////////////////////////
+// Some definitions to be reused in the rules below
+
 @mixin naked {
     margin: 0px;
     padding: 0px;
@@ -11,6 +14,49 @@
 $button-shadow: inset 1px 1px 2px #fff, inset -1px -1px 2px #aaa;
 $checked-shadow: inset 1px 1px 2px #999, inset -1px -1px 2px #ccc;
 $focused-shadow: 0px 0px 3px #06f;
+
+//////////////////////////////////////////////////////////////////////
+// Some @extend-only names (like abstract classes) to be used later on
+
+%button {
+    background-color: #bfc4d0;
+    border: 1px solid #d0d0d0;
+    box-shadow: $button-shadow;
+    outline: none;
+}
+
+%button:active {
+    background-color: #aaafbb;
+    box-shadow: $checked-shadow;
+}
+
+%toggleButtonGrid {
+    line-height: 0px;
+
+    button {
+        @extend %button;
+        display: inline-block;
+        margin: 0px;
+        padding: 0px;
+    }
+
+    button.CindyJS-active {
+        @extend %button:active;
+    }
+
+    button:focus {
+        border-color: #06f;
+    }
+
+    img {
+        margin: 0px;
+        border: none;
+        display: block;
+    }
+} // end %toggleButtonGrid
+
+//////////////////////////////////////////////////////////////////////
+// Actual rules
 
 .CindyJS-widget {
     overflow: hidden;
@@ -26,7 +72,7 @@ $focused-shadow: 0px 0px 3px #06f;
         white-space: nowrap;
         margin-top: -1000px;
 
-        img {
+        & > img {
             @include naked;
             display: inline;
             position: static;
@@ -36,81 +82,62 @@ $focused-shadow: 0px 0px 3px #06f;
         }
 
         .CindyJS-button {
-            position: relative;
             display: inline-block;
-            z-index: 2;
         }
 
     } // end baseline
 
     .CindyJS-button {
+        position: relative;
+        z-index: 2;
+    }
 
-        input[type=checkbox] {
-            position: absolute;
-            left: -10000px;
-        }
-
-        button, label {
-            margin: -6px -7px; // compensate padding + border
-            padding: 5px 6px;
-            border-radius: 4px;
-            background-color: #bfc4d0;
-            border: 1px solid #d0d0d0;
-            box-shadow: $button-shadow;
-            outline: none;
-        }
-
-        button:focus, input[type=checkbox]:focus + label {
-            box-shadow: $focused-shadow, $button-shadow;
-        }
-
-        button:active, input[type=checkbox]:checked + label {
-            background-color: #aaafbb;
-            box-shadow: $checked-shadow;
-        }
-
-        button:focus:active, input[type=checkbox]:focus:checked + label {
-            background-color: #aaafbb;
-            box-shadow: $focused-shadow, $checked-shadow;
-        }
-
-    } // end button
-
-    .CindyJS-toolbar {
+    %toggleButtonGrid {
         position: absolute;
-
         button {
             position: relative;
             z-index: 3;
         }
     }
 
+    .CindyJS-animcontrols {
+        bottom: 5px;
+        left: 5px;
+    }
+
 } // end widget
 
+.CindyJS-button {
+
+    input[type=checkbox] {
+        position: absolute;
+        left: -10000px;
+    }
+
+    button, label {
+        @extend %button;
+        margin: -6px -7px; // compensate padding + border
+        padding: 5px 6px;
+        border-radius: 4px;
+    }
+
+    button:focus, input[type=checkbox]:focus + label {
+        box-shadow: $focused-shadow, $button-shadow;
+    }
+
+    input[type=checkbox]:checked + label {
+        @extend %button:active;
+    }
+
+    button:focus:active, input[type=checkbox]:focus:checked + label {
+        background-color: #aaafbb;
+        box-shadow: $focused-shadow, $checked-shadow;
+    }
+
+} // end button
+
 .CindyJS-toolbar {
-
-    button {
-        display: inline-block;
-        margin: 0px;
-        padding: 0px;
-        border-radius: 0px;
-        background-color: #bfc4d0;
-        border: 1px solid #d0d0d0;
-        box-shadow: $button-shadow;
-        outline: none;
-    }
-
-    button.CindyJS-active, button:active {
-        box-shadow: $checked-shadow;
-    }
-
-    button:focus {
-        border-color: #06f;
-    }
-
-    img {
-        display: block;
-    }
+    @extend %toggleButtonGrid;
 
     div {
         line-height: 0px;
@@ -125,3 +152,12 @@ $focused-shadow: 0px 0px 3px #06f;
     }
 
 } // end toolbar
+
+.CindyJS-animcontrols {
+    @extend %toggleButtonGrid;
+
+    button {
+        border-radius: 4px;
+    }
+
+} // end animcontrols


### PR DESCRIPTION
Show animation controls in an overlay in front of the canvas if the `animcontrols` setting is set to true.

This commit cleans up CindyJS.scss somewhat to avoid excessive nesting and to allow re-using CindyJS-specific classes outside the CindyJS widget area.

This is also the start for using SVG button icons.  The icons are served from a single SVG file in order to allow sharing styles and other things between icons, and to keep the number of transferred files low.  The approach of using CSS and the `:target` selector to control layer visibility was inspired by https://css-tricks.com/svg-fragment-identifiers-work/.

This commit conflicts with #396, but the intention is that the SCSS selector `%toggleButtonGrid` should be used by both animation controls and toolbars. I've just merged both branches to resolve the conflicts, and the result is in https://github.com/gagern/CindyJS/commit/71e1053a4b422d5aa8daf1fb0954b3f601067580. So when one of these two issues gets merged, I'd fast-forward-merge that resolution into the other unless you beat me to it.