### PR TITLE
Some Cindy3D improvements

### DIFF
--- a/examples/cindy3d/18_EscherCube.html
+++ b/examples/cindy3d/18_EscherCube.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Escher's impossible cube</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../../build/js/CindyJS.css">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/Cindy3D.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+  use("Cindy3D");
+  initCam = true;
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+Cam = [-5, 5, -20];
+interp(a, c, d) := (v = Cam - a; a + (d.x - c.x) / |v| * v);
+PPP = interp([1, 1, 1], C1, D1);
+PPM = interp([1, 1, -1], C2, D2);
+PMM = interp([1, -1, -1], C3, D3);
+PMP = interp([1, -1, 1], C4, D4);
+MMP = interp([-1, -1, 1], C5, D5);
+MMM = interp([-1, -1, -1], C6, D6);
+MPM = interp([-1, 1, -1], C7, D7);
+MPP = interp([-1, 1, 1], C8, D8);
+vs = [PPP, PPM, PMM, PMP, MMP, MMM, MPM, MPP];
+
+begin3d(supersample->2);
+if (initCam,
+  background3d([0,0,0]);
+  shininess3d(50);
+  lookat3d(Cam, [0, 0, 0], [-1, 100, 0]);
+  fieldofview3d(8°);
+  ambientlight3d(0.3*[1,1,1]);
+directionallight3d(0, direction->[-2,-1,2],
+    diffuse->0.7*[1,1,1], specular->0.3*[1,1,1]);
+  initCam = false);
+//forall(vs, draw3d(#, color->[1,0,0], size->5));
+forall(cycle(vs) ++ [[PPP, PMP], [PPM, MPM], [PMM, MMM], [MMP, MPP]],
+  draw3d(#_1, #_2, color->[0,0.5,1], size->3));
+end3d();
+</script>
+<script type="text/javascript">
+  CindyJS({
+    scripts:"cs*",
+    ports: [{
+      id: "CSCanvas",
+      width: 632,
+      height: 200,
+      transform:[{visibleRect:[-11,9,11,3]}],
+    }],
+    geometry: [
+      {name:"A1",type:"Free",pos:[-8,8],visible:false},
+      {name:"B1",type:"Free",pos:[0,8],visible:false},
+      {name:"s1",type:"Segment",args:["A1","B1"]},
+      {name:"C1",type:"PointOnSegment",args:["s1"],pos:[-4,8],pinned:true,size:2,color:[0,0,1]},
+      {name:"D1",type:"PointOnSegment",args:["s1"],pos:[-4,8]},
+      {name:"A2",type:"Free",pos:[-9,7],visible:false},
+      {name:"B2",type:"Free",pos:[-1,7],visible:false},
+      {name:"s2",type:"Segment",args:["A2","B2"]},
+      {name:"C2",type:"PointOnSegment",args:["s2"],pos:[-5,7],pinned:true,size:2,color:[0,0,1]},
+      {name:"D2",type:"PointOnSegment",args:["s2"],pos:[-5,7]},
+      {name:"A3",type:"Free",pos:[-9,4],visible:false},
+      {name:"B3",type:"Free",pos:[-1,4],visible:false},
+      {name:"s3",type:"Segment",args:["A3","B3"]},
+      {name:"C3",type:"PointOnSegment",args:["s3"],pos:[-5,4],pinned:true,size:2,color:[0,0,1]},
+      {name:"D3",type:"PointOnSegment",args:["s3"],pos:[-6,4]},
+      {name:"A4",type:"Free",pos:[-8,5],visible:false},
+      {name:"B4",type:"Free",pos:[0,5],visible:false},
+      {name:"s4",type:"Segment",args:["A4","B4"]},
+      {name:"C4",type:"PointOnSegment",args:["s4"],pos:[-4,5],pinned:true,size:2,color:[0,0,1]},
+      {name:"D4",type:"PointOnSegment",args:["s4"],pos:[-2,5]},
+      {name:"A5",type:"Free",pos:[2,5],visible:false},
+      {name:"B5",type:"Free",pos:[10,5],visible:false},
+      {name:"s5",type:"Segment",args:["A5","B5"]},
+      {name:"C5",type:"PointOnSegment",args:["s5"],pos:[6,5],pinned:true,size:2,color:[0,0,1]},
+      {name:"D5",type:"PointOnSegment",args:["s5"],pos:[8,5]},
+      {name:"A6",type:"Free",pos:[1,4],visible:false},
+      {name:"B6",type:"Free",pos:[9,4],visible:false},
+      {name:"s6",type:"Segment",args:["A6","B6"]},
+      {name:"C6",type:"PointOnSegment",args:["s6"],pos:[5,4],pinned:true,size:2,color:[0,0,1]},
+      {name:"D6",type:"PointOnSegment",args:["s6"],pos:[4,4]},
+      {name:"A7",type:"Free",pos:[1,7],visible:false},
+      {name:"B7",type:"Free",pos:[9,7],visible:false},
+      {name:"s7",type:"Segment",args:["A7","B7"]},
+      {name:"C7",type:"PointOnSegment",args:["s7"],pos:[5,7],pinned:true,size:2,color:[0,0,1]},
+      {name:"D7",type:"PointOnSegment",args:["s7"],pos:[5,7]},
+      {name:"A8",type:"Free",pos:[2,8],visible:false},
+      {name:"B8",type:"Free",pos:[10,8],visible:false},
+      {name:"s8",type:"Segment",args:["A8","B8"]},
+      {name:"C8",type:"PointOnSegment",args:["s8"],pos:[6,8],pinned:true,size:2,color:[0,0,1]},
+      {name:"D8",type:"PointOnSegment",args:["s8"],pos:[6,8]},
+      {name:"B",type:"Button",text:"Repos",dock:{corner:"UL", offset:[10,-30]},script:"initCam=true"},
+    ],
+  });
+</script>
+</head>
+
+<body>
+  <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
+  <div id="CSCanvas"></div>
+</body>
+
+</html>

--- a/plugins/cindy3d/src/js/Camera.js
+++ b/plugins/cindy3d/src/js/Camera.js
@@ -69,8 +69,8 @@ Camera.prototype.setCamera = function(position, lookAt, up) {
   let viewDir = sub3(position, lookAt);
   this.viewDist = norm3(viewDir);
   let z2 = normalized3(viewDir);
-  let y2 = normalized3(up);
-  let x2 = cross3(y2, z2);
+  let x2 = normalized3(cross3(up, z2));
+  let y2 = cross3(z2, x2);
   let m1 = [
     x2[0], y2[0], z2[0],
     x2[1], y2[1], z2[1],

--- a/plugins/cindy3d/src/js/Camera.js
+++ b/plugins/cindy3d/src/js/Camera.js
@@ -9,7 +9,7 @@
 function Camera(width, height) {
   this.width = width;
   this.height = height;
-  this.fieldOfView = 45;
+  this.fieldOfView = 45 * (Math.PI / 360.);
   this.zNear = 0.1;
   this.zFar = 100;
   this.updatePerspective();
@@ -47,7 +47,7 @@ Camera.prototype.viewMatrix;
 Camera.prototype.mvMatrix;
 
 Camera.prototype.updatePerspective = function() {
-  let f = 1.0/Math.tan(this.fieldOfView * (Math.PI / 360.));
+  let f = 1.0/Math.tan(this.fieldOfView);
   let nearMinusFar = this.zNear - this.zFar;
   // Near plane is actually at -zNear, far plane at -zFar.
   // This is in sync with the glFrustrum call of legacy OpenGL 2.

--- a/plugins/cindy3d/src/js/Interface.js
+++ b/plugins/cindy3d/src/js/Interface.js
@@ -61,6 +61,17 @@ coerce.toDirection = function(arg, def=[0,0,0]) {
  * @param {Array.<number>=} def
  * @return {Array.<number>}
  */
+coerce.toDirectionPoint = function(arg, def=[0,0,0,0]) {
+  let lst = coerce.toDirection(arg, def);
+  if (lst !== def) lst[3] = 0;
+  return lst;
+}
+
+/**
+ * @param {CindyJS.anyval} arg
+ * @param {Array.<number>=} def
+ * @return {Array.<number>}
+ */
 coerce.toColor = function(arg, def=[0.5,0.5,0.5]) {
   if (arg.ctype === "number") {
     let c = coerce.toInterval(0, 1, arg);
@@ -142,6 +153,20 @@ coerce.toString = function(arg, def=null) {
   if (arg["ctype"] === "string")
     return arg["value"];
   console.log("argument is not a string");
+  return def;
+};
+
+/**
+ * @param {Array.<?string>} names
+ * @param {CindyJS.anyval} arg
+ * @param {?string=} def
+ * @return {?string}
+ */
+coerce.toEnum = function(names, arg, def=null) {
+  let str = coerce.toString(arg, def);
+  if (str !== def && names.indexOf(str) !== -1)
+    return str;
+  console.log("argument is not one of " + names.join(", "));
   return def;
 };
 

--- a/plugins/cindy3d/src/js/Lighting.js
+++ b/plugins/cindy3d/src/js/Lighting.js
@@ -71,8 +71,7 @@ Light.prototype.args;
 Light.prototype.typeMap = {
   "uDiffuse": "vec3",
   "uSpecular": "vec3",
-  "uLightPos": "vec3",
-  "uLightDir": "vec3",
+  "uLightPos": "vec4",
   "uSpotDir": "vec3",
   "uSpotCosCutoff": "float",
   "uSpotExponent": "float",
@@ -116,19 +115,6 @@ function PointLight(pos, diffuse, specular) {
 
 PointLight.prototype = new Light(
   "pointLight", ["uLightPos", "uDiffuse", "uSpecular"]);
-
-/**
- * @constructor
- * @extends Light
- */
-function DirectionalLight(dir, diffuse, specular) {
-  this["uLightDir"] = dir;
-  this["uDiffuse"] = diffuse;
-  this["uSpecular"] = specular;
-}
-
-DirectionalLight.prototype = new Light(
-  "directionalLight", ["uLightDir", "uDiffuse", "uSpecular"]);
 
 /**
  * @constructor

--- a/plugins/cindy3d/src/js/Lighting.js
+++ b/plugins/cindy3d/src/js/Lighting.js
@@ -4,7 +4,7 @@
  */
 function Lighting() {
   this.ambient = [0, 0, 0];
-  this.lights = [new PointLight([0, 0, 0], [1, 1, 1], [1, 1, 1])];
+  this.lights = [new CameraPointLight([0, 0, 0, 1], [1, 1, 1], [1, 1, 1])];
   this.modified = false;
 }
 
@@ -72,7 +72,7 @@ Light.prototype.typeMap = {
   "uDiffuse": "vec3",
   "uSpecular": "vec3",
   "uLightPos": "vec4",
-  "uSpotDir": "vec3",
+  "uSpotPos": "vec4",
   "uSpotCosCutoff": "float",
   "uSpotExponent": "float",
 };
@@ -106,29 +106,100 @@ Light.prototype.setUniforms = function(u, i) {
 /**
  * @constructor
  * @extends Light
+ * @param {Array.<number>} pos
+ * @param {Array.<number>} diffuse
+ * @param {Array.<number>} specular
  */
-function PointLight(pos, diffuse, specular) {
+function CameraPointLight(pos, diffuse, specular) {
   this["uLightPos"] = pos;
   this["uDiffuse"] = diffuse;
   this["uSpecular"] = specular;
 }
 
-PointLight.prototype = new Light(
-  "pointLight", ["uLightPos", "uDiffuse", "uSpecular"]);
+CameraPointLight.prototype = new Light(
+  "cameraPointLight", ["uLightPos", "uDiffuse", "uSpecular"]);
 
 /**
  * @constructor
  * @extends Light
+ * @param {Array.<number>} pos
+ * @param {Array.<number>} diffuse
+ * @param {Array.<number>} specular
  */
-function SpotLight(pos, dir, cutoff, exponent, diffuse, specular) {
+function WorldPointLight(pos, diffuse, specular) {
   this["uLightPos"] = pos;
-  this["uSpotDir"] = dir;
+  this["uDiffuse"] = diffuse;
+  this["uSpecular"] = specular;
+}
+
+WorldPointLight.prototype = new Light(
+  "worldPointLight", ["uLightPos", "uDiffuse", "uSpecular"]);
+
+/**
+ * @enum {function(new:Light, Array.<number>, Array.<number>, Array.<number>)}
+ */
+const PointLights = {
+  "camera": CameraPointLight,
+  "world": WorldPointLight,
+};
+
+/**
+ * @constructor
+ * @extends Light
+ * @param {Array.<number>} lightPos
+ * @param {Array.<number>} spotPos
+ * @param {number} cutoff
+ * @param {number} exponent
+ * @param {Array.<number>} diffuse
+ * @param {Array.<number>} specular
+ */
+function CameraSpotLight(
+  lightPos, spotPos, cutoff, exponent, diffuse, specular)
+{
+  this["uLightPos"] = lightPos;
+  this["uSpotPos"] = spotPos;
   this["uSpotCosCutoff"] = [cutoff];
   this["uSpotExponent"] = [exponent];
   this["uDiffuse"] = diffuse;
   this["uSpecular"] = specular;
 }
 
-SpotLight.prototype = new Light(
-  "spotLight", ["uLightPos", "uSpotDir", "uSpotCosCutoff", "uSpotExponent",
-                "uDiffuse", "uSpecular"]);
+CameraSpotLight.prototype = new Light(
+  "cameraSpotLight", [
+    "uLightPos", "uSpotPos", "uSpotCosCutoff", "uSpotExponent",
+    "uDiffuse", "uSpecular"]);
+
+/**
+ * @constructor
+ * @extends Light
+ * @param {Array.<number>} lightPos
+ * @param {Array.<number>} spotPos
+ * @param {number} cutoff
+ * @param {number} exponent
+ * @param {Array.<number>} diffuse
+ * @param {Array.<number>} specular
+ */
+function WorldSpotLight(
+  lightPos, spotPos, cutoff, exponent, diffuse, specular)
+{
+  this["uLightPos"] = lightPos;
+  this["uSpotPos"] = spotPos;
+  this["uSpotCosCutoff"] = [cutoff];
+  this["uSpotExponent"] = [exponent];
+  this["uDiffuse"] = diffuse;
+  this["uSpecular"] = specular;
+}
+
+WorldSpotLight.prototype = new Light(
+  "worldSpotLight", [
+    "uLightPos", "uSpotPos", "uSpotCosCutoff", "uSpotExponent",
+    "uDiffuse", "uSpecular"]);
+
+/**
+ * @enum {function(new:Light, Array.<number>, Array.<number>, number, number,
+ *                 Array.<number>, Array.<number>)}
+ */
+const SpotLights = {
+  "camera": CameraSpotLight,
+  "world": WorldSpotLight,
+};

--- a/plugins/cindy3d/src/js/Ops3D.js
+++ b/plugins/cindy3d/src/js/Ops3D.js
@@ -449,7 +449,7 @@ CindyJS.registerPlugin(1, "Cindy3D", function(api) {
   });
 
   defOp("fieldofview3d", 1, function(args, modifs) {
-    let fov = coerce.toInterval(1, 179, evaluate(args[0]), 0);
+    let fov = coerce.toInterval(0.01, 3.13, evaluate(args[0]), 0);
     if (fov > 0) {
       currentInstance.camera.fieldOfView = fov;
       currentInstance.camera.updatePerspective();

--- a/plugins/cindy3d/src/js/Ops3D.js
+++ b/plugins/cindy3d/src/js/Ops3D.js
@@ -475,46 +475,51 @@ CindyJS.registerPlugin(1, "Cindy3D", function(api) {
   defOp("pointlight3d", 1, function(args, modifs) {
     let index = coerce.toInt(evaluate(args[0]), 0);
     let position = [0, 0, 0, 1], diffuse = [1, 1, 1], specular = [1, 1, 1];
+    let frame = "camera";
     handleModifs(modifs, {
       "position": a => position = coerce.toHomog(a, position),
       "diffuse": a => diffuse = coerce.toColor(a, diffuse),
       "specular": a => specular = coerce.toColor(a, specular),
+      "frame": a => frame = coerce.toEnum(["camera", "world"], a, frame),
     });
     currentInstance.lighting.setLight(
-      index, new PointLight(position, diffuse, specular));
+      index, new (PointLights[frame])(position, diffuse, specular));
     return nada;
   });
 
   defOp("directionallight3d", 1, function(args, modifs) {
     let index = coerce.toInt(evaluate(args[0]), 0);
-    let direction = [0, -1, 0], diffuse = [1, 1, 1], specular = [1, 1, 1];
+    let direction = [0, -1, 0, 0], diffuse = [1, 1, 1], specular = [1, 1, 1];
+    let frame = "camera";
     handleModifs(modifs, {
-      "direction": a => direction = coerce.toDirection(a, direction),
+      "direction": a => direction = coerce.toDirectionPoint(a, direction),
       "diffuse": a => diffuse = coerce.toColor(a, diffuse),
       "specular": a => specular = coerce.toColor(a, specular),
+      "frame": a => frame = coerce.toEnum(["camera", "world"], a, frame),
     });
-    direction.push(0);
     currentInstance.lighting.setLight(
-      index, new PointLight(direction, diffuse, specular));
+      index, new (PointLights[frame])(direction, diffuse, specular));
     return nada;
   });
 
   defOp("spotlight3d", 1, function(args, modifs) {
     let index = coerce.toInt(evaluate(args[0]), 0);
-    let position = [0, 0, 0, 1], direction = [0, -1, 0];
+    let position = [0, 0, 0, 1], direction = [0, -1, 0, 0];
     let cutoff = Math.PI/4, exponent = 0;
     let diffuse = [1, 1, 1], specular = [1, 1, 1];
+    let frame = "camera";
     handleModifs(modifs, {
       "position": a => position = coerce.toHomog(a, position),
-      "direction": a => direction = coerce.toDirection(a, direction),
+      "direction": a => direction = coerce.toDirectionPoint(a, direction),
       "cutoffangle": a => cutoff = coerce.toInterval(0, Math.PI, a, cutoff),
       "exponent": a => exponent = coerce.toReal(a, exponent),
       "diffuse": a => diffuse = coerce.toColor(a, diffuse),
       "specular": a => specular = coerce.toColor(a, specular),
+      "frame": a => frame = coerce.toEnum(["camera", "world"], a, frame),
     });
     currentInstance.lighting.setLight(
-      index, new SpotLight(position, direction, Math.cos(cutoff),
-                           exponent, diffuse, specular));
+      index, new SpotLights[frame](
+        position, direction, Math.cos(cutoff), exponent, diffuse, specular));
     return nada;
   });
 

--- a/plugins/cindy3d/src/js/Ops3D.js
+++ b/plugins/cindy3d/src/js/Ops3D.js
@@ -481,7 +481,7 @@ CindyJS.registerPlugin(1, "Cindy3D", function(api) {
       "specular": a => specular = coerce.toColor(a, specular),
     });
     currentInstance.lighting.setLight(
-      index, new PointLight(dehom3(position), diffuse, specular));
+      index, new PointLight(position, diffuse, specular));
     return nada;
   });
 
@@ -493,8 +493,9 @@ CindyJS.registerPlugin(1, "Cindy3D", function(api) {
       "diffuse": a => diffuse = coerce.toColor(a, diffuse),
       "specular": a => specular = coerce.toColor(a, specular),
     });
+    direction.push(0);
     currentInstance.lighting.setLight(
-      index, new DirectionalLight(direction, diffuse, specular));
+      index, new PointLight(direction, diffuse, specular));
     return nada;
   });
 
@@ -512,7 +513,7 @@ CindyJS.registerPlugin(1, "Cindy3D", function(api) {
       "specular": a => specular = coerce.toColor(a, specular),
     });
     currentInstance.lighting.setLight(
-      index, new SpotLight(dehom3(position), direction, Math.cos(cutoff),
+      index, new SpotLight(position, direction, Math.cos(cutoff),
                            exponent, diffuse, specular));
     return nada;
   });

--- a/plugins/cindy3d/src/str/lighting1.glsl
+++ b/plugins/cindy3d/src/str/lighting1.glsl
@@ -30,15 +30,15 @@ void commonLight(in vec3 lightDir, in vec3 diffuse, in vec3 specular) {
   gAccumSpecular += specular * specFactor;
 }
 
-void pointLight(in vec3 lightPos, in vec3 diffuse, in vec3 specular) {
-  commonLight(normalize(lightPos - gPos), diffuse, specular);
+vec3 getLightDir(in vec4 lightPos) {
+  return normalize(lightPos.xyz - lightPos.w*gPos);
 }
 
-void directionalLight(in vec3 lightDir, in vec3 diffuse, in vec3 specular) {
-  commonLight(normalize(lightDir), diffuse, specular);
+void pointLight(in vec4 lightPos, in vec3 diffuse, in vec3 specular) {
+  commonLight(getLightDir(lightPos), diffuse, specular);
 }
 
-void spotLight(in vec3 lightPos, in vec3 spotDir,
+void spotLight(in vec4 lightPos, in vec3 spotDir,
                in float spotCosCutoff, in float spotExponent,
                in vec3 diffuse, in vec3 specular) {
   vec3 lightDir;      // direction from surface to light position
@@ -49,7 +49,7 @@ void spotLight(in vec3 lightPos, in vec3 spotDir,
   float spotCosAngle;    // cosine of angle between spotlight
   float spotAttenuation; // spotlight attenuation factor
 
-  lightDir = normalize(lightPos - gPos);
+  lightDir = getLightDir(lightPos);
   halfVector = normalize(lightDir + gEye);
   diffuseDot = max(0.0, dot(gNormal, lightDir));
   specularDot = max(0.0, dot(gNormal, halfVector));

--- a/plugins/cindy3d/src/str/lighting1.glsl
+++ b/plugins/cindy3d/src/str/lighting1.glsl
@@ -1,4 +1,5 @@
 uniform vec3 uAmbient;
+uniform mat4 uModelViewMatrix;
 
 varying vec4 vColor;
 varying float vShininess;
@@ -9,62 +10,84 @@ vec3 gNormal;
 vec3 gAccumDiffuse;
 vec3 gAccumSpecular;
 
-void commonLight(in vec3 lightDir, in vec3 diffuse, in vec3 specular) {
-  vec3 halfVector;    // Direction of maximum highlights
-  float diffuseDot;   // Dot(normal, light direction)
-  float specularDot;  // Dot(normal, light half vector)
-  float specFactor;   // specular factor
+void commonLight(in vec4 lightPos, out vec3 lightDir,
+                 out float diffuseFactor, out float specularFactor) {
+  vec3 halfVector;       // direction of maximum highlights
+  float specularDot;     // dot(normal, light half vector)
 
+  lightDir = normalize(lightPos.xyz - lightPos.w*gPos);
   halfVector = normalize(lightDir + gEye);
-  diffuseDot = max(0.0, dot(gNormal, lightDir));
+  diffuseFactor = max(0.0, dot(gNormal, lightDir));
   specularDot = max(0.0, dot(gNormal, halfVector));
 
   // If point is not lit
-  if (diffuseDot == 0.0)
-    specFactor = 0.0;
+  if (diffuseFactor == 0.0)
+    specularFactor = 0.0;
   else
-    specFactor = pow(specularDot, vShininess);
-
-  // Add light received from this light source to global colors
-  gAccumDiffuse  += diffuse * diffuseDot;
-  gAccumSpecular += specular * specFactor;
+    specularFactor = pow(specularDot, vShininess);
 }
 
-vec3 getLightDir(in vec4 lightPos) {
-  return normalize(lightPos.xyz - lightPos.w*gPos);
+vec4 flipY(in vec4 v) {
+  return vec4(v.x, -v.y, v.z, v.w);
 }
 
 void pointLight(in vec4 lightPos, in vec3 diffuse, in vec3 specular) {
-  commonLight(getLightDir(lightPos), diffuse, specular);
+  vec3 lightDir;         // direction from surface to light position
+  float diffuseFactor;   // dot(normal, light direction)
+  float specularFactor;  // specular factor
+
+  commonLight(lightPos, lightDir, diffuseFactor, specularFactor);
+
+  // Add light received from this light source to global colors
+  gAccumDiffuse  += diffuse * diffuseFactor;
+  gAccumSpecular += specular * specularFactor;
 }
 
-void spotLight(in vec4 lightPos, in vec3 spotDir,
-               in float spotCosCutoff, in float spotExponent,
-               in vec3 diffuse, in vec3 specular) {
-  vec3 lightDir;      // direction from surface to light position
-  vec3 halfVector;    // Direction of maximum highlights
-  float diffuseDot;   // Dot(normal, light direction)
-  float specularDot;  // Dot(normal, light half vector)
-  float specFactor;   // specular factor
+void cameraPointLight(in vec4 lightPos, in vec3 diffuse, in vec3 specular) {
+  pointLight(flipY(lightPos), diffuse, specular);
+}
+
+void worldPointLight(in vec4 lightPos, in vec3 diffuse, in vec3 specular) {
+  pointLight(-uModelViewMatrix*lightPos, diffuse, specular);
+}
+
+void spotLight(
+  in vec4 lightPos, in vec4 spotPos, in float spotCosCutoff,
+  in float spotExponent, in vec3 diffuse, in vec3 specular)
+{
+  vec3 lightDir;         // direction from surface to light position
+  float diffuseFactor;   // dot(normal, light direction)
+  float specularFactor;  // specular factor
+  vec3 spotDir;          // direction from light source to spot
   float spotCosAngle;    // cosine of angle between spotlight
   float spotAttenuation; // spotlight attenuation factor
 
-  lightDir = getLightDir(lightPos);
-  halfVector = normalize(lightDir + gEye);
-  diffuseDot = max(0.0, dot(gNormal, lightDir));
-  specularDot = max(0.0, dot(gNormal, halfVector));
+  commonLight(lightPos, lightDir, diffuseFactor, specularFactor);
 
+  spotDir = lightPos.w*spotPos.xyz - spotPos.w*lightPos.xyz;
   spotCosAngle = dot(-lightDir, normalize(spotDir));
   spotAttenuation =
     step(spotCosCutoff, spotCosAngle) * pow(spotCosAngle, spotExponent);
 
-  // If point is not lit
-  if (diffuseDot == 0.0)
-    specFactor = 0.0;
-  else
-    specFactor = pow(specularDot, vShininess);
-
   // Add light received from this light source to global colors
-  gAccumDiffuse  += spotAttenuation * diffuse * diffuseDot;
-  gAccumSpecular += spotAttenuation * specular * specFactor;
+  gAccumDiffuse  += spotAttenuation * diffuse * diffuseFactor;
+  gAccumSpecular += spotAttenuation * specular * specularFactor;
+}
+
+void cameraSpotLight(
+  in vec4 lightPos, in vec4 spotPos, in float spotCosCutoff,
+  in float spotExponent, in vec3 diffuse, in vec3 specular)
+{
+  spotLight(
+    flipY(lightPos), flipY(spotPos),
+    spotCosCutoff, spotExponent, diffuse, specular);
+}
+
+void worldSpotLight(
+  in vec4 lightPos, in vec4 spotPos, in float spotCosCutoff,
+  in float spotExponent, in vec3 diffuse, in vec3 specular)
+{
+  spotLight(
+    -uModelViewMatrix*lightPos, -uModelViewMatrix*spotPos,
+    spotCosCutoff, spotExponent, diffuse, specular);
 }


### PR DESCRIPTION
This fixes a bug where `fieldofview3d` was expecting its input in degrees, where it should be in radiuans (which you can of course generate using the `°` symbol in CindyScript). There is also a bug in the way the basis was computed when repositioning the camera. Apart from this, there is a new example, and lights can now be positioned with respect to the world reference frame instead of the camera reference frame.