### PR TITLE
Allow TransformSegment as an alias to TransformS

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2611,6 +2611,11 @@ geoMacros.TransformConic = function(el) {
     return [el];
 };
 
+geoMacros.TransformSegment = function(el) {
+    el.type = "TransformS";
+    return [el];
+};
+
 geoMacros.angleBisector = function(el) {
     var point = {
         name: el.name + "_Intersection",


### PR DESCRIPTION
This matches what Cinderella currently exports, and it's the more descriptive title so it probably should stay.