### PR TITLE
Node 6.3 fixed string_decoder bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.2.0"
+  - node
   - "0.12"
 script: node make build=release alltests
 sudo: false

--- a/make/check-node-version.js
+++ b/make/check-node-version.js
@@ -12,8 +12,8 @@ if (a == 0 && b < 12) {
                 process.version + " found");
   process.exit(1);
 }
-if (a > 6 || (a == 6 && (b > 2 || (b == 2 && c >= 1)))) {
-  console.error("Node versions starting at 6.2.1 have a bug,");
+if (a == 6 && b == 2 && c >= 1) {
+  console.error("Node version 6.2.x for x >= 1 have a bug,");
   console.error("likely causing the “forbidden” check to fail.");
   console.error("See https://github.com/nodejs/node/issues/7308");
   console.error("and https://github.com/CindyJS/CindyJS/pull/378 for details.");


### PR DESCRIPTION
So we adjust the warning to only warn about 6.2.x for x >= 1.
We also revert the Travis instructions to use the latest version again.