### PR TITLE
Update Closure Compiler to latest version (v20160713)

### DIFF
--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160619",
+        closure_version: "20160713",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",

--- a/make/build.js
+++ b/make/build.js
@@ -23,7 +23,7 @@ module.exports = function build(settings, task) {
     var closure_zip = "compiler-" + settings.get("closure_version") + ".zip";
     var closure_url = settings.get("closure_urlbase") + "/" + closure_zip;
     var closure_archive = "download/arch/" + closure_zip;
-    var closure_jar = "download/closure-compiler/compiler-" +
+    var closure_jar = "download/closure-compiler/closure-compiler-v" +
         settings.get("closure_version") + ".jar";
 
     task("closure-zip", [], function() {
@@ -31,7 +31,8 @@ module.exports = function build(settings, task) {
     });
 
     task("closure-jar", ["closure-zip"], function() {
-        this.unzip(closure_archive, closure_jar, "compiler.jar");
+        this.unzip(closure_archive, closure_jar, "closure-compiler-v" +
+        settings.get("closure_version") + ".jar");
     });
 
     //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This should fix #407.

According to [Closure Compiler Release notes](https://github.com/google/closure-compiler/wiki/Releases#july-13-2016-v20160713), this version provides much faster compilation.