### PR TITLE
Move animation settings to their own subobject

### DIFF
--- a/examples/142_kaleido.html
+++ b/examples/142_kaleido.html
@@ -109,7 +109,7 @@ CindyJS({
     {name: "E0", type: "Locus", color: [1.0, 0.0, 0.0], args: ["D", "C0", "P6"]},
     {name: "P7", type: "Mid", color: [1.0, 0.0, 0.0], args: ["P6", "P4"], labeled: true, printname: "$P_{7}$"}
   ],
-  autoplay: true,
+  animation: {autoplay: true},
   ports: [{
     id: "CSCanvas",
     width: 1154,

--- a/examples/143_assoc_mult_compare_geoops.html
+++ b/examples/143_assoc_mult_compare_geoops.html
@@ -77,7 +77,7 @@ CindyJS({
     {name: "p", type: "Segment", color: [0.0, 0.0, 0.0], args: ["H", "K"]},
     {name: "L", type: "PointOnSegment", pos: [4.0, 2.473684210526315, 0.21929824561403508], color: [1.0, 1.0, 1.0], args: ["p"]}
   ],
-  autoplay: true,
+  animation: {autoplay: true},
   ports: [{
     id: "CSCanvas",
     width: 799,

--- a/examples/144_randomtree.html
+++ b/examples/144_randomtree.html
@@ -77,7 +77,7 @@
                       {name:"C", type:"Free", pos:[-.25, -.25], color:[1,0,0], pinned:false, size:6, alpha: .3},
                       {name:"D", type:"Free", pos:[.25, -.25], color:[1,0,0], pinned:false, size:6, alpha: .3}
                     ],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 750,

--- a/examples/81_Clock.html
+++ b/examples/81_Clock.html
@@ -39,7 +39,7 @@ var cdy = CindyJS({
   canvasname: "CSCanvas",
   scripts: "cs*",
   language: "en",
-  autoplay: true,
+  animation: {autoplay: true},
   defaultAppearance: {}
 });
 

--- a/examples/88_TracingVis1.html
+++ b/examples/88_TracingVis1.html
@@ -31,7 +31,7 @@ var cdy2 = CindyJS({
   scripts: "cs2*",
   language: "en",
   defaultAppearance: {},
-  autoplay: false,
+  animation: {autoplay: false},
   geometry: [],
   grid: 1,
   oninit: function() {

--- a/examples/88_TracingVis2.html
+++ b/examples/88_TracingVis2.html
@@ -46,7 +46,7 @@ var cdy2 = CindyJS({
   scripts: "cs2*",
   language: "en",
   defaultAppearance: {},
-  autoplay: false,
+  animation: {autoplay: false},
   geometry: [
   {name:"C1", type:"Free", pos:[0,0], color:[0,0,0], size:2},
   {name:"CCost", type:"Free", pos:[0,0], color:[1,1,1], size:1},

--- a/examples/90_Tracing5.html
+++ b/examples/90_Tracing5.html
@@ -27,7 +27,7 @@ var cdy = CindyJS({ // See ref/createCindy documentation for details.
   enableTraceLog: true,
   tracingStateReport: "tracingStateReport",
   grid: 1,
-  autoplay: true,
+  animation: {autoplay: true},
   snap: true,
   geometry: [
     {name:"A", type:"Free", pos:[0,1]},

--- a/examples/animcontrols.html
+++ b/examples/animcontrols.html
@@ -12,7 +12,7 @@ var cdy = CindyJS({
   ports: [{id: "CSCanvas", width: 500, height: 500}],
   scripts: "cs*",
   language: "en",
-  animcontrols: true,
+  animation: {controls: true},
   defaultAppearance: {
   },
   geometry: [

--- a/examples/cindygl/02_mandelbrot_3d.html
+++ b/examples/cindygl/02_mandelbrot_3d.html
@@ -96,7 +96,7 @@
         CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 1024,

--- a/examples/cindygl/04_movingplot.html
+++ b/examples/cindygl/04_movingplot.html
@@ -42,7 +42,7 @@
         CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/05_pixelinterference.html
+++ b/examples/cindygl/05_pixelinterference.html
@@ -37,7 +37,7 @@
         CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/06_raytracer_bisection.html
+++ b/examples/cindygl/06_raytracer_bisection.html
@@ -184,7 +184,7 @@
     <script type="text/javascript">
         CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/06_raytracer_homotopy.html
+++ b/examples/cindygl/06_raytracer_homotopy.html
@@ -186,7 +186,7 @@
     <script type="text/javascript">
         CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/07_diffusion.html
+++ b/examples/cindygl/07_diffusion.html
@@ -58,7 +58,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/08_julia.html
+++ b/examples/cindygl/08_julia.html
@@ -43,7 +43,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/08_julia_advanced.html
+++ b/examples/cindygl/08_julia_advanced.html
@@ -71,7 +71,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 1024,

--- a/examples/cindygl/08_julia_conjugated.html
+++ b/examples/cindygl/08_julia_conjugated.html
@@ -66,7 +66,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 1280,

--- a/examples/cindygl/08_julia_explanation.html
+++ b/examples/cindygl/08_julia_explanation.html
@@ -63,7 +63,7 @@ tp(a) := (re(a), im(a));
                       {name:"C", type:"Free", pos:[-0.79, -0.184], color:[1,0,0], pinned:false, size:6}
                     ]
                     ,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/08_julia_nointerpolation.html
+++ b/examples/cindygl/08_julia_nointerpolation.html
@@ -43,7 +43,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/09_ifs.html
+++ b/examples/cindygl/09_ifs.html
@@ -48,7 +48,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 512,

--- a/examples/cindygl/09_ifs_barnsley.html
+++ b/examples/cindygl/09_ifs_barnsley.html
@@ -103,7 +103,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 400,

--- a/examples/cindygl/09_ifs_sierpinski.html
+++ b/examples/cindygl/09_ifs_sierpinski.html
@@ -65,7 +65,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/10_gol.html
+++ b/examples/cindygl/10_gol.html
@@ -85,7 +85,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 512,

--- a/examples/cindygl/11_tilings.html
+++ b/examples/cindygl/11_tilings.html
@@ -145,7 +145,7 @@
     {name:"CB", type:"Free", pos:[1.3,.2],color:[0,1,0],pinned:false,size:6},
     {name:"CC", type:"Free", pos:[1.3,.5],color:[0,0,1],pinned:false,size:6},
                     ],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 600,

--- a/examples/cindygl/11_tilings_kaleidoscope.html
+++ b/examples/cindygl/11_tilings_kaleidoscope.html
@@ -145,7 +145,7 @@
     {name:"CB", type:"Free", pos:[1.3,.2],color:[0,1,0],pinned:false,size:6},
     {name:"CC", type:"Free", pos:[1.3,.5],color:[0,0,1],pinned:false,size:6},
                     ],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     images: {texture: "image.png"},
                     ports: [{
                       id: "CSCanvas",

--- a/examples/cindygl/12_kleinian.html
+++ b/examples/cindygl/12_kleinian.html
@@ -105,7 +105,7 @@
                     scripts: "cs*",
                     geometry: [{name:"TA", type:"Free", pos:[0.,0.],color:[1,0,0],pinned:false,size:6},
                               {name:"TB", type:"Free", pos:[0.,0.],color:[0,0,1],pinned:false,size:6}],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/12_kleinian2.html
+++ b/examples/cindygl/12_kleinian2.html
@@ -118,7 +118,7 @@
                     geometry: [{name:"TA", type:"Free", pos:[-1 ,0.],color:[1,.3,.3],pinned:false,size:6},
                                {name:"TB", type:"Free", pos:[-1 ,0.],color:[.3,.3,1],pinned:false,size:6}
                                ],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 800,

--- a/examples/cindygl/12_kleinian2_conjugated.html
+++ b/examples/cindygl/12_kleinian2_conjugated.html
@@ -132,7 +132,7 @@
                     scripts: "cs*",
                     geometry: [{name:"TA", type:"Free", pos:[2 ,2],color:[1,.3,.3],pinned:false,size:6},
                                {name:"TB", type:"Free", pos:[2 ,2],color:[.3,.3,1],pinned:false,size:6}],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 1024,

--- a/examples/cindygl/13_random.html
+++ b/examples/cindygl/13_random.html
@@ -28,7 +28,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 512,

--- a/examples/cindygl/14_reactiondiffusion.html
+++ b/examples/cindygl/14_reactiondiffusion.html
@@ -73,7 +73,7 @@
           geometry:[
             {name:"CA", type:"Free", pos:[500,350],color:[1,0,0],pinned:false,size:6},
           ],
-          autoplay: true,
+          animation: {autoplay: true},
           ports: [{
             id: "CSCanvas",
             width: 512,

--- a/examples/cindygl/15_lic.html
+++ b/examples/cindygl/15_lic.html
@@ -99,7 +99,7 @@
                       {name:"A", kind:"P", type:"Free", pos:[1  ,-1],size:3},
                       {name:"B", kind:"P", type:"Free", pos:[-1 ,1],size:3}
                     ],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 512,

--- a/examples/cindygl/15_lic2.html
+++ b/examples/cindygl/15_lic2.html
@@ -80,7 +80,7 @@
                     geometry:[
 																					{name:"A", kind:"P", type:"Free", pos:[1.01,-1.01],size:3}
                     ],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 512,

--- a/examples/cindygl/15_lic3.html
+++ b/examples/cindygl/15_lic3.html
@@ -101,7 +101,7 @@
 																					{name:"A", kind:"P", type:"Free", pos:[.5  ,.5],size:3},
 																					{name:"B", kind:"P", type:"Free", pos:[-.5 ,-.5],size:3}
                     ],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 512,

--- a/examples/cindygl/16_userinput.html
+++ b/examples/cindygl/16_userinput.html
@@ -33,7 +33,7 @@
         var gslp=[{name:"A", kind:"P", type:"Free", pos:[-2,2]}];
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
-                    autoplay: true,
+                    animation: {autoplay: true},
                     geometry:gslp
                     }
         );

--- a/examples/cindygl/16_userinput_lic.html
+++ b/examples/cindygl/16_userinput_lic.html
@@ -78,7 +78,7 @@
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:[],
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 512,

--- a/examples/cindygl/17_images.html
+++ b/examples/cindygl/17_images.html
@@ -32,7 +32,7 @@
         var gslp=[{name:"A", kind:"P", type:"Free", pos:[0.1, 0.1]}];
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
-                    autoplay: true,
+                    animation: {autoplay: true},
                     geometry: gslp,
                     images: {image:"image.png"},
                     ports: [{

--- a/examples/cindygl/17_images_blur.html
+++ b/examples/cindygl/17_images_blur.html
@@ -43,7 +43,7 @@
         var gslp=[];
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
-                    autoplay: true,
+                    animation: {autoplay: true},
                     geometry: gslp,
                     images: {image: "image.png"},
                     ports: [{

--- a/examples/cindygl/18_hidpitest.html
+++ b/examples/cindygl/18_hidpitest.html
@@ -54,7 +54,7 @@
         var gslp=[];
         cdy = CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
-                    autoplay: true,
+                    animation: {autoplay: true},
                     geometry: gslp,
                     images: {image: "image.png"},
                     ports: [{

--- a/examples/cindygl/21_pickit.html
+++ b/examples/cindygl/21_pickit.html
@@ -125,7 +125,7 @@ var cdy = CindyJS({
     {name:"B", type:"Free", pos:[0,0]},
     {name:"C", type:"Free", pos:[0,0]}
   ],
-  autoplay: true,
+  animation: {autoplay: true},
   use: ["CindyGL"]
 });
 

--- a/examples/cindygl/22_explorer.html
+++ b/examples/cindygl/22_explorer.html
@@ -186,7 +186,7 @@ var cdy = CindyJS({
     {name:"T", type:"Free", pos:[2.0,-.4],color:[1,1,1],pinned:false,size:4},
     {name:"o", type:"Segment", args:["T1","T2"],color:[0,0,0],pinned:false,size:2}
   ],
-  autoplay: true,
+  animation: {autoplay: true},
   //transform:[{translate:[0,0]},{scale:10}],
   images:{Rot:"uiImages/Rot.png",Sat:"uiImages/SSat.png",Grid:"uiImages/Grid.png"},
   use: ["CindyGL"]

--- a/examples/cindygl/23_infix_dist.html
+++ b/examples/cindygl/23_infix_dist.html
@@ -35,7 +35,7 @@
         CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
                     geometry:gslp,
-                    autoplay: true,
+                    animation: {autoplay: true},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/examples/cindygl/27_changingimages.html
+++ b/examples/cindygl/27_changingimages.html
@@ -38,7 +38,7 @@ var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-10, -10, 10, 10]}]}],
   scripts: "cs*",
   language: "en",
-  autoplay: true,
+  animation: {autoplay: true},
   images: {image:"image.png"},
   defaultAppearance: {
   },

--- a/examples/cindygl/28_apollian_gasket.html
+++ b/examples/cindygl/28_apollian_gasket.html
@@ -109,7 +109,7 @@ drawcircle(D, c4r);
             CindyJS({canvasname:"CSCanvas",
                         scripts: "cs*",
                         geometry:gslp,
-                        autoplay:true,
+                        animation:{autoplay:true},
                         use:["CindyGL"]}
                         );
 

--- a/examples/cindygl/29_modifiers_tunnel.html
+++ b/examples/cindygl/29_modifiers_tunnel.html
@@ -45,7 +45,7 @@ var cdy = CindyJS({
   ports: [{id: "CSCanvas", transform: [{visibleRect: [-20, -20, 20, 20]}]}],
   scripts: "cs*",
   language: "en",
-  autoplay: true,
+  animation: {autoplay: true},
   images: {image:"tile.jpg"},
   defaultAppearance: {
   },

--- a/examples/cindygl/30_verbatimglsl.html
+++ b/examples/cindygl/30_verbatimglsl.html
@@ -34,7 +34,7 @@
     <script type="text/javascript">
         CindyJS({canvasname:"CSCanvas",
                     scripts: "cs*",
-                    autoplay: false,
+                    animation: {autoplay: false},
                     ports: [{
                       id: "CSCanvas",
                       width: 500,

--- a/ref/createCindy.md
+++ b/ref/createCindy.md
@@ -167,13 +167,19 @@ See the section “Lab” for details.
 A list of URLs which will be loaded.
 Whenever an image is ready, it can be used in the application instance.
 
-### autoplay
+### animation
 
-Setting this to true indicates that the animation should start immediately after startup of the instance.
+An object containing the following properties:
 
-### animcontrols
+* `autoplay` is a boolean value which indicates whether the animation should start immediately after startup of the instance.
+* `controls` is a boolean value which controls whether animation control buttons (play, pause, stop) are to be displayed.
+* `speed` is the animation speed, as a double value which defaults to 1.
 
-When set to true, buttons to control animations will be shown.
+For the sake of backwards compatibility, `autoplay` may occur as
+a top level parameter instead of nested in the `animation` object.
+Likewise a top level `animcontrols` can be given instead of
+`animation.controls`.  But these are deprecated, and only being used
+if the `animation` object is not present at all.
 
 ### oninit
 

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -215,7 +215,8 @@ function createCindyNow() {
         updateCanvasDimensions();
         if (!csctx.setLineDash)
             csctx.setLineDash = function() {};
-        if (data.animcontrols) setupAnimControls();
+        if (data.animation ? data.animation.controls : data.animcontrols)
+            setupAnimControls();
     }
     if (data.statusbar) {
         if (typeof data.statusbar === "string") {
@@ -540,7 +541,8 @@ function doneLoadingModule() {
     //Evaluate Init script
     evaluate(cscompiled.init);
 
-    if (instanceInvocationArguments.autoplay)
+    if ((instanceInvocationArguments.animation ||
+            instanceInvocationArguments).autoplay)
         csplay();
 
     if (globalInstance.canvas)


### PR DESCRIPTION
Now we have `animation.autoplay` and `animation.controls` (i.e.  properties of a newly introduced `animation` subobject) instead of just `autoplay` and `animcontrols` as options in the CindyJS invocation.
This adds structure, keeping related settings together.
It is expected that a new setting `speed` will be added to that object soon.

The old settings are still being used if the `animation` object is absent, so this is not a breaking change.