### PR TITLE
Keep track of touch event streams

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -179,6 +179,18 @@ function setuplisteners(canvas, data) {
 
 
     function touchMove(e) {
+
+        var activeTouchIDList = e.changedTouches;
+        var gotit = false;
+        for (var i = 0; i < activeTouchIDList.length; i++) {
+            if (activeTouchIDList[i].identifier === activeTouchID) {
+                gotit = true;
+            }
+        }
+        if (!gotit) {
+            return;
+        }
+
         updatePostition(e.targetTouches[0]);
         if (mouse.down) {
             cs_mousedrag();
@@ -187,8 +199,19 @@ function setuplisteners(canvas, data) {
         }
         e.preventDefault();
     }
+    var activeTouchID = -1;
 
     function touchDown(e) {
+        if (activeTouchID !== -1) {
+            return;
+        }
+
+        var activeTouchIDList = e.changedTouches;
+        if (activeTouchIDList.length === 0) {
+            return;
+        }
+        activeTouchID = activeTouchIDList[0].identifier;
+
         updatePostition(e.targetTouches[0]);
         cs_mousedown();
         mouse.down = true;
@@ -198,6 +221,18 @@ function setuplisteners(canvas, data) {
     }
 
     function touchUp(e) {
+        var activeTouchIDList = e.changedTouches;
+        var gotit = false;
+        for (var i = 0; i < activeTouchIDList.length; i++) {
+            if (activeTouchIDList[i].identifier === activeTouchID) {
+                gotit = true;
+            }
+        }
+
+        if (!gotit) {
+            return;
+        }
+        activeTouchID = -1;
         mouse.down = false;
         cindy_cancelmove();
         stateContinueFromHere();


### PR DESCRIPTION
This ensures that a mouse interaction is only terminated by lifting the finger that started it.  It is no longer possible to terminate movement by touching the canvas with a second finger.

This is code @richter-gebert sent me and I just extracted and beautified it. So I'll review this one myself, once Travis had a look and I find the time.
