### PR TITLE
Improve validity of HTML in examples

### DIFF
--- a/examples/76_I18n.html
+++ b/examples/76_I18n.html
@@ -38,12 +38,8 @@ CindyJS({
 </head>
 
 <body style="font-family:Arial;">
-  <pre>
-    <div id="enCindy" style="width:500px; height:200px; border:2px solid black"></div>
-  </pre>
-  <pre>
-    <div id="deCindy" style="width:500px; height:200px; border:2px solid black"></div>
-  </pre>
+  <div id="enCindy" style="width:500px; height:200px; border:2px solid black"></div>
+  <div id="deCindy" style="width:500px; height:200px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/77_Plurals.html
+++ b/examples/77_Plurals.html
@@ -41,12 +41,8 @@ CindyJS({
 </head>
 
 <body style="font-family:Arial;">
-  <pre>
-    <div id="enCindy" style="width:500px; height:300px; border:2px solid black"></div>
-  </pre>
-  <pre>
-    <div id="deCindy" style="width:500px; height:300px; border:2px solid black"></div>
-  </pre>
+  <div id="enCindy" style="width:500px; height:300px; border:2px solid black"></div>
+  <div id="deCindy" style="width:500px; height:300px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/85_Createimage.html
+++ b/examples/85_Createimage.html
@@ -67,9 +67,7 @@ CindyJS({
 </head>
 
 <body style="font-family:Arial;">
-  <pre>
-    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
-  </pre>
+  <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/85a_CreateimageAff.html
+++ b/examples/85a_CreateimageAff.html
@@ -69,9 +69,7 @@ CindyJS({
 </head>
 
 <body style="font-family:Arial;">
-  <pre>
-    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
-  </pre>
+  <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/86_IFS.html
+++ b/examples/86_IFS.html
@@ -89,9 +89,7 @@ CindyJS({
 </head>
 
 <body style="font-family:Arial;">
-  <pre>
-    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
-  </pre>
+  <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/87_IFSIm.html
+++ b/examples/87_IFSIm.html
@@ -137,9 +137,7 @@ CindyJS({
 </head>
 
 <body style="font-family:Arial;">
-  <pre>
-    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
-  </pre>
+  <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/87_IFSIm2.html
+++ b/examples/87_IFSIm2.html
@@ -109,9 +109,7 @@ CindyJS({
 </head>
 
 <body style="font-family:Arial;">
-  <pre>
-    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
-  </pre>
+  <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/88_Vectorfield.html
+++ b/examples/88_Vectorfield.html
@@ -107,9 +107,7 @@ CindyJS({
 </head>
 
 <body style="font-family:Arial;">
-  <pre>
-    <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
-  </pre>
+  <div id="cindy" style="width:500px; height:500px; border:2px solid black"></div>
 </body>
 
 </html>

--- a/examples/cindygl/10_gol.html
+++ b/examples/cindygl/10_gol.html
@@ -66,7 +66,7 @@
       colorplot(imagergb(L, R, "gol", #, interpolate->false));
     </script>
     
-   <list>
+   <ul>
      <li>
     Click on canvas to interact!
      </li>
@@ -76,7 +76,7 @@
       <li>
     Press SPACE to reset to blank configuration.
       </li>
-    </list>
+    </ul>
   <div id="CSCanvas" style="position:relative; top:10px;"></div>
     
 

--- a/examples/cindygl/11_tilings.html
+++ b/examples/cindygl/11_tilings.html
@@ -88,8 +88,6 @@
       createimage("image", 1000, 1000);
     </script>
     
-    <script
-    
     <script id="csmousedown" type="text/x-cindyscript">
       showfundamentaldomain = true;
     </script>

--- a/examples/cindygl/11_tilings_kaleidoscope.html
+++ b/examples/cindygl/11_tilings_kaleidoscope.html
@@ -88,8 +88,6 @@
       createimage("image", 1000, 1000);
     </script>
     
-    <script
-    
     <script id="csmousedown" type="text/x-cindyscript">
       showfundamentaldomain = true;
     </script>

--- a/examples/cindygl/22_explorer.html
+++ b/examples/cindygl/22_explorer.html
@@ -285,15 +285,15 @@ between $-1$ and $+1$.
 
   <div id="CSCanvas" style="border:2px solid black"></div>
 <div style="position:absolute; top:815px;left:10px">
-  <input id="ch1" onclick="check1()" checked=true type="checkbox" >angles&nbsp;&nbsp;&nbsp;
-  <input id="ch2" onclick="check2()" checked=true type="checkbox" >radii&nbsp;&nbsp;&nbsp;
+  <input id="ch1" onclick="check1()" checked type="checkbox" >angles&nbsp;&nbsp;&nbsp;
+  <input id="ch2" onclick="check2()" checked type="checkbox" >radii&nbsp;&nbsp;&nbsp;
   <input id="ch3" onclick="check3()" type="checkbox" >linear diagram&nbsp;&nbsp;&nbsp;
   <input id="ch4" onclick="check4()" type="checkbox" >black/white&nbsp;&nbsp;&nbsp;
   <input id="ch5" onclick="check5()" type="checkbox" >webcam<br>
   </div>
 <div style="position:absolute; top:770px; left:5px; display:inline;z-index:4">
 <input type="text" id="inp" value="(1-a)*(1+a)"  onkeypress="typ(event, this)" size="60" style="font-size:18px">
-<select id="sel" onchange="sel(event, this)" width="20">
+<select id="sel" onchange="sel(event, this)" style="width:20em;">
   <option>(1-a)*(1+a)</option>
   <option>(z-A)/(z-B)</option>
   <option>z^(1+i)</option>

--- a/examples/cindygl/29_modifiers_tunnel.html
+++ b/examples/cindygl/29_modifiers_tunnel.html
@@ -78,8 +78,8 @@ var check2=function(){
 <body style="font-family:Arial;">
   <div id="CSCanvas" style="width:800px; height:800px; border:2px solid black"></div>
   <p>
-    <input id="ch1" onclick="check1()" checked=true type="checkbox" >interpolate linear&nbsp;&nbsp;&nbsp;
-    <input id="ch2" onclick="check2()" checked=true type="checkbox" >mipmap 
+    <input id="ch1" onclick="check1()" checked type="checkbox" >interpolate linear&nbsp;&nbsp;&nbsp;
+    <input id="ch2" onclick="check2()" checked type="checkbox" >mipmap 
   </p>
 </body>
 

--- a/examples/cmdline.html
+++ b/examples/cmdline.html
@@ -39,6 +39,6 @@
     <span id="log"></span>
     <input id="inp" type="text">
     <input id="do" type="button" value="DO">
-    <div id="Cindy" style="display:none" style="width:1px; height:1px;"></div>
+    <div id="Cindy" style="display:none; width:1px; height:1px;"></div>
   </body>
 </html>


### PR DESCRIPTION
These examples contain invalid HTML which gets detected when trying to include them into our website. We should fix them. And perhaps at one point add a Travis check to ensure that examples are valid.