### PR TITLE
elementsatmouse()

### DIFF
--- a/examples/146_elementsatmouse.html
+++ b/examples/146_elementsatmouse.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Konstruktion.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="mousemove" type="text/x-cindyscript">
+apply(allelements(),#.alpha=1);
+apply(elementsatmouse(),#.alpha=0);
+repaint();
+</script>
+    <script type="text/javascript">
+CindyJS({
+  scripts: "mousemove",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  geometry: [
+    {name: "A", type: "Free", pos: [4.0, 3.393939393939394, 0.7575757575757576], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "B", type: "Free", pos: [4.0, 1.0683229813664596, 0.6211180124223602], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "C", type: "Free", pos: [4.0, 1.9104477611940296, 1.4925373134328357], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "D", type: "Free", pos: [-0.7567567567567569, -4.0, -1.3513513513513513], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "E", type: "Free", pos: [1.7142857142857142, -4.0, -1.0204081632653061], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "F", type: "Free", pos: [4.0, -2.1212121212121207, 1.5151515151515151], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "G", type: "Free", pos: [4.0, 0.26168224299065423, -0.9345794392523364], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "H", type: "Free", pos: [2.538922155688623, -4.0, -0.5988023952095808], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "a", type: "Join", color: [0.0, 0.0, 1.0], args: ["G", "H"], labeled: true},
+    {name: "seg", type: "Segment", color: [0.0, 0.0, 1.0], args: ["E", "F"], labeled: true},
+    {name: "Arc", type: "Arc", color: [0.0, 0.0, 1.0], args: ["A", "B", "C"], labeled: true},
+    {name: "K", type: "Free", pos: [4.0, 1.8181818181818181, 0.36363636363636365], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "C0", type: "CircleByRadius", pos: {xx: 0.007115452485854481, yy: 0.007115452485854481, zz: 1.0, xy: 0.0, xz: -0.15653995468879858, yz: 0.07115452485854482}, color: [0.0, 0.0, 1.0], radius: 2.336835467036565, args: ["K"], printname: "$C_{0}$"}
+  ],
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 335,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -4.06]}],
+    axes: true,
+    grid: 1.0,
+    snap: true,
+    background: "rgb(168,176,192)"
+  }],
+  cinderella: {build: 1869, version: [2, 9, 1869]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/ref/Interaction_with_Geometry.md
+++ b/ref/Interaction_with_Geometry.md
@@ -61,8 +61,6 @@ This operator gives a handle to the element that is currently moved by the mouse
 
 #### Elements close to the mouse: `elementsatmouse()`
 
-**Not available in CindyJS yet!**
-
 **Description:**
 This operator gives a list with handles to all the elements that are close to the current mouse position.
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3734,6 +3734,94 @@ evaluator.allelements$1 = function(args, modifs) {
     });
 };
 
+evaluator.elementsatmouse$0 = function(args, modifs) {
+    var eps = 0.5;
+    var mouse = List.realVector([csmouse[0], csmouse[1], 1]);
+
+    var distMouse = function(p) {
+        if (CSNumber._helper.isAlmostZero(p.value[2])) return Infinity;
+        var pz = List.normalizeZ(p);
+        return List.abs(List.sub(pz, mouse)).value.real;
+    };
+
+    var getPerp = function(l) {
+        var fp = List.turnIntoCSList([l.value[0], l.value[1], CSNumber.zero]);
+        return List.normalizeMax(List.cross(mouse, fp));
+    };
+
+    var inciPP = function(p) {
+        return (distMouse(p.homog) < eps);
+    };
+
+    var inciPL = function(l) {
+        var perp = getPerp(l.homog);
+        var pp = List.normalizeMax(List.cross(l.homog, perp));
+        var d = distMouse(pp);
+        return (d < eps);
+    };
+
+    var inciPC = function(c) {
+        var l = General.mult(c.matrix, mouse);
+        var perp = getPerp(l);
+        var sect = geoOps._helper.IntersectLC(perp, c.matrix);
+        var dists = sect.map(function(el) {
+            return distMouse(el);
+        });
+
+        var erg = Math.min(dists[0], dists[1]);
+
+        return (erg < eps);
+    };
+
+    var points = csgeo.points.filter(inciPP);
+
+    var lines = csgeo.lines.filter(function(el) {
+        var val = inciPL(el);
+        // fetch segment
+        if (val && el.kind === "S") {
+            var line = el.homog;
+            var tt = List.turnIntoCSList([line.value[0], line.value[1], CSNumber.zero]);
+            var cr = List.crossratio3(
+                el.farpoint, el.startpos, el.endpos, mouse, tt).value.real;
+            if (cr < 0 || cr > 1) val = false;
+        }
+
+        return val;
+    });
+
+    var conics = csgeo.conics.filter(function(el) {
+        var val = inciPC(el);
+        // fetch arc
+        if (val && el.isArc) {
+            var cr = List.crossratio3harm(el.startPoint, el.endPoint,
+                el.viaPoint, mouse, List.ii);
+            var m = cr.value[0];
+            var n = cr.value[1];
+            if (!CSNumber._helper.isAlmostZero(m)) {
+                n = CSNumber.div(n, m);
+                m = CSNumber.real(1);
+            } else {
+                m = CSNumber.div(m, n);
+                n = CSNumber.real(1);
+            }
+            var nor = List.abs(List.turnIntoCSList([n, m]));
+            m = CSNumber.div(m, nor);
+            n = CSNumber.div(n, nor);
+
+            var prod = CSNumber.mult(n, m);
+            if (m.value.real < 0) prod = CSNumber.neg(prod);
+
+            if (prod.value.real < 0) val = false;
+        }
+        return val;
+    });
+
+
+    var elts = points.concat(lines, conics);
+
+    return List.ofGeos(elts);
+};
+
 evaluator.incidences$1 = evaluator.allelements$1;
 
 evaluator.createpoint$2 = function(args, modifs) {


### PR DESCRIPTION
Hi,

as requested i implemented elementsatmouse().  This resolves #416.

One can't use the manual's example 

```
apply(allelements(),#.alpha=1);
apply(elementsatmouse(),#.alpha=0);
repaint();
```

since something seems to be broken in the combination of apply and repaint (issue #419). One has to drag points in order to see the result. 

Furthermore something seems to be odd with @kortenkamp's example. It's broken without a single warning.
