### PR TITLE
Update copyright header to 2016

### DIFF
--- a/src/js/Cindy.js.wrapper
+++ b/src/js/Cindy.js.wrapper
@@ -1,4 +1,4 @@
-/* CindyJS - (C) 2014-2015  The CindyJS Project
+/* CindyJS - (C) 2014-2016  The CindyJS Project
  * Mostly licensed under the Apache License 2.0, but subprojects may use different licensing.
  * See https://github.com/CindyJS/CindyJS/tree/$gitid$
  * for corresponding sources and their respective licensing conditions.


### PR DESCRIPTION
For now, this just updates the value mentioned in the template to the current year. But considering how long ago this *should* have happened, I wonder whether we should implement some machinery to remind us of updating this sooner for future years. Or perhaps we should even include the year automatically when building the distributables, either using the current year of the build or by using the year of the `HEAD` commit from which the release is being built. What do you think?