### PR TITLE
Implement coercion to list for concat operation

### DIFF
--- a/ref/Elementary_List_Operations.md
+++ b/ref/Elementary_List_Operations.md
@@ -81,6 +81,19 @@ This operator creates a list by concatenation of two other lists.
     > concat(["a", "b"], ["c", "d"])
     < ["a", "b", "c", "d"]
 
+Thanks to auto-coercion, numbers and boolean values will get
+converted to singleton lists.
+
+    > concat(2, true)
+    < [2, true]
+
+Strings and `___` auto-coerce to the empty list.
+
+    > concat("foo", [2])
+    < [2]
+    > concat([1], (;))
+    < [1]
+
 ------
 
 #### Removing elements from lists: `‹list1› -- ‹list2›`, `‹list1› ∖ ‹list2›` or `remove(‹list1›,‹list2›)`

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -11,6 +11,21 @@ List.turnIntoCSList = function(l) {
     };
 };
 
+List.EMPTY = List.turnIntoCSList([]);
+
+List.asList = function(x) {
+    if (x.ctype === "list") {
+        return x;
+    }
+    if (x.ctype === "number" || x.ctype === "boolean") {
+        return List.turnIntoCSList([x]);
+    }
+    if (x.ctype === "string" || x.ctype === "undefined") {
+        return List.EMPTY;
+    }
+    return nada;
+};
+
 List.realVector = function(l) {
     var erg = [];
     for (var i = 0; i < l.length; i++) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -2432,11 +2432,13 @@ evaluator.concat$2 = infix_concat;
 function infix_concat(args, modifs) {
     var v0 = evaluate(args[0]);
     var v1 = evaluate(args[1]);
-    if (v0.ctype === 'list' && v1.ctype === 'list') {
-        return List.concat(v0, v1);
-    }
     if (v0.ctype === 'shape' && v1.ctype === 'shape') {
         return eval_helper.shapeconcat(v0, v1);
+    }
+    var l0 = List.asList(v0);
+    var l1 = List.asList(v1);
+    if (l0.ctype === 'list' && l1.ctype === 'list') {
+        return List.concat(l0, l1);
     }
     return nada;
 }


### PR DESCRIPTION
This documents and implements some of the auto-coercion rules used by Cinderella.  The `List.asList` function should probably be called in a lot more situations than just this single one, so this is just the first.