### PR TITLE
decrease plot step size

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -999,7 +999,7 @@ evaluator.plot$2 = function(args, modifs) {
     var stroking = false;
     var start = -10; //TODO Anpassen auf PortScaling
     var stop = 10;
-    var step = 1;
+    var step = 0.1;
     var steps = 1000;
 
     var v1 = args[0];


### PR DESCRIPTION
This decreases the step size in plot. Although we wanted to rewrite plotting anyway this small patch should increase the user experience while we are working on it. The pictures show the example from PR #428.

before:
![plot2](https://cloud.githubusercontent.com/assets/14185442/17588103/ea68c6cc-5fcc-11e6-9784-3959c1dd9aed.jpg)
after:
![plot1](https://cloud.githubusercontent.com/assets/14185442/17588104/ea7d8a8a-5fcc-11e6-8c78-92c46987c90b.jpg)
 