### PR TITLE
respect isvisible property for texts

### DIFF
--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -174,6 +174,8 @@ var textCornerNames = {
 };
 
 function drawgeotext(el) {
+    if (!el.isshowing || el.visible === false)
+        return;
     var opts = {
         "size": el.size,
     };


### PR DESCRIPTION
isvisible is currently ignored for texts, one example is 146_angleFromScript.html