### PR TITLE
rename setTimeout

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3994,7 +3994,7 @@ evaluator.date$0 = function(args, modifs) {
     ]);
 };
 
-evaluator.setTimeout$2 = function(args, modifs) {
+evaluator.settimeout$2 = function(args, modifs) {
     var delay = evaluate(args[0]); // delay in seconds
     var code = args[1]; // code to execute, cannot refer to regional variables
     function callback() {


### PR DESCRIPTION
This renames setTimeout to lower case and should resolve #427. I think there are no other functions which require an update. 