### PR TITLE
Implement parseCSV to parse CSV strings into tables

### DIFF
--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -194,6 +194,111 @@ defines the function `f(x)` to be `sin(x)+cos(x)`.
 
 ------
 
+#### Parsing a CSV string: `parseCSV(‹string›)`
+
+**Description:**
+This operator parses a comma-separated values (CSV) string to a list of lists.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV("Foo,1.0
+    > Bar,2.3
+    > true,5.0.7
+    > ")
+    < [["Foo", 1], ["Bar", 2.3], [true, "5.0.7"]]
+
+All rows in a CSV file should have the same number of columns.
+If this is not the case, short rows are padded with `___`.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV("11,12
+    > 21,22,23,24,
+    > 31,32, 33
+    > 41")
+    < [[11, 12, ___, ___, ___], [21, 22, 23, 24, ""], [31, 32, " 33", ___, ___], [41, ___, ___, ___, ___]]
+
+Numbers and Booleans are converted to their respective CindyScript counterparts.
+If this is not the desired behavior the `autoconvert` modifier can be set to `false`.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV("Foo,1.0,true,bar", autoconvert->false)
+    < [["Foo", "1.0", "true", "bar"]]
+
+Boolean values may have their first letter in upper case, but the rest must be lower case.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV("true,True,TRUE,true ,false,False,fAlse, false,fALSE")
+    < [[true, true, "TRUE", "true ", false, false, "fAlse", " false", "fALSE"]]
+
+The current implementation does not auto-convert scientific notation.
+It does however handle infinite values.
+This may however change in a future release, so don't rely on this.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV("1e2,1e+2,1e-2
+    > Infinity,+Infinity,-Infinity
+    > 100,+100,-100")
+    < [["1e2", "1e+2", "1e-2"], [Infinity, Infinity, -Infinity], [100, 100, -100]]
+
+Strings may be enclosed in double quotes.
+Inside such a quoted string, occurrences of double quotes have to be doubled.
+The following example writes `'` to represent `"`, then uses `unicode("22")`
+to replace that by an actual `"` character.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV(replace("a,'b,c''d'''',e',f
+    > g,h'i'j,'k
+    > l,m,n'", "'", unicode("22")))
+    < [["a", "b,c\"d\"\",e", "f"], ["g", "h\"i\"j", "k\nl,m,n"]]
+
+Lines may be terminated by carriage return, line feed,
+or a carriage return followed by a line feed.
+The input may use a mixture of end of line conventions.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV(replace(replace("1,2\n3,4\r5,6\n\r7,8\r\n9,10",
+    >     "\r", unicode("0D")), "\n", unicode("0A")))
+    < [[1, 2], [3, 4], [5, 6], ["", ___], [7, 8], [9, 10]]
+
+The line terminator is optional for the last line.
+This is even true if the last line ends in an empty field,
+which may be tricky for reasons internal to the implementation.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV("1,2
+    > 11,")
+    < [[1, 2], [11, ""]]
+    > parseCSV("1,2,3
+    > 11,")
+    < [[1, 2, 3], [11, "", ___]]
+    > parseCSV("1,")
+    < [[1, ""]]
+    > parseCSV("1
+    > 11,")
+    < [[1, ___], [11, ""]]
+
+The modifier `delimiter` can be used to set the column-separating character.
+The argument to that modifier has to be a single character,
+excluding `"`, newline and carriage return.
+The default delimiter is the comma (as the name CSV suggests).
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV("1;2,3;4.5", delimiter->";")
+    < [[1, "2,3", 4.5]]
+
+Some delimiters warrant extra checks due to possible special meanings
+in the internal implementation, so these are checked here.
+
+    - only CindyJS: parseCSV isn't implemented for Cinderella yet
+    > parseCSV("1,2d3", delimiter->"d")
+    < [["1,2", 3]]
+    > parseCSV("1,2.3", delimiter->".")
+    < [["1,2", 3]]
+    > parseCSV("1,2$3", delimiter->"$")
+    < [["1,2", 3]]
+
+------
+
+
 #### Guessing a good representation of a number: `guess(‹number›)`
 
 **Not available in CindyJS yet!**


### PR DESCRIPTION
This supersedes both #302 and #433. It avoids depending on a third party library to do the CSV parsing, implementing the parser in our own code instead. One great benefit is that we can do unit testing in the reference manual, which makes it far easier to ensure proper coverage of all the tricky cases.

There are a number of things that might be worth discussing.

1. What number formats do we want to allow?
   * #302 required a digit before and after the decimal dot if there was a decimal point, disallowed scientific notation, allowed `Infinity` with an optional sign and disallowed `NaN`.  
   * This code here currently does the same, except for making the digit before or after the decimal point optional as long as the other one is present.
   * `tokenize` is currently based on [`parseFloat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat) but that's probably not ideal either, since it will convert a number followed by some string into the number, silently discarding the string.
   * [`reNumber`](https://github.com/CindyJS/CindyJS/blob/8db1ed82b47628870fb1cdf6a9536a9c93a008de/src/js/libcs/Parser.js#L164-L171) describes the number literals we allow in CindyJS input, but that includes possible in-token whitespace.

2. Is there any reason to add more flexibility, allowing a choice of line terminator (CR vs. LF vs. CRLF), quote character (`"` vs. `'` vs. none) or escaping mechanism (`""` vs. `\"`)? I can't think of an application for this right now, since the current defaults should cater for most sane inputs.

3. Do we need a modifier `trim` to automatically trim whitespace from input fields? If so, should this also trim quoted fields, or just unquoted ones?

4. Should we document the behavior in case of unmatched quotes, and ensure that future modifications maintain that behavior? Or do we want to leave handling of such invalid input as an implementation-defined detail? (This PR already documents use of quotes if there is text before and after them, which is a violation of [RFC 4180](https://tools.ietf.org/html/rfc4180) as well.)

5. There is a slight possibility that long strings with unmatched quotes could result in long regexp matching times due to excessive backtracking. It's still quadratic in the input, so I doubt it's worth coding against. Particularly since unmatched quotes are invalid.

6. In case input rows have different numbers of columns, do we want to pad short rows with `___` as this code currently does, or is it enough to rely on the fact that an out-of-range index will lead to an `___` value during access? Particularly while debugging the use of `___` in the function result might help highlighting different column counts that might otherwise go unnoticed, so I think that might be worth the (12 lines of) code it takes.