### PR TITLE
Detect widget resizes even if not caused by window resize

### DIFF
--- a/examples/resize.html
+++ b/examples/resize.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Responsive widget resizing</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<style type="text/css">
+  html,body { margin: 0px; padding: 0px; width: 100%; height: 100%; }
+  #CSCanvas { box-sizing: border-box; border: 2px solid #f0f; }
+  #container { box-sizing: border-box; border: 2px solid #090; }
+</style>
+</head>
+
+<body>
+  <div id="container" style="width:500px; height: 500px">
+    <div id="CSCanvas" style="width:100%; height:100%"></div>
+  </div>
+  <p>Click on page background to resize the above container</p>
+  <script type="text/javascript">
+
+var cdy = CindyJS({
+  ports: [{
+    id: "CSCanvas",
+    transform:[{visibleRect:[-1,1,1,-1]}]
+  }],
+  scripts: "cs*",
+  language: "en",
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0]},
+    {name:"B", type:"Free", pos:[0.7071,0.7071]},
+    {name:"C", type:"CircleMP", args:["A","B"]}
+  ]
+});
+
+var container = document.getElementById("container");
+var w = 500, h = 500;
+document.body.addEventListener("click", function(evnt) {
+  if (evnt.clientX > w || evnt.clientY > h) {
+    container.style.width = (w = evnt.clientX) + "px";
+    container.style.height = (h = evnt.clientY) + "px";
+  }
+}, false);
+
+  </script>
+</body>
+
+</html>

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -289,8 +289,60 @@ function setuplisteners(canvas, data) {
             });
         }, false);
     }
+    resizeSensor(canvas.parentNode);
 
     scheduleUpdate();
+}
+
+function mkdiv(parent, style) {
+    var div = document.createElement("div");
+    div.setAttribute("style", style);
+    parent.appendChild(div);
+    return div;
+}
+
+// Inspired by
+// github.com/marcj/css-element-queries/blob/bfa9a7f/src/ResizeSensor.js
+// written by Marc J. Schmidt and others, licensed under the MIT license.
+function resizeSensor(element) {
+    if (typeof document === "undefined") return;
+    var styleChild = "position: absolute; transition: 0s; left: 0; top: 0;";
+    var style = styleChild + " right: 0; bottom: 0; overflow: hidden;" +
+        " z-index: -1; visibility: hidden;";
+    var expand = mkdiv(element, style);
+    var expandChild = mkdiv(
+        expand, styleChild + " width: 100000px; height: 100000px");
+    var shrink = mkdiv(element, style);
+    mkdiv(shrink, styleChild + " width: 200%; height: 200%");
+
+    function reset() {
+        expand.scrollLeft = expand.scrollTop =
+            shrink.scrollLeft = shrink.scrollTop = 100000;
+    }
+
+    reset();
+    var w = element.clientWidth;
+    var h = element.clientHeight;
+    var scheduled = false;
+
+    function onScroll() {
+        if (w !== element.clientWidth || h !== element.clientHeight) {
+            w = element.clientWidth;
+            h = element.clientHeight;
+            if (!scheduled) {
+                scheduled = true;
+                requestAnimFrame(function() {
+                    scheduled = false;
+                    updateCanvasDimensions();
+                    scheduleUpdate();
+                });
+            }
+        }
+        reset();
+    }
+
+    expand.addEventListener("scroll", onScroll);
+    shrink.addEventListener("scroll", onScroll);
 }
 
 var requestAnimFrame;

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -148,8 +148,6 @@ function canvasWithContainingDiv(elt) {
     if (position === "static")
         div.style.position = "relative"; // serve as a positioning root
     div.appendChild(canvas);
-    // TODO: implement component resizing detection, probably similar to
-    // github.com/marcj/css-element-queries/blob/bfa9a7f/src/ResizeSensor.js
     return canvas;
 }
 


### PR DESCRIPTION
This adapts the resize sensor from the CSS Element Queries project, written by Marc J. Schmidt and others.  Source of the adapted code: https://github.com/marcj/css-element-queries/blob/bfa9a7f/src/ResizeSensor.js

The idea is that although there is no resize event on the DOM box level in HTML 5, it is possible to (ab)use the scroll event instead.  An extremely large box scrolled to only show its bottom right portion will change its scroll position if its parent container expands, in order to not leave a gap.  Conversely a box sized 200% of its parent will be scrolled if its parent shrinks since it shrinks twice as fast.  Combined these two will detect size changes using some hidden DOM elements nested inside the already existing positioning container that also contains our canvas.

This is probably the best solution to https://github.com/CindyJS/website/issues/13.