### PR TITLE
Remove unused symlink

### DIFF
--- a/tools/compiler.jar
+++ b/tools/compiler.jar
@@ -1,1 +1,0 @@
-../download/closure-compiler/compiler-20150126.jar


### PR DESCRIPTION
The build system refers to the closure compiler by version number, so there is no need to have this unversioned symlink around.