### PR TITLE
Implement text operator to convert argument to string

### DIFF
--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -27,10 +27,30 @@ For this see [Arithmetic Operators](Arithmetic_Operators.md).
 
 #### Conversion to string: `text(‹expr›)`
 
-**Not available in CindyJS yet!**
-
 **Description:**
 The operator `text(‹expr›)` evaluates the expression `‹expr›` and converts the result to a string representation.
+
+    > text(7.2)
+    < "7.2"
+    > text([true, "foo", (;)])
+    < "[true, foo, ___]"
+
+Undefined input yields undefined output in Cinderella:
+
+    - only Cinderella
+    > text(;)
+    < ___
+
+In CindyJS the output is still a string, in order to avoid corner cases.
+
+    - only CindyJS
+    > text(;)
+    < "___"
+
+Geometric objects get auto-coerced to mathematical values
+
+    > createpoint("A", [6, 4, 2]); text(A)
+    < "[3, 2]"
 
 ------
 
@@ -145,7 +165,7 @@ Number conversion without splitting can be achieved using an empty separator lis
 #### Replacing in strings: `replace(‹string1›,‹string2›,‹string3›)`
 
 **Description:**
-This operator replaces all (!) occurrences of &lt;string2&gt; in &lt;string1&gt; by &lt;string3&gt;.
+This operator replaces all (!) occurrences of ‹string2› in ‹string1› by ‹string3›.
 
 This operator is extremely useful for creating text replacement systems of the kind they are used in so called Lindenmeyer Systems.
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3067,6 +3067,12 @@ evaluator.stopanimation$0 = function(args, modifs) {
 ///////////////////////////////
 
 
+evaluator.text$1 = function(args, modifs) {
+    var v0 = evaluateAndVal(args[0]); // Cinderella compatible
+    // if (v0 === nada) return nada; // Cinderella compatible
+    return General.string(niceprint(v0));
+};
+
 evaluator.replace$3 = function(args, modifs) {
     var v0 = evaluate(args[0]);
     var v1 = evaluate(args[1]);


### PR DESCRIPTION
In order to be compatible with Cinderella, the code does cast its argument to a value if it is a geometric object.  This is in sync with current Cinderella behavior, but the code there is annotated with a comment, so this might change again in the future.

Contrary to Cinderella behavior, we always return a string, even if the argument is nada.  In many cases this makes no difference, but in those cases where it does make a difference, this behavior is arguably the more useful one, so using it avoids extra case distinctions.

Both these decisions are of course open to discussion.