### PR TITLE
Support newlines in text

### DIFF
--- a/examples/148_mltext.html
+++ b/examples/148_mltext.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Multi-line text</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../build/js/katex-plugin.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+drawtext((0, 0), "A1
+A2
+A3
+A4
+A5", size->20);
+</script>
+<script type="text/javascript">
+
+for(var i = 1; i <= 2; ++i)
+CindyJS({
+  ports: [{id: "CSCanvas" + i, width: 500, height: 500, axes:true}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {},
+  use: i === 2 ? ["katex"] : [],
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0], size:1},
+    {name:"B", type:"Free", pos:[0,-4.6], size:1},
+    {name:"T0", type:"Text", pos:[2,0], size:20, text:"B1\nB2\nB3\nB4\nB5"},
+    {name:"T1", type:"Text", pos:[4,0], size:20, text:"C1\n$C_2$\nC3\n$C\n_4$\nC5"},
+    {name:"B0", type:"Button", pos:[-5,0], size:20, text:"D1\n$D_2$\nD3"}
+  ]
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas1" style="border:2px solid black"></div>
+  <div id="CSCanvas2" style="border:2px solid black"></div>
+</body>
+
+</html>

--- a/plugins/katex/src/js/katex-plugin.js
+++ b/plugins/katex/src/js/katex-plugin.js
@@ -257,7 +257,6 @@
             if ((i & 1) === 0) {
                 if (text.indexOf("\n") !== -1) {
                     var rows = text.split("\n");
-                    console.log(rows);
                     element.appendChild(document.createTextNode(rows[0]));
                     for (var j = 1; j < rows.length; ++j) {
                         element.appendChild(document.createElement("br"));

--- a/ref/Texts_and_Tables.md
+++ b/ref/Texts_and_Tables.md
@@ -89,7 +89,10 @@ By this it is easy to produce multilined text, as the following piece of code sh
     > multilined text.")
     D fillStyle = "rgb(0,0,0)"
     D font = "18px sans-serif"
-    D fillText("In Cinderella 'newlines' in Text\nare really used as line terminators.\nSo this text will appear as a\nmultilined text.", 250.5, 229.5)
+    D fillText("In Cinderella 'newlines' in Text", 250.5, 229.5)
+    D fillText("are really used as line terminators.", 250.5, 255.6)
+    D fillText("So this text will appear as a", 250.5, 281.7)
+    D fillText("multilined text.", 250.5, 307.8)
 
 ![Image](img/Newlines.png)
 

--- a/ref/createCindy.md
+++ b/ref/createCindy.md
@@ -119,11 +119,14 @@ The default is defined as follows:
     J   pointColor: [1,0,0],
     J   lineColor: [0,0,1],
     J   pointSize: 5,
-    J   lineSize: 2,
+    J   lineSize: 1,
     J   alpha: 1,
     J   overhangLine: 1.1,
     J   overhangSeg: 1,
-    J   dimDependent: 1
+    J   dimDependent: 0.7,
+    J   fontFamily: "sans-serif",
+    J   textsize: 20,
+    J   lineHeight: 1.45
     J }
 
 Any parameter which stays at this default value doesn't have to be specified at all.

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -940,14 +940,8 @@ evaluator.drawtext$2 = function(args, modifs, callback) {
         callback(txt, font, xx, yy, Render2D.align, size);
     } else {
         textRendererCanvas(
-            csctx, txt, xx, yy, Render2D.align, size, size * 1.45);
-        /* The value of 1.45 for the line height agrees reasonably well
-         * with the default font of Cinderella on OS X,
-         * but it might well be that the Java line height
-         * is read from the font file,
-         * so that other fonts should use other line heights.
-         * Not sure whether we can reasonably reproduce this.
-         */
+            csctx, txt, xx, yy, Render2D.align,
+            size, size * defaultAppearance.lineHeight);
     }
 
     return nada;

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -876,14 +876,34 @@ eval_helper.drawpolygon = function(args, modifs, df, cycle) {
 
 };
 
-// This is a hook: the following function may get replaced by a plugin.
-var textRendererCanvas = function(ctx, text, x, y, align) {
+function defaultTextRendererCanvas(ctx, text, x, y, align, size, lineHeight) {
+    if (text.indexOf("\n") !== -1) {
+        text.split("\n").forEach(function(row) {
+            defaultTextRendererCanvas(ctx, row, x, y, align, size);
+            y += lineHeight;
+        });
+        return;
+    }
     var width = ctx.measureText(text).width;
     ctx.fillText(text, x - width * align, y);
-};
+}
+
+// This is a hook: the following function may get replaced by a plugin.
+var textRendererCanvas = defaultTextRendererCanvas;
 
 // This is a hook: the following function may get replaced by a plugin.
 var textRendererHtml = function(element, text, font) {
+    if (text.indexOf("\n") !== -1) {
+        // TODO: find a way to align the element by its FIRST row
+        // as Cinderella does it, instead of by the last row as we do now.
+        var rows = text.split("\n");
+        element.textContent = rows[0];
+        for (var i = 1; i < rows.length; ++i) {
+            element.appendChild(document.createElement("br"));
+            element.appendChild(document.createTextNode(rows[i]));
+        }
+        return;
+    }
     element.textContent = text;
 };
 
@@ -917,9 +937,17 @@ evaluator.drawtext$2 = function(args, modifs, callback) {
         Render2D.family);
     csctx.font = font;
     if (callback) {
-        callback(txt, font, xx, yy, Render2D.align);
+        callback(txt, font, xx, yy, Render2D.align, size);
     } else {
-        textRendererCanvas(csctx, txt, xx, yy, Render2D.align);
+        textRendererCanvas(
+            csctx, txt, xx, yy, Render2D.align, size, size * 1.45);
+        /* The value of 1.45 for the line height agrees reasonably well
+         * with the default font of Cinderella on OS X,
+         * but it might well be that the Java line height
+         * is read from the font file,
+         * so that other fonts should use other line heights.
+         * Not sure whether we can reasonably reproduce this.
+         */
     }
 
     return nada;

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -11,6 +11,14 @@ defaultAppearance.dimDependent = 0.7;
 defaultAppearance.fontFamily = "sans-serif";
 defaultAppearance.textsize = 20; // Cinderella uses 12 by default
 
+defaultAppearance.lineHeight = 1.45;
+/* The value of 1.45 for the line height agrees reasonably well with
+ * the default font and size in Cinderella on OS X, but it might well
+ * be that the Java line height is read from the font file, so that
+ * other fonts should use other line heights.
+ * Not sure whether we can reasonably reproduce this.
+ */
+
 function setDefaultAppearance(obj) {
     var key;
     for (key in obj)

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -208,8 +208,10 @@ function drawgeotext(el) {
             if (text === cache.text && font === cache.font &&
                 x === cache.x && y === cache.y && align === cache.align)
                 return;
-            if (font !== cache.font)
+            if (font !== cache.font) {
                 label.style.font = font;
+                label.style.lineHeight = defaultAppearance.lineHeight;
+            }
             if (text !== cache.text)
                 if (textRendererHtml(label, text, font) === false)
                     text = false; // Do not cache, must re-run


### PR DESCRIPTION
This adds support for newlines in text, for drawtext calls, Text elements and Button elements, both with and without the KaTeX plugin.

There are a number of unresolved issues yet:

1. The line height factor was measuered from Cinderella, but might be font-dependent, in which case we might want to measure some specific text in an attempt to approximate that value in a better way.

2. Buttons are aligned by their last row of text, where Cinderella aligns them by their first row.

3. The actual height of a TeX formula isn't taken into account when advancing to the next row, making the combination of KaTeX and multi-line text unsuitable for formulas much higher than the regular run of text.

All of these are mentioned in comments inside this code. Fixing them might require considerable additional work, and very likely some new ideas as well, so I propose merging this as it is, and leaving further improvements for future commits.

Should we document the issues with vertical alignment of buttons somewhere, so that we can change that in the future without breaking guaranteed behavior? I fear not, because on the one hand I don't know of any applicable documentation users would actually read, and on the other hand I fear that even then if they wanted multi-line buttons they'd still use a case distinction and risk breakage by a future version. So I think if we get to do vertical alignment the Cinderella way we should do that in a major version bump. The TeX formula height might be a different matter because affected formulas will likely look severely broken. But there, too, people might do case distinctions and add additional newlines, so we should probably do the same major version bump for that as well. Are you comfortable with this?