### PR TITLE
Update Closure Compiler to the latest version (v20160822)

### DIFF
--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160713",
+        closure_version: "20160822",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",

--- a/make/build.js
+++ b/make/build.js
@@ -363,6 +363,7 @@ module.exports = function build(settings, task) {
             dependency_mode: "LOOSE",
             create_source_map: "build/js/CindyGL.js.map",
             compilation_level: this.setting("cgl_closure_level"),
+            rewrite_polyfills: false,
             warning_level: this.setting("cgl_closure_warnings"),
             source_map_format: "V3",
             source_map_location_mapping: [


### PR DESCRIPTION
This is the upcoming release of Closure Compiler.

`--rewrite_polyfills` is now on by default. This caused some problems with CindyGL that I could fix by explicitly deactivating `--rewrite_polyfills` for CindyGL.

I have tested some examples of CindyJS core, Cindy3D, and CindyGL, all of which seem to work now.