### PR TITLE
Compile examples during build

### DIFF
--- a/examples/Life2.html
+++ b/examples/Life2.html
@@ -18,18 +18,21 @@ m=zeromatrix(n,n);
      );
    );
 
+mo(x):=mod(x-1,n)+1;
+
+mmo(i,j):=m_(mo(i))_(mo(j));
+
 neigh(i,j):=
-  m_mo(i-1)_mo(j-1)+
-  m_mo(i)_mo(j-1)+
-  m_mo(i+1)_mo(j-1)+
-  m_mo(i+1)_mo(j)+
-  m_mo(i+1)_mo(j+1)+
-  m_mo(i)_mo(j+1)+
-  m_mo(i-1)_mo(j+1)+
-  m_mo(i-1)_mo(j);
+  mmo(i-1,j-1)+
+  mmo(i,j-1)+
+  mmo(i+1,j-1)+
+  mmo(i+1,j)+
+  mmo(i+1,j+1)+
+  mmo(i,j+1)+
+  mmo(i-1,j+1)+
+  mmo(i-1,j);
 
 cf(i,j):=if(m_i_j==1,hue(neigh(i,j)/8)*.6,(1,1,1));
-mo(x):=mod(x-1,n)+1;
 
 drawm():=(
    repeat(n,i,

--- a/make/build.js
+++ b/make/build.js
@@ -121,6 +121,26 @@ module.exports = function build(settings, task) {
     });
 
     //////////////////////////////////////////////////////////////////////
+    // Make sure all examples compile
+    //////////////////////////////////////////////////////////////////////
+
+    task("excomp", [], function() {
+        this.excomp(
+            "examples/**/*.html",
+            "src/js/libcs/Parser.js",
+            function(html, parser) {
+                var re = /<script[^>]*type *= *['"]text\/x-cindyscript['"][^>]*>([^]*?)<\/script>/g;
+                var match, count = 0;
+                while (match = re.exec(html)) {
+                    ++count;
+                    var res = parser.parse(match[1]);
+                    if (res.ctype === "error") throw res;
+                }
+                return count;
+            });
+    });
+
+    //////////////////////////////////////////////////////////////////////
     // Run test suite from reference manual using node
     //////////////////////////////////////////////////////////////////////
 
@@ -131,6 +151,7 @@ module.exports = function build(settings, task) {
     task("tests", [
         "nodetest",
         "unittests",
+        "excomp",
     ]);
 
     //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This fixes #445 and implements the suggestion made there about compiling all the examples as part of our usual test suite.

I'm slightly unsure about the split between `commands.js` and `build.js` here. Usually the idea is that `commands.js` implements some reusable command, and `build.js` instantiates this by feeding it some parameters. This leads to a very readable high-level `build.js`: you read a few lines and understand the intended action. On the other hand, it has the drawback that people need to look in two places if they want to fully understand the operation of a given task.

Now in this case, I couldn't think of a way to fit the new `excomp` task into a reusable pattern. The combination of uncached module loading and file iteration together with the specific messages and counting behavior felt pretty special. On the other hand, having all of that functionality in `build.js` would have hidden the high-level overview behind a huge amount of technical details. So I split the functionality anyway, making sure to name all the involved files and the crucial loop over the scripts in `build.js`, but leaving everything else in `commands.js`. Hope this makes sense.