### PR TITLE
Update Closure Compiler to v20160822

### DIFF
--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160713",
+        closure_version: "20160822",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",

--- a/plugins/cindy3d/src/js/Cindy3D.js.wrapper
+++ b/plugins/cindy3d/src/js/Cindy3D.js.wrapper
@@ -1,3 +1,3 @@
 (function(){
 %output%
-})();//# sourceMappingURL=Cindy3D.js.map
+}).call(this);//# sourceMappingURL=Cindy3D.js.map

--- a/plugins/cindygl/src/js/CindyGL.js.wrapper
+++ b/plugins/cindygl/src/js/CindyGL.js.wrapper
@@ -1,4 +1,4 @@
 (function(){
 %output%
-})();//# sourceMappingURL=CindyGL.js.map
+}).call(this);//# sourceMappingURL=CindyGL.js.map
 

--- a/tools/prepare-deploy.js
+++ b/tools/prepare-deploy.js
@@ -91,6 +91,7 @@ function map(name, err, content) {
     var root = map.sourceRoot || ".";
     map.sourceRoot = "https://raw.githubusercontent.com/CindyJS/CindyJS/" + head + "/";
     map.sources = map.sources.map(function(src) {
+        if (/^ \[synthetic:.*\] $/.test(src)) return src;
         return ppath.normalize(ppath.join("build/js", root, src));
     });
     map.sourcesContent = map.sources.map(function(src) {


### PR DESCRIPTION
This addresses the issue identified in https://github.com/CindyJS/CindyJS/pull/444#issuecomment-242285587 and therefore works with active `--rewrite_polyfills` flag, at least in case of the julia set example. I haven't performed any other tests, though, so I think this should be tested some more before merging. At least to make sure that the examples that Stefan checked for #444 still work even with polyfills in place.