### PR TITLE
Simulation time and speed

### DIFF
--- a/examples/150_simulationtime.html
+++ b/examples/150_simulationtime.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Simulation time and animation speed</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+t = 0;
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+textsize(26);
+drawtext((0,2),"t = ", align->"right");
+drawtext((0,0),"speed = ", align->"right");
+drawtext((0,2),t);
+drawtext((0,0),if(t == 0, 0, t / seconds()));
+</script>
+<script id="cssimulationstart" type="text/x-cindyscript">
+resetclock();
+</script>
+<script id="cstick" type="text/x-cindyscript">
+t = simulationtime();
+</script>
+<script id="cssimulationstop" type="text/x-cindyscript">
+t = 0;
+</script>
+    <script type="text/javascript">
+CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  animation: {autoplay: false, controls: true, speed: 1.0},
+  autoplay: false,
+  animcontrols: true,
+  ports: [{
+    id: "CSCanvas",
+    width: 294,
+    height: 224,
+    transform: [{visibleRect: [-7.18, 4.94, 4.58, -4.02]}],
+    background: "rgb(168,176,192)"
+  }],
+  geometry: [
+    {name:"A", type:"Free", pos:[-4.5,-2]}
+  ],
+  cinderella: {build: 1865, version: [2, 9, 1865]}
+});
+    </script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+</body>
+
+</html>

--- a/examples/150_simulationtime.html
+++ b/examples/150_simulationtime.html
@@ -36,7 +36,13 @@ CindyJS({
     textsize: 12.0
   },
   angleUnit: "°",
-  animation: {autoplay: false, controls: true, speed: 1.0},
+  animation: {
+    autoplay: false,
+    controls: true,
+    speed: 0.5,
+    speedRange: [0, 1],
+    accuracy: 1
+  },
   autoplay: false,
   animcontrols: true,
   ports: [{

--- a/examples/151_ballTiming.html
+++ b/examples/151_ballTiming.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Physics simulation timing</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="cssimulationstart" type="text/x-cindyscript">
+resetclock();
+;
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+if (A.y > 0, t = seconds(); u = simulationtime());
+drawtext((-4, 3), format(t, 8));
+drawtext((-4, 2), format(u, 8));
+</script>
+    <script type="text/javascript">
+CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  geometry: [
+    {name: "A", type: "Free", pos: [1, 12], color: [1, 0, 0], labeled: true}
+  ],
+  behavior: [
+    {type: "Environment", gravity: 0.01},
+    {geo: ["A"], type: "Mass"}
+  ],
+  animation: {autoplay: false, controls: true, speed: 1.0},
+  autoplay: false,
+  animcontrols: true,
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 336,
+    transform: [{visibleRect: [-4.86, 13.1, 22.34, -0.34]}],
+    axes: true,
+    background: "rgb(168,176,192)"
+  }],
+  cinderella: {build: 1865, version: [2, 9, 1865]}
+});
+    </script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+  <p>The example above shows a ball falling from a height of 12 units.
+    The upper time is real elapsed time in seconds, the lower is
+    simulation time.  The relation between these was tuned in an
+    attempt to resemble Cinderella on current (2016) hardware.</p>
+</body>
+
+</html>

--- a/examples/151_ballTiming.html
+++ b/examples/151_ballTiming.html
@@ -36,9 +36,7 @@ CindyJS({
   animation: {
     autoplay: false,
     controls: true,
-    speed: 0.5,
-    speedRange: [0, 1],
-    accuracy: 1
+    speed: 1.0,
   },
   autoplay: false,
   animcontrols: true,

--- a/examples/151_ballTiming.html
+++ b/examples/151_ballTiming.html
@@ -33,7 +33,13 @@ CindyJS({
     {type: "Environment", gravity: 0.01},
     {geo: ["A"], type: "Mass"}
   ],
-  animation: {autoplay: false, controls: true, speed: 1.0},
+  animation: {
+    autoplay: false,
+    controls: true,
+    speed: 0.5,
+    speedRange: [0, 1],
+    accuracy: 1
+  },
   autoplay: false,
   animcontrols: true,
   ports: [{

--- a/examples/template.html
+++ b/examples/template.html
@@ -4,6 +4,7 @@
 <head>
 <title>Cindy JS Example</title>
 <meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script id="csinit" type="text/x-cindyscript">
 

--- a/ref/Timing_and_Animations.md
+++ b/ref/Timing_and_Animations.md
@@ -64,8 +64,6 @@ Resets the value of the `seconds()` operator.
 
 #### Accessing the timestamp of a simulation: `simulationtime()`
 
-**Not available in CindyJS yet!**
-
 **Description:**
 This operator gives a handle to the running time clock synchronized with the progression of an animation or simulation.
 

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -454,10 +454,9 @@ function cs_mouseclick(e) {
 }
 
 function cs_tick(e) {
-    if (csPhysicsInited) { //TODO: Check here if physics is required
-        if (typeof(lab) !== 'undefined') {
-            lab.tick();
-        }
+    simtime = simnow();
+    if (csPhysicsInited && typeof(lab) !== 'undefined') {
+        lab.tick();
     }
     if (csanimating) {
         evaluate(cscompiled.tick);

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -454,10 +454,15 @@ function cs_mouseclick(e) {
 }
 
 function cs_tick(e) {
-    simtime = simnow();
+    var now = Date.now();
+    var delta = Math.min(simcap, now - simtick) * simspeed * simfactor;
+    //console.log(delta, Math.min(simcap, now - simtick), simspeed, simfactor);
+    simtick = now;
+    var time = simtime + delta;
     if (csPhysicsInited && typeof(lab) !== 'undefined') {
-        lab.tick();
+        lab.tick(delta);
     }
+    simtime = time;
     if (csanimating) {
         evaluate(cscompiled.tick);
     }

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -456,7 +456,6 @@ function cs_mouseclick(e) {
 function cs_tick(e) {
     var now = Date.now();
     var delta = Math.min(simcap, now - simtick) * simspeed * simfactor;
-    //console.log(delta, Math.min(simcap, now - simtick), simspeed, simfactor);
     simtick = now;
     var time = simtime + delta;
     if (csPhysicsInited && typeof(lab) !== 'undefined') {

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -257,8 +257,17 @@ function createCindyNow() {
             csctx.setLineDash = function() {};
         if (data.animation ? data.animation.controls : data.animcontrols)
             setupAnimControls(data);
-        if (data.animation && isFiniteNumber(data.animation.speed))
-            setSpeed(data.animation.speed);
+        if (data.animation && isFiniteNumber(data.animation.speed)) {
+            if (data.animation.accuracy === undefined &&
+                data.cinderella &&
+                data.cinderella.version &&
+                data.cinderella.version[0] === 2 &&
+                data.cinderella.version[1] === 9 &&
+                data.cinderella.version[2] < 1880)
+                setSpeed(data.animation.speed * 0.5);
+            else
+                setSpeed(data.animation.speed);
+        }
         if (data.animation && isFiniteNumber(data.animation.accuracy))
             simaccuracy = data.animation.accuracy;
     }

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -524,7 +524,7 @@ function setupAnimControls(data) {
 var setSpeedKnob = null;
 
 function setSpeed(speed) {
-    simspeed = Math.max(0, speed); // do we want to allow negative speed?
+    simspeed = speed;
     if (setSpeedKnob) setSpeedKnob(speed);
 }
 

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -9,11 +9,40 @@ var cscompiled = {};
 var csanimating = false;
 var csstopped = true;
 var simtime = 0; // accumulated simulation time since start
-var simspeed = 1.0; // the animation.speed setting
-var simfactor = 0.022; // internal simtime units per millisecond at speed 1
-var simunit = 0.0127; // reported simulationtime per internal simtime
-var simcap = 1000/20; // max. ms between frames for fps-independent sim
+var simspeed = 0.5; // global speed setting, will get scaled for applications
+var simcap = 1000 / 20; // max. ms between frames for fps-independent sim
 var simtick = 0; // Date.now of the most recent simulation tick
+var simaccuracy = 10; // number of sub-steps per frame
+
+var simunit = 5 / 360; // reported simulationtime() per internal simtime unit
+/* Cinderella has a factor 5 for its internal animation clock,
+ * and the division by 360 is in the simulationtime function implementation.
+ */
+
+// internal simtime units per millisecond at simspeed 1
+var simfactor = 0.32 / simunit / 1000 * 2;
+/*              ^^^^ simulationtime per second, observed in Cinderella
+ *                     ^^^^^^^ simulationtime per simtime unit
+ *                               ^^^^ milliseconds per second
+ *                                      ^ default accuracy factor
+ *
+ * Cinderella does timing different from CindyJS, so here are some notes.
+ * The default in Cinderella is speed=1.0, accuracy=2, frames=1 in its terms,
+ * which in CindyJS terminology would mean speed=0.5, accuracy=1.
+ * It schedules animation frames with 20ms between, so the actual framerate
+ * depends on the time each such frame takes to compute.
+ * The step in simulated time for each such job is computed in Cinderella
+ * as speed * 2^(frames - accuracy), so it's 0.5 units by default.
+ * This amount is internal only; the simulationtime() divides the accumulated
+ * time by 360.  Using its output, one can observe the amount of simulated
+ * time for each second of wall time.  It will vary with hardware, but
+ * on current desktops was observed to be close to 0.32 per second,
+ * corresponding to 23.04ms between consecutive frames on average.
+ * So that's where all the magic values in the simfactor computation come from.
+ *
+ * Should these values (simunit and simfactor) be different for widgets
+ * which were not exported from Cinderella? (gagern, 2016-09-02)
+ */
 
 // Coordinate system settings
 var csscale = 1;
@@ -227,9 +256,11 @@ function createCindyNow() {
         if (!csctx.setLineDash)
             csctx.setLineDash = function() {};
         if (data.animation ? data.animation.controls : data.animcontrols)
-            setupAnimControls();
+            setupAnimControls(data);
         if (data.animation && isFiniteNumber(data.animation.speed))
             setSpeed(data.animation.speed);
+        if (data.animation && isFiniteNumber(data.animation.accuracy))
+            simaccuracy = data.animation.accuracy;
     }
     if (data.statusbar) {
         if (typeof data.statusbar === "string") {
@@ -409,10 +440,20 @@ var animcontrols = {
     stop: noop
 };
 
-function setupAnimControls() {
+function setupAnimControls(data) {
     var controls = document.createElement("div");
     controls.className = "CindyJS-animcontrols";
     canvas.parentNode.appendChild(controls);
+    var speedLo = 0;
+    var speedHi = 1;
+    var speedScale = 1;
+    if (data.animation && data.animation.speedRange &&
+        isFiniteNumber(data.animation.speedRange[0]) &&
+        isFiniteNumber(data.animation.speedRange[1])) {
+        speedLo = data.animation.speedRange[0];
+        speedHi = data.animation.speedRange[1];
+        speedScale = speedHi - speedLo;
+    }
     var slider = document.createElement("div");
     slider.className = "CindyJS-animspeed";
     controls.appendChild(slider);
@@ -430,8 +471,9 @@ function setupAnimControls() {
     animcontrols.stop(true);
 
     setSpeedKnob = function(speed) {
-        speed = Math.min(100, 50 * speed);
-        speed = Math.round(speed * 10) * 0.1;
+        speed = (speed - speedLo) / speedScale;
+        speed = Math.max(0, Math.min(1, speed));
+        speed = Math.round(speed * 1000) * 0.1; // avoid scientific notation
         knob.style.width = speed + "%";
     };
 
@@ -461,7 +503,7 @@ function setupAnimControls() {
         if (!speedDragging) return;
         var rect = slider.getBoundingClientRect();
         var x = event.clientX - rect.left - slider.clientLeft + 0.5;
-        setSpeed(2.0 * x / rect.width);
+        setSpeed(speedScale * x / rect.width + speedLo);
     }
 
     function speedUp(event) {
@@ -473,7 +515,7 @@ function setupAnimControls() {
 var setSpeedKnob = null;
 
 function setSpeed(speed) {
-    simspeed = Math.max(0, speed);
+    simspeed = Math.max(0, speed); // do we want to allow negative speed?
     if (setSpeedKnob) setSpeedKnob(speed);
 }
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -7,27 +7,6 @@ evaluator.version$0 = function(args, modifs) {
     return List.turnIntoCSList(ver.map(General.wrap));
 };
 
-evaluator.timestamp$0 = function(args, modifs) {
-    return {
-        "ctype": "number",
-        "value": {
-            "real": new Date().getTime(),
-            "imag": 0
-        }
-    };
-};
-
-evaluator.seconds$0 = function(args, modifs) { //OK
-    return {
-        "ctype": "number",
-        "value": {
-            'real': (new Date().getTime() / 1000),
-            'imag': 0
-        }
-    };
-};
-
-
 evaluator.clearconsole$0 = function(args, modifs) {
     csconsole.clear();
 };
@@ -4095,14 +4074,12 @@ if (!Date.now) Date.now = function() {
 };
 var epoch = 0;
 
+evaluator.timestamp$0 = function(args, modifs) {
+    return CSNumber.real(Date.now());
+};
+
 evaluator.seconds$0 = function(args, modifs) { //OK
-    return {
-        "ctype": "number",
-        "value": {
-            'real': ((Date.now() - epoch) / 1000),
-            'imag': 0
-        }
-    };
+    return CSNumber.real((Date.now() - epoch) / 1000);
 };
 
 evaluator.resetclock$0 = function(args, modifs) {
@@ -4123,6 +4100,10 @@ evaluator.date$0 = function(args, modifs) {
     return List.realVector([
         now.getFullYear(), now.getMonth() + 1, now.getDate()
     ]);
+};
+
+evaluator.simulationtime$0 = function(args, modifs) {
+    return CSNumber.real(simtime);
 };
 
 evaluator.settimeout$2 = function(args, modifs) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4103,7 +4103,7 @@ evaluator.date$0 = function(args, modifs) {
 };
 
 evaluator.simulationtime$0 = function(args, modifs) {
-    return CSNumber.real(simtime);
+    return CSNumber.real(simtime * simunit);
 };
 
 evaluator.settimeout$2 = function(args, modifs) {
@@ -4435,18 +4435,16 @@ evaluator.compileToWebGL$1 = function(args, modifs) {
 };
 
 
-/***********************************/
-/**********    PHYSIC    ***********/
-/***********************************/
+/************************************/
+/**********    PHYSICS    ***********/
+/************************************/
 
 
 evaluator.setsimulationspeed$1 = function(args, modifs) {
 
     var v0 = evaluateAndVal(args[0]);
     if (v0.ctype === 'number') {
-        if (typeof(labObjects) !== "undefined" && typeof(labObjects.env) !== "undefined") {
-            labObjects.env.deltat = v0.value.real;
-        }
+        setSpeed(v0.value.real);
     }
     return nada;
 };
@@ -4456,7 +4454,7 @@ evaluator.setsimulationaccuracy$1 = function(args, modifs) {
     var v0 = evaluateAndVal(args[0]);
     if (v0.ctype === 'number') {
         if (typeof(labObjects) !== "undefined" && typeof(labObjects.env) !== "undefined") {
-            labObjects.env.accuracy = v0.value.real;
+            labObjects.env.accuracy = Math.max(1, v0.value.real | 0);
         }
     }
     return nada;

--- a/src/js/liblab/LabBasics.js
+++ b/src/js/liblab/LabBasics.js
@@ -106,10 +106,11 @@ function csinitphys(behavs) {
 }
 
 
-lab.tick = function() {
-
+lab.tick = function(deltat) {
+    deltat = deltat / labObjects.env.accuracy;
     for (var i = 0; i < labObjects.env.accuracy; i++) {
-        lab.tick1(labObjects.env.deltat / labObjects.env.accuracy);
+        lab.tick1(deltat);
+        simtime += deltat;
         cs_simulationstep();
     }
 };

--- a/src/js/liblab/LabBasics.js
+++ b/src/js/liblab/LabBasics.js
@@ -107,8 +107,8 @@ function csinitphys(behavs) {
 
 
 lab.tick = function(deltat) {
-    deltat = deltat / labObjects.env.accuracy;
-    for (var i = 0; i < labObjects.env.accuracy; i++) {
+    deltat = deltat / simaccuracy;
+    for (var i = 0; i < simaccuracy; i++) {
         lab.tick1(deltat);
         simtime += deltat;
         cs_simulationstep();

--- a/src/js/liblab/LabObjects.js
+++ b/src/js/liblab/LabObjects.js
@@ -929,7 +929,8 @@ labObjects.Environment = {
         if (typeof(beh.friction) === 'undefined') beh.friction = 0;
         if (typeof(beh.springstrength) === 'undefined') beh.springstrength = 1;
         if (typeof(beh.accuracy) === 'undefined') beh.accuracy = 10;
-        if (typeof(beh.deltat) === 'undefined') beh.deltat = 0.3;
+        if (typeof(beh.deltat) === 'undefined') beh.deltat = 0.3 * simspeed;
+        else setSpeed(beh.deltat / 0.3);
         if (typeof(beh.charges) === 'undefined') beh.charges = false;
         if (typeof(beh.balls) === 'undefined') beh.balls = false;
         if (typeof(beh.newton) === 'undefined') beh.newton = false;
@@ -938,7 +939,6 @@ labObjects.Environment = {
         beh.errorbound = 0.001;
         beh.lowestdeltat = 0.0000001;
         beh.slowdownfactor = 2;
-
 
     },
 

--- a/src/js/liblab/LabObjects.js
+++ b/src/js/liblab/LabObjects.js
@@ -929,7 +929,7 @@ labObjects.Environment = {
         if (typeof(beh.friction) === 'undefined') beh.friction = 0;
         if (typeof(beh.springstrength) === 'undefined') beh.springstrength = 1;
         if (typeof(beh.accuracy) !== 'undefined') simaccuracy = beh.accuracy;
-        if (typeof(beh.deltat) !== 'undefined') setSpeed(beh.deltat / 0.3);
+        if (typeof(beh.deltat) !== 'undefined') setSpeed(beh.deltat / 0.6);
         if (typeof(beh.charges) === 'undefined') beh.charges = false;
         if (typeof(beh.balls) === 'undefined') beh.balls = false;
         if (typeof(beh.newton) === 'undefined') beh.newton = false;

--- a/src/js/liblab/LabObjects.js
+++ b/src/js/liblab/LabObjects.js
@@ -928,7 +928,7 @@ labObjects.Environment = {
         if (typeof(beh.gravity) === 'undefined') beh.gravity = 0;
         if (typeof(beh.friction) === 'undefined') beh.friction = 0;
         if (typeof(beh.springstrength) === 'undefined') beh.springstrength = 1;
-        if (typeof(beh.accuracy) === 'undefined') beh.accuracy = 10;
+        if (typeof(beh.accuracy) !== 'undefined') simaccuracy = beh.accuracy;
         if (typeof(beh.deltat) !== 'undefined') setSpeed(beh.deltat / 0.3);
         if (typeof(beh.charges) === 'undefined') beh.charges = false;
         if (typeof(beh.balls) === 'undefined') beh.balls = false;

--- a/src/js/liblab/LabObjects.js
+++ b/src/js/liblab/LabObjects.js
@@ -929,8 +929,7 @@ labObjects.Environment = {
         if (typeof(beh.friction) === 'undefined') beh.friction = 0;
         if (typeof(beh.springstrength) === 'undefined') beh.springstrength = 1;
         if (typeof(beh.accuracy) === 'undefined') beh.accuracy = 10;
-        if (typeof(beh.deltat) === 'undefined') beh.deltat = 0.3 * simspeed;
-        else setSpeed(beh.deltat / 0.3);
+        if (typeof(beh.deltat) !== 'undefined') setSpeed(beh.deltat / 0.3);
         if (typeof(beh.charges) === 'undefined') beh.charges = false;
         if (typeof(beh.balls) === 'undefined') beh.balls = false;
         if (typeof(beh.newton) === 'undefined') beh.newton = false;

--- a/src/scss/CindyJS.scss
+++ b/src/scss/CindyJS.scss
@@ -100,6 +100,11 @@ $focused-shadow: 0px 0px 3px #06f;
         }
     }
 
+    .CindyJS-animspeed {
+        position: relative;
+        z-index: 3;
+    }
+
     .CindyJS-animcontrols {
         bottom: 5px;
         left: 5px;
@@ -154,10 +159,39 @@ $focused-shadow: 0px 0px 3px #06f;
 } // end toolbar
 
 .CindyJS-animcontrols {
+    position: absolute;
+    background-color: #00f;
+    height: 26px + 10px;
+    width: 3*34px;
+
+    .CindyJS-animspeed {
+        height: 10px;
+        width: 100%;
+        border-radius: 4px;
+        background-color: #ff7f7f;
+        box-shadow: $checked-shadow;
+
+        div {
+            width: 50%;
+            height: 100%;
+            border-radius: 4px;
+            background-color: #cc0000;
+            box-shadow: $button-shadow;
+        }
+    }
+
+    .CindyJS-animbuttons {
+        white-space: nowrap;
+    }
+} // end animcontrols
+
+.CindyJS-animbuttons {
     @extend %toggleButtonGrid;
 
     button {
         border-radius: 4px;
+        width: 34px;
+        height: 26px;
+        box-sizing: border-box;
     }
-
-} // end animcontrols
+} // end animbuttons


### PR DESCRIPTION
In Cinderella, one animation frame advances the internal simulation time by a fixed amount, proportional to the selected simulation speed. The next frame is scheduled 20ms after the previous frame finished its computation. This means that if the time required for the computation of a single animation frame is not significantly less than these 20ms, then the apparent speed (as seen by the user) depends on that computation. This is what I call “framerate-controlled speed”, since the per-frame time advancement is fixed but the speed seen by the user depends on the frame rate.

Doing the same in CindyJS can be problematic. While `requestAnimationFrame` *might* result in approximately 50 calls per second (i.e. the inverse of 20ms), there is no guarantee to this effect. It may be far less on slow devices. It may be more on fast devices, and particularly so on future devices, which might conceivably run their display at e.g. 200Hz and be prepared to render animations at that same speed. So we have essentially three alternatives:

1. Don't use `requestAnimationFrame` for animations, but use `setTimeout` with those same 20ms between frames, to closely resemble Cinderella.
2. Use whatever framerate the browser supports, so that the same animation will run at very different apparent speeds depending on the device being used.
3. Use (a suitably scaled version of) actual elapsed time, so that simulations will run at the same speed no matter the device.

A problem with 3. is that animations may take computation time proportional to the span of simulation time to be simulated, thanks to refinements. So a complicated animation on a slow device may well end up taking longer for a computation than the span of wall time for which it is doing the computation. That way a time dept can be accumulated, conceivably causing the simulation to freeze.

The solution proposed here is a mixture of 2. and 3. For devices capable of computing 20fps or more, the approach is 3, to provide device-independent simulation speed. For slower devices, the actual time between frames is capped at 1/20 of a second, so that if the frame rate drops below 20fps, the animation speed drops with it in order to avoid total deadlock.

The benefit of devide-independent simulation speed comes with some drawbacks. One is reduced compatibility with Cinderella due to different semantics. For example, as long as the 20fps barrier isn't reached, simulations won't slow down in situations requiring more computation. Another possible problem is reproducibility: with simulation time increments derived from elapsed wall time, two runs of some theoretically deterministic simulation from the same starting position might lead to different outcomes due to different numeric behavior depending on the step sizes being used. This can be observed in the ball example included in this pull request.

At the moment I don't see how Cinderella's internal units map to those of CindyJS. Looking at the sources it would seem that Cinderella has a frame approximately every 20ms (at least with low computation overhead), and advances the internal simulation time by 5.0 times the current simulation speed (which defaults to 1.0 for new documents). So that would mean approximately 250 internal time units per second. The `simulationtime` function then divides this internal time by 360, so there would be 25/36=0.6944 script-visible simulation time units per second. But measuring the behavior of a falling ball, I'm seeing something closer to 22 internal time units per second, and 0.0127 script-visible units per internal one, or 0.2794 per second. Observations from the `150_simulationtime` example in Cinderella show that there are more like 0.3 units per second, so apparently I'm not reading the Cinderella code correctly. But at this time I have no real clue where this difference comes from, and whether my measurements are specific to the gravitational force I used in my setup. I've entered the numbers I observed as constants but I'm far from happy with this. Some further investigation of this aspect might be required.

On the other hand, I think that even as it stands now, this PR is a step in the right direction and should be merged. As it stands, it will add the following value to CindyJS.

* Includes a slider above the animation control buttons allowing users to control the speed
* Honors the speed setting exported by Cinderella
* At least some examples will run at speeds comparable to what Cinderella will exhibit
* Support for the `simulationtime` function

Regarding backwards compatibility: The `deltat` setting on the environment object gets translated into a call to adjust the simulation speed, mapping the old default `deltat: 0.3` to the default `speed: 1.0`. So code making use of `deltat` should work fine. I checked some examples which make use of this and they looked fine to me. Therefore I don't see this as a breaking change even if the speed might change somewhat for some simulations.