### PR TITLE
Make gravitational proportional to mass

### DIFF
--- a/src/js/liblab/LabObjects.js
+++ b/src/js/liblab/LabObjects.js
@@ -1054,7 +1054,7 @@ labObjects.Environment = {
             var m = masses[i];
 
             m.behavior.fx += 0;
-            m.behavior.fy += -beh.gravity;
+            m.behavior.fy += -beh.gravity * m.behavior.mass;
             m.behavior.fz += 0;
 
 


### PR DESCRIPTION
At the moment, the force the environment's gravity exerts on each mass is not scaled by that mass. This causes heavy objects to fall more slowly than lighter ones, in the absence of friction. This change corrects that mistake.