### PR TITLE
Fix incorrect font for buttons

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2416,7 +2416,6 @@ geoOps.Text.signature = "**";
 geoOps.Text.updatePosition = noop;
 geoOps.Text.initialize = function(el) {
     el.text = String(el.text);
-    el.size = CSNumber.real(el.size ? +el.size : defaultAppearance.textsize);
     if (el.pos) el.pos = geoOps._helper.initializePoint(el);
     if (el.dock) {
         if (el.dock.offset && el.dock.offset.length === 2)


### PR DESCRIPTION
The text size was set in two places, and since both of them did wrap the text size in a CSNumber after a cast to native number, this led to a text size of NaN which made the whole CSS font style specification invalid.

One notable consequence of this was the Buttons1 example using default fonts for both its buttons, which happened to be different for the push button and for the toggle button.