### PR TITLE
Support calculations

### DIFF
--- a/examples/Calculation.html
+++ b/examples/Calculation.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Calculations</title>
+    <link rel="stylesheet" href="../build/js/CindyJS.css">
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+    <script type="text/javascript">
+CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  geometry: [
+    {name: "A", type: "Free", pos: [-1.469387755102041, -4.0, -2.0408163265306123], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "Text0", type: "Calculation", pos: [0.0, -4.0, -0.6666666666666666], color: [0.0, 0.0, 0.0], text: "A.xy"},
+    {name: "Text1", type: "Equation", pos: [0.0, -4.0, -0.8], color: [0.0, 0.0, 0.0], text: "A.xy"},
+    {name: "Text2", type: "Evaluate", pos: [0.0, -4.0, -1.0], color: [0.0, 0.0, 0.0], text: "err(A.xy)"},
+    {name: "Text3", type: "Plot", pos: [0.0, -4.0, -1.3333333333333333], color: [0.0, 0.0, 0.0], text: "sin(x/A.x)*A.y"}
+  ],
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 322,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -3.54]}],
+    background: "rgb(168,176,192)"
+  }],
+  cinderella: {build: 1873, version: [2, 9, 1873]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2610,6 +2610,57 @@ geoOps.Text.initialize = function(el) {
     }
 };
 
+geoOps.Calculation = {};
+geoOps.Calculation.kind = "Text";
+geoOps.Calculation.signature = "**";
+geoOps.Calculation.updatePosition = noop;
+geoOps.Calculation.initialize = function(el) {
+    geoOps.Text.initialize(el);
+    el.calculation = analyse(el.text);
+};
+geoOps.Calculation.getText = function(el) {
+    return niceprint(evaluate(el.calculation));
+};
+
+geoOps.Equation = {};
+geoOps.Equation.kind = "Text";
+geoOps.Equation.signature = "**";
+geoOps.Equation.updatePosition = noop;
+geoOps.Equation.initialize = function(el) {
+    geoOps.Text.initialize(el);
+    el.calculation = analyse(el.text);
+};
+geoOps.Equation.getText = function(el) {
+    return el.text + " = " + niceprint(evaluate(el.calculation));
+};
+
+geoOps.Evaluate = {};
+geoOps.Evaluate.kind = "Text";
+geoOps.Evaluate.signature = "**";
+geoOps.Evaluate.updatePosition = noop;
+geoOps.Evaluate.initialize = function(el) {
+    geoOps.Text.initialize(el);
+    el.calculation = analyse(el.text);
+};
+geoOps.Evaluate.getText = function(el) {
+    evaluate(el.calculation); // ugly: side effects in draw
+    return el.text;
+};
+
+geoOps.Plot = {};
+geoOps.Plot.kind = "Text";
+geoOps.Plot.signature = "**";
+geoOps.Plot.updatePosition = noop;
+geoOps.Plot.initialize = function(el) {
+    geoOps.Text.initialize(el);
+    // Parenthesize expression to avoid modifier injection
+    el.calculation = analyse("plot((" + el.text + "))");
+};
+geoOps.Plot.getText = function(el) {
+    evaluate(el.calculation);
+    return el.text;
+};
+
 function commonButton(el, event, button) {
     var outer = document.createElement("div");
     var img = document.createElement("img");
@@ -2792,11 +2843,6 @@ geoMacros.Pole = function(el) {
 geoMacros.Polar = function(el) {
     el.type = "PolarOfPoint";
     return [el];
-};
-
-geoMacros.Calculation = function(el) {
-    console.log("Calculation stripped from construction");
-    return [];
 };
 
 geoMacros.Arc = function(el) {

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -189,7 +189,9 @@ function drawgeotext(el) {
     };
     var pos = el.pos;
     var text = el.text;
-    text = text.replace(/@[$#]"([^"\\]|\\.)*"/g, function(match) {
+    var getText = geoOps[el.type].getText;
+    if (getText) text = getText(el);
+    else text = text.replace(/@[$#]"([^"\\]|\\.)*"/g, function(match) {
         var name, el2;
         try {
             name = JSON.parse(match.substring(2));

--- a/src/js/libgeo/StateIO.js
+++ b/src/js/libgeo/StateIO.js
@@ -14,6 +14,7 @@ var attributesToClone = [
     "arrowsides",
     "arrowsize",
     //"behavior", // needs dedicated code
+    //"calculation", // internal
     "clip",
     "color",
     "dashtype",


### PR DESCRIPTION
Calculations, i.e. the GSLP elements one can add with the *f(x)* button in Cinderella, are being properly exported since Cinderella beta build 1873. This adds CindyJS rendering support for these.