### PR TITLE
added imagergb[a] outside of colorplot

### DIFF
--- a/examples/148_ImageRGB3.html
+++ b/examples/148_ImageRGB3.html
@@ -27,7 +27,7 @@
          createimage("testcanvas", 100, 100);
          canvas(A, B, "testcanvas", fillcircle(A, |A,B|/2, alpha->0.5, color->(1,0,0)));
          drawimage(A, B, "testcanvas");
-         p = linereflect(line([0,-2, 100]))*map(A, B, (0, 0), (dim_1, 0))*D.homog; //pixel-coordinates starting from upper left corner
+         p = linereflect(line([0,-2, 100]))*map(A, B, (0, 0), (100, 0))*D.homog; //pixel-coordinates starting from upper left corner
          col = imagergb("testcanvas", p_1/p_3, p_2/p_3);
          D.color = (col_1, col_2, col_3)/255;
          D.alpha = .5*col_4+.5;
@@ -38,8 +38,8 @@
                    {name:"A", kind:"P", type:"Free", pos:[-4,-8,1]},
                    {name:"B", kind:"P", type:"Free", pos:[4,-8,1]},
                    {name:"C", kind:"P", type:"Free", pos:[0,3,1],size:10},
-         						{name:"D", kind:"P", type:"Free", pos:[-3,-7,1],size:10}
-                   ];
+         					 {name:"D", kind:"P", type:"Free", pos:[-3,-7,1],size:10}
+                  ];
 
          CindyJS({canvasname:"CSCanvas",
                      movescript:"csmove",

--- a/examples/148_ImageRGB3.html
+++ b/examples/148_ImageRGB3.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8">
+      <title>Cindy JS</title>
+      <script type="text/javascript" src="../build/js/Cindy.js"></script>
+      <link rel="stylesheet" href="../css/cindy.css">
+   </head>
+   <body style="font-family:Arial;">
+      <h1>CindyJS: imagergb3</h1>
+      <script id='csmove' type='text/x-cindyscript'>
+         drawimage(A, B, "rost");
+         dim=imagesize("rost");
+         p = linereflect(line([0,-2, dim_2]))*map(A, B, (0, 0), (dim_1, 0))*C.homog; //pixel-coordinates starting from upper left corner
+         col = imagergb("rost", p_1/p_3, p_2/p_3);
+         C.color = (col_1, col_2, col_3)/255;
+         C.alpha = .5*col_4+.5;
+
+         forall((0..dim_1/20)*20,i,
+	         forall((0..dim_2/20)*20,j,
+		         col = imagergb("rost",i,j);
+		         draw((i,-j)*.03, color->(col_1,col_2,col_3)/255,
+		         alpha->col_4) // border->false not supported yet
+	         )
+         );
+
+         createimage("testcanvas", 100, 100);
+         canvas(A, B, "testcanvas", fillcircle(A, |A,B|/2, alpha->0.5, color->(1,0,0)));
+         drawimage(A, B, "testcanvas");
+         p = linereflect(line([0,-2, 100]))*map(A, B, (0, 0), (dim_1, 0))*D.homog; //pixel-coordinates starting from upper left corner
+         col = imagergb("testcanvas", p_1/p_3, p_2/p_3);
+         D.color = (col_1, col_2, col_3)/255;
+         D.alpha = .5*col_4+.5;
+      </script>
+      <div  id="CSCanvas" style="width:500px; height:500px; border:2px solid #000000"></div>
+      <script type="text/javascript">
+         var gslp=[
+                   {name:"A", kind:"P", type:"Free", pos:[-4,-8,1]},
+                   {name:"B", kind:"P", type:"Free", pos:[4,-8,1]},
+                   {name:"C", kind:"P", type:"Free", pos:[0,3,1],size:10},
+         						{name:"D", kind:"P", type:"Free", pos:[-3,-7,1],size:10}
+                   ];
+
+         CindyJS({canvasname:"CSCanvas",
+                     movescript:"csmove",
+                     geometry:gslp,
+                     images:{rost:"rost.png"}
+            });
+      </script>
+   </body>
+</html>

--- a/examples/148_ImageRGB4.html
+++ b/examples/148_ImageRGB4.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8">
+      <title>Cindy JS</title>
+      <script type="text/javascript" src="../build/js/Cindy.js"></script>
+      <link rel="stylesheet" href="../css/cindy.css">
+   </head>
+   <body style="font-family:Arial;">
+      <h1>CindyJS: imagergb4</h1>
+			<script id='csinit' type='text/x-cindyscript'>
+				interpolate = true; repeat = false;
+			</script>
+      <script id='csmove' type='text/x-cindyscript'>
+         drawimage(A, B, "pixels");
+         C.color = imagergb(A, B, "pixels", C, interpolate->interpolate, repeat->repeat);
+      </script>
+
+      <script type="text/javascript">
+         var gslp=[{name:"A", kind:"P", type:"Free", pos:[-8,-8,1]},
+                   {name:"B", kind:"P", type:"Free", pos:[8,-8,1]},
+                   {name:"C", kind:"P", type:"Free", pos:[0,3,1],size:10}];
+
+         cdy = CindyJS({canvasname:"CSCanvas",
+                     scripts: 'cs*',
+                     geometry:gslp,
+                     images: {pixels:"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AYECQkMDRcfOAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAWSURBVAjXY2BgYAg6+Zjh/////xkYACNZBfuVdNqYAAAAAElFTkSuQmCC"}
+            });
+      </script>
+			<div id="CSCanvas" style="width:500px; height:500px;"></div>
+		  <p>
+		    <input onclick="cdy.evokeCS('interpolate = ' + this.checked);" checked type="checkbox" >interpolate bilinear&nbsp;&nbsp;&nbsp;
+		    <input onclick="cdy.evokeCS('repeat = ' + this.checked);" type="checkbox" >repeat
+		  </p>
+   </body>
+</html>

--- a/examples/148_ImageRGBA4.html
+++ b/examples/148_ImageRGBA4.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8">
+      <title>Cindy JS</title>
+      <script type="text/javascript" src="../build/js/Cindy.js"></script>
+      <link rel="stylesheet" href="../css/cindy.css">
+   </head>
+   <body style="font-family:Arial;">
+      <h1>CindyJS: imagergba4</h1>
+			<script id='csinit' type='text/x-cindyscript'>
+				interpolate = true; repeat = false;
+			</script>
+      <script id='csmove' type='text/x-cindyscript'>
+         drawimage(A, B, "pixels");
+         col = imagergba(A, B, "pixels", C, interpolate->interpolate, repeat->repeat);
+         C.color = (col_1, col_2, col_3);
+         C.alpha = .5*col_4+.5;
+      </script>
+
+      <script type="text/javascript">
+         var gslp=[{name:"A", kind:"P", type:"Free", pos:[-8,-8,1]},
+                   {name:"B", kind:"P", type:"Free", pos:[8,-8,1]},
+                   {name:"C", kind:"P", type:"Free", pos:[0,3,1],size:10}];
+
+         cdy = CindyJS({canvasname:"CSCanvas",
+                     scripts: 'cs*',
+                     geometry:gslp,
+                     images: {pixels:"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4AYECQkMDRcfOAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAWSURBVAjXY2BgYAg6+Zjh/////xkYACNZBfuVdNqYAAAAAElFTkSuQmCC"}
+            });
+      </script>
+			<div id="CSCanvas" style="width:500px; height:500px;"></div>
+		  <p>
+		    <input onclick="cdy.evokeCS('interpolate = ' + this.checked);" checked type="checkbox" >interpolate bilinear&nbsp;&nbsp;&nbsp;
+		    <input onclick="cdy.evokeCS('repeat = ' + this.checked);" type="checkbox" >repeat
+		  </p>
+   </body>
+</html>

--- a/examples/148_ImageRGBA4extern.html
+++ b/examples/148_ImageRGBA4extern.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8">
+      <title>Cindy JS</title>
+      <script type="text/javascript" src="../build/js/Cindy.js"></script>
+      <link rel="stylesheet" href="../css/cindy.css">
+   </head>
+   <body style="font-family:Arial;">
+      <h1>CindyJS: imagergba4</h1>
+      imagergba does not work on images from different origin. Nethertheless, the following script should not crash.
+      <script id='csmove' type='text/x-cindyscript'>
+         drawimage(A, B, "logo");
+         imagergba(A, B, "logo", C);
+         errc("I am alive.")
+      </script>
+
+      <script type="text/javascript">
+         var gslp=[{name:"A", kind:"P", type:"Free", pos:[-8,-8,1]},
+                   {name:"B", kind:"P", type:"Free", pos:[8,-8,1]},
+                   {name:"C", kind:"P", type:"Free", pos:[0,3,1],size:10}];
+
+         cdy = CindyJS({canvasname:"CSCanvas",
+                     scripts: 'cs*',
+                     geometry:gslp,
+                     images: {logo: "http://cindyjs.org/assets/img/logo.png"}
+            });
+      </script>
+			<div id="CSCanvas" style="width:500px; height:500px;"></div>
+   </body>
+</html>

--- a/examples/cindygl/34_cpuimagergba.html
+++ b/examples/cindygl/34_cpuimagergba.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8">
+      <title>Cindy JS</title>
+      <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+			<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+   </head>
+   <body style="font-family:Arial;">
+      <h1>CindyJS: imagergba4</h1>
+			<script id='csinit' type='text/x-cindyscript'>
+				interpolate = true; repeat = false;
+				t0 = seconds();
+				createimage("test", 4, 3);
+			</script>
+      <script id='csmove' type='text/x-cindyscript'>
+         colorplot(A, B, "test", hue(.1*((seconds()-t0)+|#,A|)));
+				 colorplot(imagergba(A, B, "test", #, interpolate->interpolate, repeat->repeat));
+         col = imagergba(A, B, "test", C, interpolate->interpolate, repeat->repeat);
+         C.color = (col_1, col_2, col_3);
+         C.alpha = .5*col_4+.5;
+      </script>
+
+      <script type="text/javascript">
+         var gslp=[{name:"A", kind:"P", type:"Free", pos:[-8,-8,1]},
+                   {name:"B", kind:"P", type:"Free", pos:[8,-8,1]},
+                   {name:"C", kind:"P", type:"Free", pos:[0,3,1],size:10}];
+
+         cdy = CindyJS({canvasname:"CSCanvas",
+                     scripts: 'cs*',
+                     geometry:gslp,
+										 autoplay: true,
+										 use: ["CindyGL"]
+
+            });
+      </script>
+			<div id="CSCanvas" style="width:500px; height:500px;"></div>
+		  <p>
+		    <input onclick="cdy.evokeCS('interpolate = ' + this.checked);" checked type="checkbox" >interpolate bilinear&nbsp;&nbsp;&nbsp;
+		    <input onclick="cdy.evokeCS('repeat = ' + this.checked);" type="checkbox" >repeat
+		  </p>
+   </body>
+</html>

--- a/examples/cindygl/34_cpuimagergba.html
+++ b/examples/cindygl/34_cpuimagergba.html
@@ -4,18 +4,18 @@
       <meta charset="utf-8">
       <title>Cindy JS</title>
       <script type="text/javascript" src="../../build/js/Cindy.js"></script>
-			<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+      <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
    </head>
    <body style="font-family:Arial;">
       <h1>CindyJS: imagergba4</h1>
-			<script id='csinit' type='text/x-cindyscript'>
-				interpolate = true; repeat = false;
-				t0 = seconds();
-				createimage("test", 4, 3);
-			</script>
+      <script id='csinit' type='text/x-cindyscript'>
+        interpolate = true; repeat = false;
+        t0 = seconds();
+        createimage("test", 4, 3);
+      </script>
       <script id='csmove' type='text/x-cindyscript'>
          colorplot(A, B, "test", hue(.1*((seconds()-t0)+|#,A|)));
-				 colorplot(imagergba(A, B, "test", #, interpolate->interpolate, repeat->repeat));
+         colorplot(imagergba(A, B, "test", #, interpolate->interpolate, repeat->repeat));
          col = imagergba(A, B, "test", C, interpolate->interpolate, repeat->repeat);
          C.color = (col_1, col_2, col_3);
          C.alpha = .5*col_4+.5;
@@ -29,15 +29,15 @@
          cdy = CindyJS({canvasname:"CSCanvas",
                      scripts: 'cs*',
                      geometry:gslp,
-										 autoplay: true,
-										 use: ["CindyGL"]
+                     autoplay: true,
+                     use: ["CindyGL"]
 
             });
       </script>
-			<div id="CSCanvas" style="width:500px; height:500px;"></div>
-		  <p>
-		    <input onclick="cdy.evokeCS('interpolate = ' + this.checked);" checked type="checkbox" >interpolate bilinear&nbsp;&nbsp;&nbsp;
-		    <input onclick="cdy.evokeCS('repeat = ' + this.checked);" type="checkbox" >repeat
-		  </p>
+      <div id="CSCanvas" style="width:500px; height:500px;"></div>
+      <p>
+        <input onclick="cdy.evokeCS('interpolate = ' + this.checked);" checked type="checkbox" >interpolate bilinear&nbsp;&nbsp;&nbsp;
+        <input onclick="cdy.evokeCS('repeat = ' + this.checked);" type="checkbox" >repeat
+      </p>
    </body>
 </html>

--- a/plugins/cindygl/src/js/General.js
+++ b/plugins/cindygl/src/js/General.js
@@ -292,6 +292,16 @@ function getPixelType() {
     else return gl.UNSIGNED_BYTE;
 }
 
+function toFloat(pixels) {
+    let res = [];
+    for (let i = 0; i < pixels.length; i++) {
+        if (can_use_texture_float) res.push(pixels[i]);
+        else if (can_use_texture_half_float) res.push(decodeFloat16(pixels[i]));
+        else res.push(pixels[i] / 255);
+    }
+    return res;
+}
+
 function smallestPowerOfTwoGreaterOrEqual(a) {
     let ans = 1;
     while (ans < a) ans <<= 1;

--- a/plugins/cindygl/src/js/General.js
+++ b/plugins/cindygl/src/js/General.js
@@ -250,45 +250,45 @@ var toByte = f => f * 255
 
 /**
  * converts a float array to an array encoded in the internal type
- * @param {Array<number>} pixels
+ * @param {Array<number>} samples
  */
-function createPixelArrayFromFloat(pixels) {
-    if (can_use_texture_float) return new Float32Array(pixels);
-    if (can_use_texture_half_float) { //return new Uint16Array(pixels.map(toHalf)); <- does not work in recent safari
-        let newpixels = new Uint16Array(pixels.length);
-        for (let i = 0; i < pixels.length; i++) {
-            newpixels[i] = toHalf(pixels[i]);
+function createPixelArrayFromFloat(samples) {
+    if (can_use_texture_float) return new Float32Array(samples);
+    if (can_use_texture_half_float) { //return new Uint16Array(samples.map(toHalf)); <- does not work in recent safari
+        let newsamples = new Uint16Array(samples.length);
+        for (let i = 0; i < samples.length; i++) {
+            newsamples[i] = toHalf(samples[i]);
         }
-        return newpixels;
-    } else { //return new Uint8Array(pixels.map(toByte)); <- does not work in recent safari
-        let newpixels = new Uint8Array(pixels.length);
-        for (let i = 0; i < pixels.length; i++) {
-            newpixels[i] = toByte(pixels[i]);
+        return newsamples;
+    } else { //return new Uint8Array(samples.map(toByte)); <- does not work in recent safari
+        let newsamples = new Uint8Array(samples.length);
+        for (let i = 0; i < samples.length; i++) {
+            newsamples[i] = toByte(samples[i]);
         }
-        return newpixels;
+        return newsamples;
     }
 }
 
 /**
  * converts a float array to an array encoded in the internal type
- * @param {Array<number>} pixels
+ * @param {Array<number>} samples
  */
-function createPixelArrayFromUint8(pixels) {
-    if (can_use_texture_float) { //return (new Float32Array(pixels)).map(x => x / 255.); <- does not work in recent safari
-        let newpixels = new Float32Array(pixels.length);
-        for (let i = 0; i < pixels.length; i++) {
-            newpixels[i] = pixels[i] / 255.;
+function createPixelArrayFromUint8(samples) {
+    if (can_use_texture_float) { //return (new Float32Array(samples)).map(x => x / 255.); <- does not work in recent safari
+        let newsamples = new Float32Array(samples.length);
+        for (let i = 0; i < samples.length; i++) {
+            newsamples[i] = samples[i] / 255.;
         }
-        return newpixels;
+        return newsamples;
     }
 
-    if (can_use_texture_half_float) { //return new Uint16Array((new Float32Array(pixels)).map(x => x / 255.)); <- does not work in recent safari
-        let newpixels = new Uint16Array(pixels.length);
-        for (let i = 0; i < pixels.length; i++) {
-            newpixels[i] = toHalf(pixels[i] / 255.);
+    if (can_use_texture_half_float) { //return new Uint16Array((new Float32Array(samples)).map(x => x / 255.)); <- does not work in recent safari
+        let newsamples = new Uint16Array(samples.length);
+        for (let i = 0; i < samples.length; i++) {
+            newsamples[i] = toHalf(samples[i] / 255.);
         }
-        return newpixels;
-    } else return new Uint8Array(pixels);
+        return newsamples;
+    } else return new Uint8Array(samples);
 }
 
 /**
@@ -307,12 +307,12 @@ function getPixelType() {
     else return gl.UNSIGNED_BYTE;
 }
 
-function toFloat(pixels) {
+function toFloat(samples) {
     let res = [];
-    for (let i = 0; i < pixels.length; i++) {
-        if (can_use_texture_float) res.push(pixels[i]);
-        else if (can_use_texture_half_float) res.push(decodeFloat16(pixels[i]));
-        else res.push(pixels[i] / 255);
+    for (let i = 0; i < samples.length; i++) {
+        if (can_use_texture_float) res.push(samples[i]);
+        else if (can_use_texture_half_float) res.push(decodeFloat16(samples[i]));
+        else res.push(samples[i] / 255);
     }
     return res;
 }

--- a/plugins/cindygl/src/js/General.js
+++ b/plugins/cindygl/src/js/General.js
@@ -231,6 +231,21 @@ function toHalf(fval) {
         126 - val); // div by 2^(1-(exp-127+15)) and >> 13 | exp=0
 };
 
+//from http://stackoverflow.com/questions/5678432/decompressing-half-precision-floats-in-javascript
+function decodeFloat16(binary) {
+    let exponent = (binary & 0x7C00) >> 10;
+    let fraction = binary & 0x03FF;
+    return (binary >> 15 ? -1 : 1) * (
+        exponent ?
+        (
+            exponent === 0x1F ?
+            fraction ? NaN : Infinity :
+            Math.pow(2, exponent - 15) * (1 + fraction / 0x400)
+        ) :
+        6.103515625e-5 * (fraction / 0x400)
+    );
+};
+
 var toByte = f => f * 255
 
 /**

--- a/plugins/cindyjs.externs
+++ b/plugins/cindyjs.externs
@@ -30,7 +30,7 @@ CindyJS.op;
  *    generation: number,
  *    whenReady: function(function()),
  *    drawTo: (undefined|function(CanvasRenderingContext2D,number,number)),
- *    readPixels: (undefined|function(number,number))
+ *    readPixels: (undefined|function(number,number,number,number))
  *  }}
  */
 CindyJS.image;

--- a/plugins/cindyjs.externs
+++ b/plugins/cindyjs.externs
@@ -29,7 +29,8 @@ CindyJS.op;
  *    live: boolean,
  *    generation: number,
  *    whenReady: function(function()),
- *    drawTo: (undefined|function(CanvasRenderingContext2D,number,number))
+ *    drawTo: (undefined|function(CanvasRenderingContext2D,number,number)),
+ *    readPixels: (undefined|function(number,number))
  *  }}
  */
 CindyJS.image;

--- a/ref/Image_Manipulation_and_Rendering.md
+++ b/ref/Image_Manipulation_and_Rendering.md
@@ -285,12 +285,10 @@ This is a pair of integer values that refers to the pixel width and height of th
 
 ------
 
-#### Getting pixel data: `imagergb(‹imagename›,‹int›,‹int›)`
-
-**Not available in CindyJS yet!**
+#### Getting pixel data: `imagergba(‹imagename›,‹int›,‹int›)`
 
 **Description:**
-The function `imagergb(‹imagename›,x,y)` delivers the raw data of the color information of the pixel at original position *(x,y)*.
+The function `imagergba(‹imagename›,x,y)` delivers the raw data of the color information of the pixel at original position *(x,y)*.
 The operator returns a four-dimensional vector with the raw data of the color.
 The first three entries represent the *rgb*-value with each entry ranging from 0 to 255.
 The last entry represents the alpha value.
@@ -303,7 +301,7 @@ It plots a point with the corresponding color and opacity and by this creates a 
     > dim=imagesize("MyImage");
     > forall((0..dim_1/10)*10,i,err(i);
     >   forall((0..dim_2/10)*10,j,
-    >     col=imagergb("MyImage",i,j);
+    >     col=imagergba("MyImage",i,j);
     >     draw((i,-j)*.03,color->(col_1,col_2,col_3)/255,
     >                     alpha->col_4,
     >                     border->false)
@@ -311,6 +309,35 @@ It plots a point with the corresponding color and opacity and by this creates a 
     > )
 
 ![Image](img/RostS9.png)
+
+------
+
+#### Getting pixel data: `imagergb(‹imagename›,‹int›,‹int›)`
+
+**Description:**
+This function does the same as `imagergba(‹imagename›,‹int›,‹int›)`. In particular, it also delivers the alpha value in order to preserve backward compatibility.
+
+------
+
+#### Picking the color and alpha value of one point using two reference points: `imagergba(‹pos›,‹pos›,‹imagename›,‹pos›)`
+
+**Description:**
+ The function `imagergba(‹pos›,‹pos›,‹imagename›,‹pos›)` returns the color and the alpha value of the at the coordinate given as forth argument while assuming that the lower left and right corner coincide with the first two arguments respectively. The result is encoded as a 4-component vector with each entry ranging from 0 to 1, representing the *rgb*-value and alpha value.
+
+ **Modifiers:**
+ The command supports two modifiers.
+
+ | Modifier        | Parameter | Effect                                                                      |
+ | --------------- | --------- | --------------------------------------------------------------------------- |
+ | `interpolation` | `boolean` | Use bilinear interpolation or access closes pixel                           |
+ | `repeat`        | `boolean` | Assume a repeating tiling when accessing coordinates outside the boundaries |
+
+------
+
+ #### Picking the color of one point using two reference points: `imagerga(‹pos›,‹pos›,‹imagename›,‹pos›)`
+
+ **Description:**
+ The function `imagergb(‹pos›,‹pos›,‹imagename›,‹pos›)` behaves in the same way as `imagergba(‹pos›,‹pos›,‹imagename›,‹pos›)` and supports the same modifiers, but `imagergb(‹pos›,‹pos›,‹imagename›,‹pos›)` returns a 3-component vector representing the *rgb*-value.
 
 ------
 

--- a/ref/Image_Manipulation_and_Rendering.md
+++ b/ref/Image_Manipulation_and_Rendering.md
@@ -326,6 +326,8 @@ This function does the same as `imagergba(‹imagename›,‹int›,‹int›)`.
 
 **Description:**
  The function `imagergba(‹pos›,‹pos›,‹imagename›,‹pos›)` returns the color and the alpha value of the at the coordinate given as forth argument while assuming that the lower left and right corner coincide with the first two arguments respectively. The result is encoded as a 4-component vector with each entry ranging from 0 to 1, representing the *rgb*-value and alpha value.
+ 
+ The command returns an empty vector if the image is from a different origin.
 
  **Modifiers:**
  The command supports two modifiers.
@@ -333,7 +335,7 @@ This function does the same as `imagergba(‹imagename›,‹int›,‹int›)`.
  | Modifier        | Parameter | Effect                                                                      |
  | --------------- | --------- | --------------------------------------------------------------------------- |
  | `interpolation` | `boolean` | Use bilinear interpolation.                                                 |
- | `repeat`        | `boolean` | Assume a repeating tiling when accessing coordinates outside the boundaries. If not set, `[0,0,0,0]` is returned. |
+ | `repeat`        | `boolean` | Assume a repeating tiling when accessing coordinates outside the boundaries. If not set, `[0,0,0,0]` is returned if the specified coordinate is outside of the image. |
 
 ------
 

--- a/ref/Image_Manipulation_and_Rendering.md
+++ b/ref/Image_Manipulation_and_Rendering.md
@@ -288,10 +288,13 @@ This is a pair of integer values that refers to the pixel width and height of th
 #### Getting pixel data: `imagergba(‹imagename›,‹int›,‹int›)`
 
 **Description:**
-The function `imagergba(‹imagename›,x,y)` delivers the raw data of the color information of the pixel at original position *(x,y)*.
+The function `imagergba(‹imagename›,x,y)` delivers the raw data of the color information of the pixel at original position *(x,y)*. The coordinate is given left to right and top to bottom. Non-integer values are rounded to closest integers. 
+
 The operator returns a four-dimensional vector with the raw data of the color.
 The first three entries represent the *rgb*-value with each entry ranging from 0 to 255.
 The last entry represents the alpha value.
+
+If the given coordinates are outside of the image, the vector `[0,0,0,0]` is returned.
 
 **Example:**
 The following piece of (slightly elaborate) code first asks for the dimensions of an image and then samples the image in both directions.
@@ -329,8 +332,8 @@ This function does the same as `imagergba(‹imagename›,‹int›,‹int›)`.
 
  | Modifier        | Parameter | Effect                                                                      |
  | --------------- | --------- | --------------------------------------------------------------------------- |
- | `interpolation` | `boolean` | Use bilinear interpolation or access closes pixel                           |
- | `repeat`        | `boolean` | Assume a repeating tiling when accessing coordinates outside the boundaries |
+ | `interpolation` | `boolean` | Use bilinear interpolation.                                                 |
+ | `repeat`        | `boolean` | Assume a repeating tiling when accessing coordinates outside the boundaries. If not set, `[0,0,0,0]` is returned. |
 
 ------
 

--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -391,13 +391,13 @@ evaluator.cameravideo$0 = function() {
 
 var helpercanvas; //invisible helper canvas.
 function getHelperCanvas(width, height) {
-  if (!helpercanvas) {
-      //creating helpercanvas only once increases the running time
-      helpercanvas = /** @type {HTMLCanvasElement} */ (document.createElement("canvas"));
-  }
-  helpercanvas.width = width;
-  helpercanvas.height = height;
-  return helpercanvas;
+    if (!helpercanvas) {
+        //creating helpercanvas only once increases the running time
+        helpercanvas = /** @type {HTMLCanvasElement} */ (document.createElement("canvas"));
+    }
+    helpercanvas.width = width;
+    helpercanvas.height = height;
+    return helpercanvas;
 }
 
 /**
@@ -437,7 +437,7 @@ evaluator.imagergba$3 = function(args, modifs) {
 
     x = Math.round(x.value.real);
     y = Math.round(y.value.real);
-    if (!Number.isFinite(x) || !Number.isFinite(y)) return nada;
+    if (!isFiniteNumber(x) || !isFiniteNumber(y)) return nada;
 
     var rgba = readPixelsIndirection(img, x, y, 1, 1);
     return List.realVector([rgba[0] * 255, rgba[1] * 255, rgba[2] * 255, rgba[3]]);
@@ -509,7 +509,7 @@ evaluator.imagergba$4 = function(args, modifs) {
     var xi = Math.floor(coord.x); //integral part
     var yi = Math.floor(coord.y);
 
-    if (!Number.isFinite(xi) || !Number.isFinite(yi)) return nada;
+    if (!isFiniteNumber(xi) || !isFiniteNumber(yi)) return nada;
 
     var rgba = [0, 0, 0, 0];
     if (interpolate) {

--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -438,7 +438,7 @@ evaluator.imagergba$3 = function(args, modifs) {
     var x = evaluateAndVal(args[1]);
     var y = evaluateAndVal(args[2]);
 
-    if (!img || x.ctype !== 'number' || y.ctype !== 'number') return nada;
+    if (!img || x.ctype !== 'number' || y.ctype !== 'number' || !img.ready) return nada;
 
     x = Math.round(x.value.real);
     y = Math.round(y.value.real);
@@ -529,7 +529,7 @@ function readimgatcoord(img, coord, modifs) {
  */
 evaluator.imagergba$4 = function(args, modifs) {
     var img = imageFromValue(evaluateAndVal(args[2]));
-    if (!img) return nada;
+    if (!img || !img.ready) return nada;
 
     var w = img.width;
     var h = img.height;

--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -414,10 +414,15 @@ function readPixelsIndirection(img, x, y, width, height) {
             ctx = img.img.getContext('2d');
             data = ctx.getImageData(x, y, width, height).data;
         } else { //copy corresponding subimage of img.img to temporary canvas
-            var helpercanvas = getHelperCanvas(width, height);
-            ctx = helpercanvas.getContext('2d');
-            ctx.drawImage(img.img, x, y, width, height, 0, 0, width, height);
-            data = ctx.getImageData(0, 0, width, height).data;
+            try {
+                var helpercanvas = getHelperCanvas(width, height);
+                ctx = helpercanvas.getContext('2d');
+                ctx.drawImage(img.img, x, y, width, height, 0, 0, width, height);
+                data = ctx.getImageData(0, 0, width, height).data;
+            } catch (exception) {
+                console.log(exception);
+            }
+
         }
         for (var i in data) res.push(data[i] / 255);
     }
@@ -529,8 +534,8 @@ evaluator.imagergba$4 = function(args, modifs) {
                 pixels = pixels.slice(0, 4).concat(p10, p01, p11);
             }
         } else { //clamp to boundary
-          if (xi === -1 || xi === w - 1) xf = Math.round(xf);
-          if (yi === -1 || yi === h - 1) yf = Math.round(yf);
+            if (xi === -1 || xi === w - 1) xf = Math.round(xf);
+            if (yi === -1 || yi === h - 1) yf = Math.round(yf);
         }
 
         //bilinear interpolation for each component i

--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -526,19 +526,11 @@ evaluator.imagergba$4 = function(args, modifs) {
                 var p10 = readPixelsIndirection(img, (xi + 1) % w, yi, 1, 1);
                 var p01 = readPixelsIndirection(img, xi, (yi + 1) % h, 1, 1);
                 var p11 = readPixelsIndirection(img, (xi + 1) % w, (yi + 1) % h, 1, 1);
-                pixels = pixels.slice(0, 4).concat(p10).concat(p01).concat(p11);
+                pixels = pixels.slice(0, 4).concat(p10, p01, p11);
             }
         } else { //clamp to boundary
-            if (xi === -1 && xf >= 0.5)
-                for (i = 0; i < 4; i++)
-                    for (j = 0; j < 2; j++) pixels[8 * j + i] = pixels[8 * j + i + 4];
-            if (xi === w - 1 && xf < 0.5)
-                for (i = 0; i < 4; i++)
-                    for (j = 0; j < 2; j++) pixels[8 * j + i + 4] = pixels[8 * j + i];
-            if (yi === -1 && yf >= 0.5)
-                for (i = 0; i < 8; i++) pixels[i] = pixels[i + 8];
-            if (yi === h - 1 && yf < 0.5)
-                for (i = 0; i < 8; i++) pixels[i + 8] = pixels[i];
+          if (xi === -1 || xi === w - 1) xf = Math.round(xf);
+          if (yi === -1 || yi === h - 1) yf = Math.round(yf);
         }
 
         //bilinear interpolation for each component i

--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -390,6 +390,16 @@ evaluator.cameravideo$0 = function() {
 };
 
 var helpercanvas; //invisible helper canvas.
+function getHelperCanvas(width, height) {
+  if (!helpercanvas) {
+      //creating helpercanvas only once increases the running time
+      helpercanvas = /** @type {HTMLCanvasElement} */ (document.createElement("canvas"));
+  }
+  helpercanvas.width = width;
+  helpercanvas.height = height;
+  return helpercanvas;
+}
+
 /**
  * reads a rectangular block of pixels from the upper left corner.
  * The colors are representent as a 4 component RGBA vector with entries in [0,1]
@@ -404,13 +414,7 @@ function readPixelsIndirection(img, x, y, width, height) {
             ctx = img.img.getContext('2d');
             data = ctx.getImageData(x, y, width, height).data;
         } else { //copy corresponding subimage of img.img to temporary canvas
-            if (!helpercanvas) {
-                //creating helpercanvas only once increases the running time
-                helpercanvas = /** @type {HTMLCanvasElement} */ (document.createElement("canvas"));
-            }
-            helpercanvas.width = width;
-            helpercanvas.height = height;
-
+            var helpercanvas = getHelperCanvas(width, height);
             ctx = helpercanvas.getContext('2d');
             ctx.drawImage(img.img, x, y, width, height, 0, 0, width, height);
             data = ctx.getImageData(0, 0, width, height).data;


### PR DESCRIPTION
This should fix https://github.com/CindyJS/CindyJS/issues/417

This pull request implements the imagergb[a] command outside of colorplot.
- imagergb[a]$3 corresponds to the one that is known from Cinderella; both(!) returning a RGBA-vector with entries between 0-255 for the colors, and 0-1 for the alpha-value.
- imagergb[a]$4(‹point1›, ‹point2›, ‹image›, ‹point3›) returns a RGB[A]-vector for color at the coordinate ‹point3› assuming that the left/right lower corner is ‹point1›/‹point2› resp. All entries are in the interval [0,1].
