### PR TITLE
Support load$2 and load$3

### DIFF
--- a/examples/152_load.html
+++ b/examples/152_load.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+
+  color = [1, 1, 0];
+  load("http://sws.geonames.org/2921044/about.rdf", // should support CORS
+    if(isundefined(#), color = [1, 0, 0], color = [0, 0.8, 0]));
+
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+
+  fillcircle((0, 0), 5, color->color);
+  drawcircle((0, 0), 5, color->[0,0,0]);
+
+</script>
+<script type="text/javascript">
+
+var cdy = CindyJS({
+  ports: [{id: "CSCanvas", width: 500, height: 500}],
+  scripts: "cs*",
+  language: "en",
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+  <p>This widget attempts to load <a href="http://sws.geonames.org/2921044/about.rdf">some remote resource</a> using a cross-origin XMLHttpRequest. While the load is in progress, the circle is filled yellow. After a successful load it turns green, in case of an error it will become red.</p>
+</body>
+
+</html>

--- a/ref/File_Management.md
+++ b/ref/File_Management.md
@@ -38,6 +38,46 @@ The resulting output is
 
 ------
 
+#### Loading data asynchroneously: `load(‹string›,‹var›,‹expr›)`
+
+**Description:**
+This version is supported by CindyJS.
+It loads a resource, identified by the HTTP or HTTPS URL `‹string›`.
+When the resource has finished loading,
+it will call execute `‹expr›` with the content of the resource
+treated as a string value and assigned to the variable `‹var›`.
+If loading the resource fails, `‹expr›` will get executed as well,
+but in this case `‹var›` is bound to the undefined value `___`.
+
+The function itself will return `true` if loading was started,
+or `___` if the `‹string›` argument was not a valid URL to be loaded.
+
+Note that the URL must be an absolute URL, at the time of this writing.
+
+**Example:**
+
+    > load("http://some.host/some/resource.txt", result,
+    >   if(isundefined(result),
+    >     err("Loading failed"),
+    >     err("Successfully loaded " + result)));
+
+------
+
+#### Loading data asynchroneously: `load(‹string›,‹expr›)`
+
+**Description:**
+This is a shorthand notation for `load(‹string›,#,‹expr›)`,
+using `#` as the variable referencing the result inside `‹expr›`.
+
+**Example:**
+
+    > load("http://some.host/some/resource.txt",
+    >   if(isundefined(#),
+    >     err("Loading failed"),
+    >     err("Successfully loaded " + #)));
+
+------
+
 #### Importing program code: `import(‹string›)`
 
 **Not available in CindyJS yet!**


### PR DESCRIPTION
The unary`load$1` is not feasible in a web environment, since loading has to happen asynchronously.  So we use a callback model: the function doing the loading takes a piece of code to be invoked once loading has succeeded.  A variable will contain the resulting value during execution of that code, with the default of `#` as usual if the variable name is omitted.

I guess once this gets merged, we can tick or remove `load$1` from #219. Perhaps we should bulk-remove all the functions where we know we are not going to support them any time soon. And adjust the manual to state as much.