### PR TITLE
Initial support for dictionaries

### DIFF
--- a/make/sources.js
+++ b/make/sources.js
@@ -3,6 +3,7 @@
 exports.libcs = [
     "src/js/libcs/CSNumber.js",
     "src/js/libcs/List.js",
+    "src/js/libcs/Dict.js",
     "src/js/libcs/General.js",
     "src/js/libcs/Essentials.js",
     "src/js/libcs/Namespace.js",

--- a/ref/Dictionaries.md
+++ b/ref/Dictionaries.md
@@ -1,0 +1,90 @@
+# Dictionaries
+
+Dictrionaries are maps from keys to values.
+Like all other data structures in CindyJS, dictionaries are immutable.
+Modifying a dictionary does in fact create a new dictionary.
+Since dictionary keys have to be compared in full for dictionary lookups,
+users are advised against using large data structures as dictionary keys.
+The order of key-value pairs in a dictionary is implementation-defined.
+
+**This is an experimental feature in its early stages of development.**
+
+All of the features described here are subject to changes without notice,
+i.e. may change even without a major version bump.
+If you want to avoid accidents, please inform the CindyJS development team
+of how you are using dictionaries, so that we can try to maintain compatibility
+for your use cases or inform you if things are likely to break soon.
+
+At this early stage, a lot of the functionality is only available through
+named functions but should become available through operator symbols, too.
+The named functions will probably remain as an alternative
+for the sake of compatibility and clarity.
+
+## Creating a new: `dict()`
+
+Without arguments, this creates an empty dictionary.
+
+    > dict()
+    < {}
+
+It is however possible to add elements to this dictionary
+by using modifiers in the function invocation.
+The names of the modifiers will be used as string keys.
+
+    > dict(foo->"bar", baz->123)
+    < {"baz":123, "foo":"bar"}
+
+It is not possible to define a dictionary with non-string keys in this way.
+
+## Adding a mapping: `put(‹dict›,‹expr1›,‹expr2›)`
+
+Creates a new dictionary with is equivalent to `‹dict›` but in which
+the key ‹expr1› is mapped to the value ‹expr2›.
+
+    > d = dict();
+    > d = put(d, 12, 34);
+    > d
+    < {12:34}
+
+This does *not* modify the dictionary passed in the first argument, so
+you have to store the result back to permanently alter an existing dictionary.
+
+    > put(d, 56, 78)
+    < {12:34, 56:78}
+    > d
+    < {12:34}
+
+It is possible to use the undefined value as a dictionary key.
+
+    > put(dict(), (;), "what?")
+    < {___:"what?"}
+
+Different complex numbers correspond to different keys,
+even if they have the same real part.
+
+    > d = dict();
+    > d = put(d, 32 + 1*i, 321);
+    > d = put(d, 32 - 1*i, 329);
+    > d = put(d, 32, 320);
+    > d = put(d, "32", 23);
+    < {32 - i*1:329, 32:320, 32 + i*1:321, "32":23}
+
+Note that the use of quotation marks here in this documentation
+is specific to the documentation.  The usual stringification of values
+in Cinderella and CindyJS does not apply quotation marks, which may lead
+to confusing output.  For example, the above dict may *appear* to have
+to identical keys `32`:
+
+    > println(d)
+    * {32 - i*1:329, 32:320, 32 + i*1:321, 32:23}
+
+## Retrieving a value: `get(‹dict›,‹expr›)`
+
+Retrieves the value associated with the key `‹expr›`,
+or `___` if that key is not present in the dictionary.
+
+    > d = dict(k->77);
+    > get(d, "k")
+    < 77
+    > get(d, "d")
+    < ___

--- a/ref/js/runtests.js
+++ b/ref/js/runtests.js
@@ -183,6 +183,11 @@ function myniceprint(val) {
     return JSON.stringify(val.value);
   if (val.ctype === "list")
     return "[" + val.value.map(myniceprint).join(", ") + "]";
+  if (val.ctype === "dict")
+    return "{" + Object.keys(val.value).sort().map(function(key) {
+      var kv = val.value[key];
+      return myniceprint(kv.key) + ":" + myniceprint(kv.value);
+    }).join(", ") + "}";
   return cjs.niceprint(val).toString();
 };
 
@@ -214,6 +219,10 @@ function sanityCheck(val) {
     if (!Array.isArray(val.value))
       throw Error("not an array");
     val.value.forEach(sanityCheck);
+    break;
+  case "dict":
+    if (typeof val.value !== "object")
+      throw Error("not a dict object");
     break;
   case "undefined":
     break;

--- a/src/js/libcs/Dict.js
+++ b/src/js/libcs/Dict.js
@@ -1,0 +1,74 @@
+/*
+ * Dictionaries map CindyScript values to CindyScript values.
+ * Since values are immutable and support equality testing,
+ * they can be easily used as keys.
+ *
+ * Internally the map is an object with properties
+ * whose names are stringified versions of the CindyScript keys.
+ * The values are objects which hold the original key and value.
+ * To keep overhead low, avoid deeply nested data structures as keys.
+ */
+
+var Dict = {};
+
+Dict.key = function(x) {
+    if (x.ctype === "string")
+        return "s" + x.value.length + ":" + x.value + ";";
+    if (x.ctype === "number")
+        return "n" + x.value.real + "," + x.value.imag + ";";
+    if (x.ctype === "list")
+        return "l" + x.value.length + ":" +
+            x.value.map(Dict.key).join(",") + ";";
+    if (x.ctype === "boolean")
+        return "b" + x.value + ";";
+    if (x.ctype === "dict") {
+        var keys = Object.keys(x.value).sort();
+        return "d" + keys.length + ":" + keys.join(",") + ";";
+    }
+    if (x.ctype !== "undefined")
+        csconsole.err("Bad dictionary key: " + niceprint(x));
+    return "undef";
+};
+
+// Dictionary creation is a two-step process:
+// one creates a dictionary (empty or cloned), then adds entries to it.
+// During this process, the dictionary is considered mutable.
+// But as for all other CindyJS data structures, once the construction
+// is complete and other code gains access to the dictionary,
+// the dictionary is considered immutable.
+
+Dict.create = function() {
+    return {
+        ctype: "dict",
+        value: {} // or Map or Object.create(null)?
+    };
+};
+
+Dict.clone = function(dict) {
+    var res = Dict.create();
+    for (var key in dict.value)
+        if (dict.value.hasOwnProperty(key))
+            res.value[key] = dict.value[key];
+    return res;
+};
+
+// Modifying operation
+Dict.put = function(dict, key, value) {
+    dict.value[Dict.key(key)] = {
+        key: key,
+        value: value
+    };
+};
+
+Dict.get = function(dict, key, dflt) {
+    var kv = dict.value[Dict.key(key)];
+    if (kv) return kv.value; // check kv.key?
+    return dflt;
+};
+
+Dict.niceprint = function(dict) {
+    return "{" + Object.keys(dict.value).sort().map(function(key) {
+        var kv = dict.value[key];
+        return niceprint(kv.key) + ":" + niceprint(kv.value);
+    }).join(", ") + "}";
+};

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -93,6 +93,9 @@ function niceprint(a) {
         }
         return erg + "]";
     }
+    if (a.ctype === 'dict') {
+        return Dict.niceprint(a);
+    }
     if (a.ctype === 'function') {
         return 'FUNCTION';
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -2825,6 +2825,40 @@ evaluator.column$2 = function(args, modifs) {
 
 
 ///////////////////////////////
+//        DICTIONARIES       //
+///////////////////////////////
+
+evaluator.dict$0 = function(args, modifs) {
+    var d = Dict.create();
+    for (var key in modifs)
+        if (modifs.hasOwnProperty(key))
+            Dict.put(d, General.string(key), evaluate(modifs[key]));
+    return d;
+};
+
+evaluator.put$3 = function(args, modifs) {
+    var d = evaluate(args[0]);
+    var k = evaluate(args[1]);
+    var v = evaluate(args[2]);
+    if (d.ctype === "dict") {
+        d = Dict.clone(d);
+        Dict.put(d, k, v);
+        return d;
+    }
+    return nada;
+};
+
+evaluator.get$2 = function(args, modifs) {
+    var d = evaluate(args[0]);
+    var k = evaluate(args[1]);
+    if (d.ctype === "dict") {
+        return Dict.get(d, k, nada);
+    }
+    return nada;
+};
+
+
+///////////////////////////////
 //         COLOR OPS         //
 ///////////////////////////////
 

--- a/tests/Dict_tests.js
+++ b/tests/Dict_tests.js
@@ -1,0 +1,35 @@
+var assert = require("chai").assert;
+var rewire = require("rewire");
+
+var cindyJS = rewire("../build/js/exposed.js");
+
+var nada = cindyJS.__get__("nada");
+var Dict = cindyJS.__get__("Dict");
+var General = cindyJS.__get__("General");
+
+describe("Dictionary", function() {
+    it("can hold a value", function() {
+        var d = Dict.create();
+        Dict.put(d, General.wrap("thekey"), General.wrap(42));
+        var v = Dict.get(d, General.wrap("the" + "key"));
+        assert(v.value.real == 42);
+    });
+    it("returns default for unsed", function() {
+        var d = Dict.create();
+        Dict.put(d, General.wrap("otherkey"), General.wrap(42));
+        var v = Dict.get(d, General.wrap("the" + "key"), nada);
+        assert(v === nada);
+    });
+    it("can use numbers as keys", function() {
+        var d = Dict.create();
+        Dict.put(d, General.wrap(123), General.wrap(42));
+        var v = Dict.get(d, General.wrap(123));
+        assert(v.value.real == 42);
+    });
+    it("does not stringify", function() {
+        var d = Dict.create();
+        Dict.put(d, General.wrap("123"), General.wrap(42));
+        var v = Dict.get(d, General.wrap(123), null);
+        assert(v === null);
+    });
+});


### PR DESCRIPTION
This adds enough support for dictionaries that they can be used to construct JSON-like data structures.  Furthermore, the general direction of this concept is already recognizable, in particular the support for non-string keys and the use of a key-building function to stringify these.