### PR TITLE
Bugfix: x^integer in CindyGL

### DIFF
--- a/plugins/cindygl/src/js/WebGLImplementation.js
+++ b/plugins/cindygl/src/js/WebGLImplementation.js
@@ -13,7 +13,7 @@ webgltype[type.color] = 'vec4';
 webgltype[type.point] = 'vec3'; //use homogenious coordinates
 webgltype[type.coordinate2d] = 'vec2';
 
-//(a, b) \in \C^4 \mapsto (re a, im a, re b, im b) \in \R^4 
+//(a, b) \in \C^4 \mapsto (re a, im a, re b, im b) \in \R^4
 webgltype[type.vec2complex] = 'vec4';
 
 // (a b)    (re a, -im a, re b, -im b)
@@ -333,7 +333,7 @@ webgltr["ceil"] = [
 ];
 
 webgltr["mod"] = [
-    [int_fun$2, (a, cb) => ('int(' + usefunction('mod')('float(' + a[0] + '), float(' + a[1] + ')', cb) + ')')], //useinfix('%') '%' : integer modulus operator supported in GLSL ES 3.00 only  
+    [int_fun$2, (a, cb) => ('int(' + usefunction('mod')('float(' + a[0] + '), float(' + a[1] + ')', cb) + ')')], //useinfix('%') '%' : integer modulus operator supported in GLSL ES 3.00 only
     [float_fun$2, usefunction('mod')],
     [complex_fun$2, usefunction('mod')] //or implement [complex_fun$2, useincludefunction('modc')], see https://github.com/CindyJS/CindyJS/issues/272
 ];
@@ -395,9 +395,7 @@ webgltr["pow"] = [
             args: [type.float, type.int],
             res: type.float
         },
-        function(args) {
-            return "pow(" + args[0] + ", float(" + args[1] + "))";
-        } //TODO: 0^0=1 in cindyjs
+        useincludefunction('powi')
     ],
     [{
         args: [type.complex, type.complex],

--- a/plugins/cindygl/src/str/powi.glsl
+++ b/plugins/cindygl/src/str/powi.glsl
@@ -1,3 +1,6 @@
 float powi(float a, int b){
-    return pow(a, float(b));
+  if(mod(float(b), 2.) < .5)
+    return pow(abs(a), float(b));
+  else
+    return sign(a)*pow(abs(a), float(b));
 }


### PR DESCRIPTION
With this commit the float operator x^i will give correct results for x<0 and large i. In particular x^i can now be used for raytracacing algebraic surfaces of high degree.