### PR TITLE
Adjust scale of drawimage(‹pos›,‹image›) to match Cinderella

### DIFF
--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -159,6 +159,9 @@ evaluator.drawimage$2 = function(args, modifs) {
         var sc = Math.sqrt(xx1 * xx1 + yy1 * yy1) / Math.sqrt(ixx1 * ixx1 + iyy1 * iyy1);
         var ang = -Math.atan2(xx1, yy1) + Math.atan2(ixx1, iyy1);
 
+        var viewScale = csport.drawingstate.matrix.sdet / 72;
+        scax *= viewScale;
+        scay *= viewScale;
 
         if (alpha !== 1)
             csctx.globalAlpha = alpha;


### PR DESCRIPTION
While CindyJS sized its images relative to the viewport so far, this modification makes the size relative to the user coordinate system as it is done in Cinderella.

This is a breaking change, since it will very likely break content which made use of the 2-ary `drawimage` function before. Therefore I recommend that we merge this and #443 and then release CindyJS 0.8.0. Unless someone is aware of other breaking changes.

This fixes #466.