### PR TITLE
Update Closure Compiler to latest version (v20160911)

### DIFF
--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160822",
+        closure_version: "20160911",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",


### PR DESCRIPTION
This brings several improvements to Closure Compiler.

I have tested the new version with several examples of CindyJS core, Cindy3D, and CindyGL, all of which worked.