### PR TITLE
Fullsize and fullscreen examples

### DIFF
--- a/examples/fullscreen.html
+++ b/examples/fullscreen.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Widget which can enter fullscreen mode</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<style type="text/css">
+  #outer { width: 400px; height: 400px; }
+  #CSCanvas { width: 100%; height: 100%; }
+</style>
+</head>
+
+<body style="font-family:Arial; ">
+  <div id="outer">
+    <div id="CSCanvas"></div>
+  </div>
+  <button id="fs">Fullscreen</button>
+  <script type="text/javascript">
+
+var cdy = CindyJS({
+  ports: [{
+    id: "CSCanvas",
+    transform: [{visibleRect:[-1,1,1,-1]}],
+    background: "rgb(255,255,255)"
+  }],
+  scripts: "cs*",
+  language: "en",
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0]},
+    {name:"B", type:"Free", pos:[0.7071,0.7071]},
+    {name:"C", type:"CircleMP", args:["A","B"]}
+  ]
+});
+
+var btn = document.getElementById("fs");
+var div = document.getElementById("CSCanvas");
+btn.onclick = function() {
+  (div.requestFullscreen ||
+   div.webkitRequestFullscreen ||
+   div.mozRequestFullScreen ||
+   div.msRequestFullscreen ||
+   function(){}).call(div);
+};
+  </script>
+</body>
+
+</html>

--- a/examples/fullsize.html
+++ b/examples/fullsize.html
@@ -7,6 +7,7 @@
 <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <style type="text/css">
   html,body { margin: 0px; padding: 0px; }
+  html,body,#CSCanvas { width: 100%; height: 100%; }
 </style>
 <script type="text/javascript">
 
@@ -28,7 +29,7 @@ var cdy = CindyJS({
 </head>
 
 <body style="font-family:Arial; ">
-  <div id="CSCanvas" style="width:100vw; height:100vh"></div>
+  <div id="CSCanvas"></div>
 </body>
 
 </html>


### PR DESCRIPTION
This improves the fullsize example for mobile devices, by specifying the height as `100%` instead of `100vh`. The former is the minimal viewport size, i.e. what you see if the top bar with the browser controls is displayed. The latter is the maximal viewport size, i.e. with the top bar hidden the way it is after scrolling. Since we don't scroll, the former is the right thing to use here.

See https://github.com/bokand/URLBarSizing for a nice summary of current behavior of various browsers.

This also demonstrates how a widget can be run in full screen mode. This may not work on all browsers, mobile browsers in particular, but it has been tested successfully on common desktop browsers.