### PR TITLE
Add the ability to read Text coordinates

### DIFF
--- a/examples/153_MoveText.html
+++ b/examples/153_MoveText.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Construction.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <link rel="stylesheet" href="http://cindyjs.org/dist/v0.7/CindyJS.css">
+    <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <script type="text/javascript">
+createCindy({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  geometry: [
+    {name: "Text0", type: "Text", pos: [3.48, 4.08, 1.0], color: [0.0, 0.0, 0.0], fillcolor: [1.0, 0.29, 0.29], fillalpha: 0.5384615384615384, text: "Move Me!"},
+    {name: "Text1", type: "Button", pos: [3.8496240601503757, -4.0, -0.7518796992481203], color: [0.0, 0.0, 0.0], fillcolor: [1.0, 1.0, 1.0], fillalpha: 0.27272728085517883, script: "Text0.xy = Text0.xy + [1,1];", text: "Move diagonal"},
+    {name: "Text1'", type: "Button", pos: [2.9655172413793105, -4.0, -0.5747126436781609], color: [0.0, 0.0, 0.0], fillcolor: [1.0, 1.0, 1.0], fillalpha: 0.27272728085517883, script: "Text0.xy = [1,1];", text: "Move to [1,1]"},
+    {name: "Text2", type: "Calculation", pos: [4.0, -2.784, -0.8], color: [0.0, 0.0, 0.0], text: "Text0.xy"}
+  ],
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 285,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -2.06]}],
+    axes: true,
+    grid: 1.0,
+    background: "rgb(168,176,192)"
+  }],
+  cinderella: {build: 1872, version: [2, 9, 1872]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/examples/153_MoveText.html
+++ b/examples/153_MoveText.html
@@ -22,7 +22,7 @@
     <link rel="stylesheet" href="../build/js/CindyJS.css">
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
-createCindy({
+var cdy = CindyJS(({
   scripts: "cs*",
   defaultAppearance: {
     dimDependent: 0.7,

--- a/examples/153_MoveText.html
+++ b/examples/153_MoveText.html
@@ -19,8 +19,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="http://cindyjs.org/dist/v0.7/CindyJS.css">
-    <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <link rel="stylesheet" href="../build/js/CindyJS.css">
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
 createCindy({
   scripts: "cs*",

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -47,7 +47,6 @@ Accessor.getField = function(geo, field) {
             return General.withUsage(geo.homog, "Point");
         }
 
-
         if (field === "x") {
             return CSNumber.div(geo.homog.value[0], geo.homog.value[2]);
         }
@@ -235,26 +234,26 @@ Accessor.setField = function(geo, field, value) {
         }
     }
 
-    if (geo.kind === "P" &&  geo.movable) {
-	    if (field === "xy" && List._helper.isNumberVecN(value, 2)) {
-	        movepointscr(geo, List.turnIntoCSList([value.value[0], value.value[1], CSNumber.real(1)]), "homog");
-	    }
+    if (geo.kind === "P" && geo.movable) {
+        if (field === "xy" && List._helper.isNumberVecN(value, 2)) {
+            movepointscr(geo, List.turnIntoCSList([value.value[0], value.value[1], CSNumber.real(1)]), "homog");
+        }
 
-	    if (field === "xy" && List._helper.isNumberVecN(value, 3)) {
-	        movepointscr(geo, value, "homog");
-	    }
+        if (field === "xy" && List._helper.isNumberVecN(value, 3)) {
+            movepointscr(geo, value, "homog");
+        }
 
-	    if (field === "x" && value.ctype === "number") {
-	        movepointscr(geo, List.turnIntoCSList([CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[1], geo.homog.value[2]]), "homog");
-	    }
+        if (field === "x" && value.ctype === "number") {
+            movepointscr(geo, List.turnIntoCSList([CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[1], geo.homog.value[2]]), "homog");
+        }
 
-	    if (field === "y" && value.ctype === "number") {
-	        movepointscr(geo, List.turnIntoCSList([geo.homog.value[0], CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[2]]), "homog");
-	    }
+        if (field === "y" && value.ctype === "number") {
+            movepointscr(geo, List.turnIntoCSList([geo.homog.value[0], CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[2]]), "homog");
+        }
 
-	    if (field === "homog" && List._helper.isNumberVecN(value, 3)) {
-	        movepointscr(geo, value, "homog");
-	    }   	
+        if (field === "homog" && List._helper.isNumberVecN(value, 3)) {
+            movepointscr(geo, value, "homog");
+        }
     }
 
     if (field === "homog" && geo.kind === "L" && geo.movable && List._helper.isNumberVecN(value, 3)) {
@@ -283,6 +282,21 @@ Accessor.setField = function(geo, field, value) {
         if (field === "text") {
             if (geo.type === "EditableText") {
                 geo.html.value = niceprint(value);
+            }
+        }
+        if (geo.movable) { // Texts may move without tracing
+            if (field === "xy") {
+                if (List._helper.isNumberVecN(value, 2)) {
+                    geo.homog = List.turnIntoCSList([value.value[0], value.value[1], CSNumber.real(1)]);
+                } else if (List._helper.isNumberVecN(value, 3)) {
+                    geo.homog = value;
+                }
+            } else if (field === "homog" && List._helper.isNumberVecN(value, 3)) {
+                geo.homog = value;
+            } else if (field === "x" && value.ctype === "number") {
+                geo.homog = List.turnIntoCSList([CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[1], geo.homog.value[2]]);
+            } else if (field === "y" && value.ctype === "number") {
+                geo.homog = List.turnIntoCSList([geo.homog.value[0], CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[2]]);
             }
         }
     }

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -126,6 +126,19 @@ Accessor.getField = function(geo, field) {
                 return General.string(String(geo.html.value));
             }
         }
+        if (field === "xy") {
+            erg = List.dehom(geo.homog);
+            return General.withUsage(erg, "Point");
+        }
+        if (field === "homog") {
+            return General.withUsage(geo.homog, "Point");
+        }
+        if (field === "x") {
+            return CSNumber.div(geo.homog.value[0], geo.homog.value[2]);
+        }
+        if (field === "y") {
+            return CSNumber.div(geo.homog.value[1], geo.homog.value[2]);
+		}
     }
     if (field === "trace") {
         return General.bool(!!geo.drawtrace);
@@ -229,7 +242,7 @@ Accessor.setField = function(geo, field, value) {
     if (field === "xy" && geo.kind === "P" && geo.movable && List._helper.isNumberVecN(value, 3)) {
         movepointscr(geo, value, "homog");
     }
-
+	
     if (field === "x" && geo.kind === "P" && geo.movable && value.ctype === "number") {
         movepointscr(geo, List.turnIntoCSList([CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[1], geo.homog.value[2]]), "homog");
     }
@@ -271,6 +284,9 @@ Accessor.setField = function(geo, field, value) {
                 geo.html.value = niceprint(value);
             }
         }
+		if (field === "xy") {
+			
+		}
     }
     if (geo.behavior) {
         if (field === "mass" && geo.behavior.type === "Mass" && value.ctype === "number") {

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -138,7 +138,7 @@ Accessor.getField = function(geo, field) {
         }
         if (field === "y") {
             return CSNumber.div(geo.homog.value[1], geo.homog.value[2]);
-		}
+        }
     }
     if (field === "trace") {
         return General.bool(!!geo.drawtrace);
@@ -235,25 +235,26 @@ Accessor.setField = function(geo, field, value) {
         }
     }
 
-    if (field === "xy" && geo.kind === "P" && geo.movable && List._helper.isNumberVecN(value, 2)) {
-        movepointscr(geo, List.turnIntoCSList([value.value[0], value.value[1], CSNumber.real(1)]), "homog");
-    }
+    if (geo.kind === "P" &&  geo.movable) {
+	    if (field === "xy" && List._helper.isNumberVecN(value, 2)) {
+	        movepointscr(geo, List.turnIntoCSList([value.value[0], value.value[1], CSNumber.real(1)]), "homog");
+	    }
 
-    if (field === "xy" && geo.kind === "P" && geo.movable && List._helper.isNumberVecN(value, 3)) {
-        movepointscr(geo, value, "homog");
-    }
-	
-    if (field === "x" && geo.kind === "P" && geo.movable && value.ctype === "number") {
-        movepointscr(geo, List.turnIntoCSList([CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[1], geo.homog.value[2]]), "homog");
-    }
+	    if (field === "xy" && List._helper.isNumberVecN(value, 3)) {
+	        movepointscr(geo, value, "homog");
+	    }
 
-    if (field === "y" && geo.kind === "P" && geo.movable && value.ctype === "number") {
-        movepointscr(geo, List.turnIntoCSList([geo.homog.value[0], CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[2]]), "homog");
-    }
+	    if (field === "x" && value.ctype === "number") {
+	        movepointscr(geo, List.turnIntoCSList([CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[1], geo.homog.value[2]]), "homog");
+	    }
 
+	    if (field === "y" && value.ctype === "number") {
+	        movepointscr(geo, List.turnIntoCSList([geo.homog.value[0], CSNumber.mult(value, geo.homog.value[2]), geo.homog.value[2]]), "homog");
+	    }
 
-    if (field === "homog" && geo.kind === "P" && geo.movable && List._helper.isNumberVecN(value, 3)) {
-        movepointscr(geo, value, "homog");
+	    if (field === "homog" && List._helper.isNumberVecN(value, 3)) {
+	        movepointscr(geo, value, "homog");
+	    }   	
     }
 
     if (field === "homog" && geo.kind === "L" && geo.movable && List._helper.isNumberVecN(value, 3)) {
@@ -284,9 +285,6 @@ Accessor.setField = function(geo, field, value) {
                 geo.html.value = niceprint(value);
             }
         }
-		if (field === "xy") {
-			
-		}
     }
     if (geo.behavior) {
         if (field === "mass" && geo.behavior.type === "Mass" && value.ctype === "number") {


### PR DESCRIPTION
This commit will add the ability to read `xy`, `homog`, `x` and `y` coordinates from Text objects.
The code is actually the same than it is for reading point coordinates, so this might be refactored
to include the code only once. 

there is some superfluous if statement at line 287, please ignore this, I will use it soon in another commit (or remove it).

This will fix #484.