### PR TITLE
Perform division without inversion

### DIFF
--- a/ref/Texts_and_Tables.md
+++ b/ref/Texts_and_Tables.md
@@ -59,7 +59,7 @@ The code
     D fillStyle = "rgba(127,0,127,1)"
     D font = "bold 25px sans-serif"
     D fillText("Text", 375.5, 229.5)
-    D fillStyle = "rgba(101,0,153,1)"
+    D fillStyle = "rgba(102,0,153,1)"
     D font = "bold 27px sans-serif"
     D fillText("Text", 400.5, 229.5)
     D fillStyle = "rgba(76,0,178,1)"

--- a/src/js/libcs/CSNumber.js
+++ b/src/js/libcs/CSNumber.js
@@ -282,7 +282,18 @@ CSNumber.inv = function(a) {
 
 
 CSNumber.div = function(a, b) {
-    return CSNumber.mult(a, CSNumber.inv(b));
+    var ar = a.value.real;
+    var ai = a.value.imag;
+    var br = b.value.real;
+    var bi = b.value.imag;
+    var s = br * br + bi * bi;
+    return {
+        "ctype": "number",
+        "value": {
+            'real': (ar * br + ai * bi) / s,
+            'imag': (ai * br - ar * bi) / s
+        }
+    };
 };
 
 CSNumber.eps = 1e-10;


### PR DESCRIPTION
This avoids rounding errors, particularly when dividing integers.

Fixes #494.