### PR TITLE
Fine-tune Cinderella version check for animation speed

### DIFF
--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -261,7 +261,7 @@ function createCindyNow() {
                 data.cinderella.version &&
                 data.cinderella.version[0] === 2 &&
                 data.cinderella.version[1] === 9 &&
-                data.cinderella.version[2] < 1880)
+                data.cinderella.version[2] < 1875)
                 setSpeed(data.animation.speed * 0.5);
             else
                 setSpeed(data.animation.speed);


### PR DESCRIPTION
The Cinderella export change to include accuracy as part of the speed value was first included in build 1875, so files created from that or later versions should not halve their speed even if the accuracy got manually removed after exportin the file.