### PR TITLE
Support keyup and keytyped events

### DIFF
--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -278,13 +278,14 @@ function createCindyNow() {
     }
 
     //Setup the scripts
-    var scripts = ["move", "keydown",
+    var scripts = ["move",
+        "keydown", "keyup", "keytyped", "keytype",
         "mousedown", "mouseup", "mousedrag", "mousemove", "mouseclick",
         "init", "tick", "draw",
         "simulationstep", "simulationstart", "simulationstop", "ondrop"
     ];
-    var scriptconf = data.scripts,
-        scriptpat = null;
+    var scriptconf = data.scripts;
+    var scriptpat = null;
     if (typeof scriptconf === "string" && scriptconf.search(/\*/))
         scriptpat = scriptconf;
     if (typeof scriptconf !== "object")
@@ -317,6 +318,17 @@ function createCindyNow() {
             cscompiled[s] = cscode;
         }
     });
+    if (data.cinderella &&
+        data.cinderella.version &&
+        data.cinderella.version[0] === 2 &&
+        data.cinderella.version[1] === 9 &&
+        data.cinderella.version[2] < 1888 &&
+        !cscompiled.keydown) {
+        // Cinderella backwards-compatible naming of key events
+        cscompiled.keydown = cscompiled.keytyped;
+        cscompiled.keytyped = cscompiled.keytype;
+        cscompiled.keytype = undefined;
+    }
 
     if (isFiniteNumber(data.grid) && data.grid > 0) {
         csgridsize = data.grid;

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -190,6 +190,19 @@ function canvasWithContainingDiv(elt) {
     return canvas;
 }
 
+function isCinderellaBeforeVersion() {
+    var c = instanceInvocationArguments.cinderella;
+    if (!c || !c.version)
+        return false;
+    for (var i = 0; i < arguments.length; ++i) {
+        var x = c.version[i];
+        var y = arguments[i];
+        if (x !== y)
+            return (typeof x === typeof y) && (x < y);
+    }
+    return false;
+}
+
 function createCindyNow() {
     startupCalled = true;
     if (waitForPlugins !== 0) return;
@@ -257,11 +270,7 @@ function createCindyNow() {
             setupAnimControls(data);
         if (data.animation && isFiniteNumber(data.animation.speed)) {
             if (data.animation.accuracy === undefined &&
-                data.cinderella &&
-                data.cinderella.version &&
-                data.cinderella.version[0] === 2 &&
-                data.cinderella.version[1] === 9 &&
-                data.cinderella.version[2] < 1875)
+                isCinderellaBeforeVersion(2, 9, 1875))
                 setSpeed(data.animation.speed * 0.5);
             else
                 setSpeed(data.animation.speed);
@@ -318,12 +327,7 @@ function createCindyNow() {
             cscompiled[s] = cscode;
         }
     });
-    if (data.cinderella &&
-        data.cinderella.version &&
-        data.cinderella.version[0] === 2 &&
-        data.cinderella.version[1] === 9 &&
-        data.cinderella.version[2] < 1888 &&
-        !cscompiled.keydown) {
+    if (isCinderellaBeforeVersion(2, 9, 1888) && !cscompiled.keydown) {
         // Cinderella backwards-compatible naming of key events
         cscompiled.keydown = cscompiled.keytyped;
         cscompiled.keytyped = cscompiled.keytype;

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2711,6 +2711,20 @@ function commonButton(el, event, button) {
         };
     }
     button.addEventListener(event, onEvent);
+    if (!instanceInvocationArguments.keylistener &&
+        (cscompiled.keydown || cscompiled.keyup || cscompiled.keytyped)) {
+        button.addEventListener("keydown", function(e) {
+            if (e.keyCode === 9 /* tab */ ) return;
+            cs_keydown(e);
+        });
+        button.addEventListener("keyup", function(e) {
+            cs_keyup(e);
+        });
+        button.addEventListener("keypress", function(e) {
+            if (e.keyCode === 9 /* tab */ ) return;
+            cs_keytyped(e);
+        });
+    }
     geoOps.Text.initialize(el);
 }
 


### PR DESCRIPTION
Things are slightly complicated by the fact that Cinderella uses strange event names for reasons of backwards compatibility: it maps “Key Down” in the GUI to “keytyped” in the export, and “Key Typed” in the GUI to “keytype” in the export. I've submitted a merge request to change that, but I've also included a backwards-compatibility hack to detect and adjust previous exports.