### PR TITLE
Allow currenttext as an alias for the text accessor

### DIFF
--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -120,7 +120,7 @@ Accessor.getField = function(geo, field) {
                 return General.bool(false);
             }
         }
-        if (field === "text") {
+        if (field === "text" || field === "currenttext") {
             if (geo.type === "EditableText") {
                 return General.string(String(geo.html.value));
             }
@@ -287,7 +287,7 @@ Accessor.setField = function(geo, field, value) {
         if (field === "pressed" && value.ctype === "boolean" && geo.checkbox) {
             geo.checkbox.checked = value.value;
         }
-        if (field === "text") {
+        if (field === "text" || field === "currenttext") {
             if (geo.type === "EditableText") {
                 geo.html.value = niceprint(value);
             }


### PR DESCRIPTION
Apparently Cinderella supports both `.text` (inherited from the basic text class) and `.currenttext` (specific to the `EditableText` type), so we should support both as well.