### PR TITLE
tokenize: Do not autoconvert tokens starting in digits

### DIFF
--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -111,6 +111,8 @@ that represents the subdivision of `‹string›` recursively by the tokens in t
     < [["one", "two"], [""], ["three", "four"]]
     > tokenize("one:two..three:four", ["..",":"])
     < [["one", "two"], ["three", "four"]]
+    > tokenize("(1;2)", ";")
+    < ["(1", "2)"]
 
 `tokenize` usually converts string representations of numbers to number objects.
 This can lead to information loss.

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3109,8 +3109,8 @@ evaluator.tokenize$2 = function(args, modifs) {
                     convert = erg.value;
                 }
             }
-            if (convert) {
-                var fl = parseFloat(str);
+            if (convert && str !== "") {
+                var fl = Number(str);
                 if (!isNaN(fl)) {
                     return CSNumber.real(fl);
                 }


### PR DESCRIPTION
I found this while working with some MC2 widgets.