### PR TITLE
Drag and drop: support JSON, support URLs

### DIFF
--- a/examples/141_fileDrop.html
+++ b/examples/141_fileDrop.html
@@ -33,6 +33,7 @@ draw(point(dropPoint), color->[0,1,0], alpha->0.5);
 <script id="csondrop" type="text/x-cindyscript">
   dropped = dropped();
   dropPoint = droppoint();
+  err(dropped);
 </script>
 <script type="text/javascript">
 
@@ -53,6 +54,12 @@ var cdy = CindyJS({
 
 <body style="font-family:Arial;">
   <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
+  <p>You can also drag and drop
+    <a href="../package.json" draggable="true">this link</a> (on some browsers)
+    or these images (on most browsers):<br>
+    <img src="rost.png" draggable="true">
+    <img src="boe.png" draggable="true">
+  </p>
 </body>
 
 

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -229,7 +229,7 @@ function setuplisteners(canvas, data) {
                         textDone(i, reader.result);
                     };
                     reader.readAsText(file);
-                } else if ((/^image\//).test(tile.type)) {
+                } else if ((/^image\//).test(file.type)) {
                     reader.onload = function() {
                         imgDone(reader.result);
                     };

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -223,13 +223,27 @@ function setuplisteners(canvas, data) {
 
         Array.prototype.forEach.call(files, function(file, i) {
             var reader = new FileReader();
-            if ((/^text\//).test(file.type)) {
+            var type = file.type.replace(/;[^]*/, "");
+            if ((/^text\//).test(type)) {
                 reader.onload = function() {
                     var value = General.string(reader.result);
                     oneDone(i, value);
                 };
                 reader.readAsText(file);
-            } else if ((/^image\//).test(file.type)) {
+            } else if (type === "application/json") {
+                reader.onload = function() {
+                    var data, value;
+                    try {
+                        data = JSON.parse(reader.result);
+                        value = General.wrapJSON(data);
+                    } catch (err) {
+                        console.error(err);
+                        value = nada;
+                    }
+                    oneDone(i, value);
+                };
+                reader.readAsText(file);
+            } else if ((/^image\//).test(type)) {
                 reader.onload = function() {
                     var img = new Image();
                     img.onload = function() {
@@ -239,6 +253,7 @@ function setuplisteners(canvas, data) {
                 };
                 reader.readAsDataURL(file);
             } else {
+                console.log("Unknown MIME type: " + file.type);
                 oneDone(i, nada);
             }
         });

--- a/src/js/libcs/General.js
+++ b/src/js/libcs/General.js
@@ -243,3 +243,27 @@ General.withUsage = function(v, usage) {
         "usage": usage
     };
 };
+
+General.wrapJSON = function(data) {
+    switch (typeof data) {
+        case "number":
+            return CSNumber.real(data);
+        case "string":
+            return General.string(data);
+        case "boolean":
+            return General.bool(data);
+        case "object":
+            if (data === null)
+                return nada;
+            if (Array.isArray(data))
+                return List.turnIntoCSList(data.map(General.wrapJSON));
+            var d = Dict.create();
+            for (var k in data)
+                Dict.put(d, General.string(k), General.wrapJSON(data[k]));
+            return d;
+        default:
+            console.log(
+                "Failed to convert " + (typeof data) + " to CindyJS data type");
+            return nada;
+    }
+};


### PR DESCRIPTION
This enhances our drag & drop support by allowing users to drop JSON files, and also to drag sources which may yield a list of URIs, in particular image elements or URLs displayed in a different tab.