### PR TITLE
Allow setting the fillcolor of buttons

### DIFF
--- a/examples/Buttons2.html
+++ b/examples/Buttons2.html
@@ -2,25 +2,13 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Buttons2.cdy</title>
-    <style type="text/css">
-        * {
-            margin: 0px;
-            padding: 0px;
-        }
-
-        #CSConsole {
-            background-color: #FAFAFA;
-            border-top: 1px solid #333333;
-            bottom: 0px;
-            height: 200px;
-            overflow-y: scroll;
-            position: fixed;
-            width: 100%;
-        }
-    </style>
+    <title>Buttons2</title>
     <link rel="stylesheet" href="../build/js/CindyJS.css">
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
+    <script id="csinit" type="text/x-cindyscript">
+      Text2.fillcolor = [0.75, 0.75, 1];
+      Text5.fillcolor = [1, 1, 0];
+    </script>
     <script type="text/javascript">
 CindyJS({
   scripts: "cs*",
@@ -37,10 +25,10 @@ CindyJS({
     {name: "a", type: "VerticalLine", pos: [4.0, -0.0, 0.0], color: [0.0, 0.0, 1.0]},
     {name: "b", type: "VerticalLine", pos: [-0.4, -0.0, 4.0], color: [0.0, 0.0, 1.0]},
     {name: "Text0", type: "Button", pos: [0.0, -4.0, -1.0], color: [0.0, 0.0, 0.0], text: "Left push", align: "left"},
-    {name: "Text1", type: "Button", pos: [0.0, -4.0, -2.0], color: [0.0, 0.0, 0.0], text: "center | center", align: "mid"},
+    {name: "Text1", type: "Button", pos: [0.0, -4.0, -2.0], color: [0.0, 0.0, 0.0], text: "center | center", align: "mid", fillcolor: [0, 1, 0]},
     {name: "Text2", type: "Button", pos: [0.0, -0.0, 4.0], color: [0.0, 0.0, 0.0], text: "Right push", align: "right"},
     {name: "Text3", type: "ToggleButton", pos: [4.0, 1.6, 0.4], color: [0.0, 0.0, 0.0], text: "Left toggle", align: "left"},
-    {name: "Text4", type: "ToggleButton", pos: [4.0, 0.8, 0.4], color: [0.0, 0.0, 0.0], text: "mid | mid", align: "mid"},
+    {name: "Text4", type: "ToggleButton", pos: [4.0, 0.8, 0.4], color: [0.0, 0.0, 0.0], text: "mid | mid", align: "mid", fillcolor: [1, 0.75, 0], fillalpha: 0.27},
     {name: "Text5", type: "ToggleButton", pos: [4.0, -0.0, 0.4], color: [0.0, 0.0, 0.0], text: "Right toggle", align: "right"},
     {name: "c", type: "VerticalLine", pos: [-0.8, -0.0, 4.0], color: [0.0, 0.0, 1.0]},
     {name: "Text6", type: "Text", pos: [4.0, -0.0, 0.8], color: [0.0, 0.0, 0.0], text: "Right text", align: "right"},

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -120,11 +120,6 @@ Accessor.getField = function(geo, field) {
                 return General.bool(false);
             }
         }
-        if (field === "text" || field === "currenttext") {
-            if (geo.type === "EditableText") {
-                return General.string(String(geo.html.value));
-            }
-        }
         if (field === "xy") {
             erg = List.dehom(geo.homog);
             return General.withUsage(erg, "Point");
@@ -187,6 +182,10 @@ Accessor.getField = function(geo, field) {
         }
 
     }
+    var getter = geoOps[geo.type]["get_" + field];
+    if (typeof getter === "function") {
+        return getter(geo);
+    }
     return nada;
 
 
@@ -205,15 +204,7 @@ Accessor.setField = function(geo, field, value) {
         geo.alpha = value;
     }
     if (field === "fillcolor" && List._helper.isNumberVecN(value, 3)) {
-        if (geo.type === "EditableText") {
-            geo.fillcolor = value.value.map(function(i) {
-                return i.value.real;
-            });
-            geo.html.style.backgroundColor =
-                Render2D.makeColor(geo.fillcolor, geo.fillalpha);
-        } else {
-            geo.fillcolor = value;
-        }
+        geo.fillcolor = value;
     }
     if (field === "fillalpha" && value.ctype === "number") {
         geo.fillalpha = value;
@@ -268,29 +259,9 @@ Accessor.setField = function(geo, field, value) {
         movepointscr(geo, value, "homog");
     }
 
-    if (field === "angle" && geo.type === "Through" && value.ctype === "number") {
-        var cc = CSNumber.cos(value);
-        var ss = CSNumber.sin(value);
-        dir = List.turnIntoCSList([cc, ss, CSNumber.real(0)]);
-        movepointscr(geo, dir, "dir");
-    }
-    if (field === "slope" && geo.type === "Through" && value.ctype === "number") {
-        dir = List.turnIntoCSList([CSNumber.real(1), value, CSNumber.real(0)]);
-        movepointscr(geo, dir, "dir");
-    }
-    if (geo.kind === "C") {
-        if (field === "radius" && geo.type === "CircleMr" && value.ctype === "number") {
-            movepointscr(geo, value, "radius");
-        }
-    }
     if (geo.kind === "Text") {
         if (field === "pressed" && value.ctype === "boolean" && geo.checkbox) {
             geo.checkbox.checked = value.value;
-        }
-        if (field === "text" || field === "currenttext") {
-            if (geo.type === "EditableText") {
-                geo.html.value = niceprint(value);
-            }
         }
         if (geo.movable) { // Texts may move without tracing
             if (field === "xy") {
@@ -334,6 +305,10 @@ Accessor.setField = function(geo, field, value) {
             geo.behavior.vx = value.value[0].value.real;
             geo.behavior.vy = value.value[1].value.real;
         }
+    }
+    var setter = geoOps[geo.type]["set_" + field];
+    if (typeof setter === "function") {
+        return setter(geo, value);
     }
 
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2722,6 +2722,12 @@ function commonButton(el, event, button) {
         inlinebox.appendChild(arguments[i]);
     canvas.parentNode.appendChild(outer);
     el.html = arguments[arguments.length - 1];
+    if (!isFiniteNumber(el.fillalpha))
+        el.fillalpha = 1.0;
+    if (el.fillcolor) {
+        el.html.style.backgroundColor =
+            Render2D.makeColor(el.fillcolor, el.fillalpha);
+    }
     var onEvent = scheduleUpdate;
     if (el.script) {
         var code = analyse(el.script);
@@ -2746,6 +2752,15 @@ geoOps.Button.initialize = function(el) {
 geoOps.Button.getParamForInput = geoOps.Text.getParamForInput;
 geoOps.Button.getParamFromState = geoOps.Text.getParamFromState;
 geoOps.Button.putParamToState = geoOps.Text.putParamToState;
+geoOps.Button.set_fillcolor = function(el, value) {
+    if (List._helper.isNumberVecN(value, 3)) {
+        el.fillcolor = value.value.map(function(i) {
+            return i.value.real;
+        });
+        el.html.style.backgroundColor =
+            Render2D.makeColor(el.fillcolor, el.fillalpha);
+    }
+};
 
 geoOps.ToggleButton = {};
 geoOps.ToggleButton.kind = "Text";
@@ -2767,6 +2782,7 @@ geoOps.ToggleButton.initialize = function(el) {
 geoOps.ToggleButton.getParamForInput = geoOps.Text.getParamForInput;
 geoOps.ToggleButton.getParamFromState = geoOps.Text.getParamFromState;
 geoOps.ToggleButton.putParamToState = geoOps.Text.putParamToState;
+geoOps.ToggleButton.set_fillcolor = geoOps.Button.set_fillcolor;
 
 geoOps.EditableText = {};
 geoOps.EditableText.kind = "Text";
@@ -2777,12 +2793,6 @@ geoOps.EditableText.initialize = function(el) {
     var textbox = document.createElement("input");
     textbox.setAttribute("type", "text");
     textbox.className = "CindyJS-editabletext";
-    if (!isFiniteNumber(el.fillalpha))
-        el.fillalpha = 1.0;
-    if (el.fillcolor) {
-        textbox.style.backgroundColor =
-            Render2D.makeColor(el.fillcolor, el.fillalpha);
-    }
     if (isFiniteNumber(el.minwidth))
         textbox.style.width = (el.minwidth - 3) + "px";
     if (typeof el.text === "string")
@@ -2799,6 +2809,7 @@ geoOps.EditableText.getText = function(el) {
 geoOps.EditableText.getParamForInput = geoOps.Text.getParamForInput;
 geoOps.EditableText.getParamFromState = geoOps.Text.getParamFromState;
 geoOps.EditableText.putParamToState = geoOps.Text.putParamToState;
+geoOps.EditableText.set_fillcolor = geoOps.Button.set_fillcolor;
 geoOps.EditableText.get_currenttext = function(el) {
     return General.string(String(el.html.value));
 };
@@ -2807,15 +2818,6 @@ geoOps.EditableText.set_currenttext = function(el, value) {
 };
 geoOps.EditableText.get_text = geoOps.EditableText.get_currenttext;
 geoOps.EditableText.set_text = geoOps.EditableText.set_currenttext;
-geoOps.EditableText.set_fillcolor = function(el, value) {
-    if (List._helper.isNumberVecN(value, 3)) {
-        el.fillcolor = value.value.map(function(i) {
-            return i.value.real;
-        });
-        el.html.style.backgroundColor =
-            Render2D.makeColor(el.fillcolor, el.fillalpha);
-    }
-};
 
 function noop() {}
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -348,6 +348,21 @@ geoOps.Through.updatePosition = function(el) {
     el.homog = General.withUsage(homog, "Line");
 };
 geoOps.Through.stateSize = 6;
+geoOps.Through.set_angle = function(el, value) {
+    if (value.ctype === "number") {
+        var cc = CSNumber.cos(value);
+        var ss = CSNumber.sin(value);
+        var dir = List.turnIntoCSList([cc, ss, CSNumber.real(0)]);
+        movepointscr(el, dir, "dir");
+    }
+};
+geoOps.Through.set_slope = function(el, value) {
+    if (value.ctype === "number") {
+        var dir = List.turnIntoCSList(
+            [CSNumber.real(1), value, CSNumber.real(0)]);
+        movepointscr(el, dir, "dir");
+    }
+};
 
 
 geoOps.Free = {};
@@ -723,6 +738,11 @@ geoOps.CircleMr.updatePosition = function(el) {
     el.radius = r;
 };
 geoOps.CircleMr.stateSize = 2;
+geoOps.CircleMr.set_radius = function(el, value) {
+    if (value.ctype === "number") {
+        movepointscr(el, value, "radius");
+    }
+};
 
 
 geoOps._helper.ScaledCircleMrr = function(M, rr) {
@@ -2779,6 +2799,23 @@ geoOps.EditableText.getText = function(el) {
 geoOps.EditableText.getParamForInput = geoOps.Text.getParamForInput;
 geoOps.EditableText.getParamFromState = geoOps.Text.getParamFromState;
 geoOps.EditableText.putParamToState = geoOps.Text.putParamToState;
+geoOps.EditableText.get_currenttext = function(el) {
+    return General.string(String(el.html.value));
+};
+geoOps.EditableText.set_currenttext = function(el, value) {
+    el.html.value = niceprint(value);
+};
+geoOps.EditableText.get_text = geoOps.EditableText.get_currenttext;
+geoOps.EditableText.set_text = geoOps.EditableText.set_currenttext;
+geoOps.EditableText.set_fillcolor = function(el, value) {
+    if (List._helper.isNumberVecN(value, 3)) {
+        el.fillcolor = value.value.map(function(i) {
+            return i.value.real;
+        });
+        el.html.style.backgroundColor =
+            Render2D.makeColor(el.fillcolor, el.fillalpha);
+    }
+};
 
 function noop() {}
 


### PR DESCRIPTION
This fixes #510.

I've decided to move the type-specific accessors to GeoOps, so that we don't clutter Accessors with a lot of type-specific functionality. Let me know whether you consider this a good move.