### PR TITLE
Correctly obtain used fonts from KaTeX box

### DIFF
--- a/plugins/katex/src/js/katex-plugin.js
+++ b/plugins/katex/src/js/katex-plugin.js
@@ -188,8 +188,9 @@
                     }
                 } else {
                     try {
-                        row.push(katex.canvasBox(parts[i], ctx, opts));
-                        for (var font in parts[i].fontsUsed) {
+                        box = katex.canvasBox(parts[i], ctx, opts);
+                        row.push(box);
+                        for (var font in box.fontsUsed) {
                             var fontState = fonts[font];
                             if (fontState !== true) {
                                 fontsMissing = true;


### PR DESCRIPTION
This fixes a bug introduced by 8be4849eb678d3a8e8db6ce2b7bb78cee7ddb29a where we no longer detect which fonts are actually being used by a given formula, thus leading to incorrect rendering while the fonts load, and even incorrect rendering afterwards as results based on wrong metrics get cached.