### PR TITLE
Point on Arc

### DIFF
--- a/examples/146_pointOnArc.html
+++ b/examples/146_pointOnArc.html
@@ -22,7 +22,7 @@
     <link rel="stylesheet" href="http://cindyjs.org/dist/v0.7/CindyJS.css">
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
     <script type="text/javascript">
-createCindy({
+CindyJS({
   scripts: "cs*",
   defaultAppearance: {
     dimDependent: 0.7,

--- a/examples/146_pointOnArc.html
+++ b/examples/146_pointOnArc.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Konstruktion.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <link rel="stylesheet" href="http://cindyjs.org/dist/v0.7/CindyJS.css">
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+    <script type="text/javascript">
+createCindy({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  geometry: [
+    {name: "A", type: "Free", pos: [4.0, -0.0, -1.3333333333333333], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "B", type: "Free", pos: [0.0, -4.0, -1.3333333333333333], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "C", type: "Free", pos: [4.0, -0.0, 1.0], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "C0", type: "ArcBy3", color: [0.0, 0.0, 1.0], args: ["A", "B", "C"], printname: "$C_{0}$"},
+    {name: "D", type: "PointOnArc", pos: [4.0, {r: 3.5919057321475005, i: -3.897695342403635E-15}, {r: 1.5350177749681453, i: -1.0630078206555368E-15}], color: [1.0, 0.0, 0.0], args: ["C0"], labeled: true}
+  ],
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 335,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -4.06]}],
+    axes: true,
+    grid: 1.0,
+    snap: true,
+    background: "rgb(168,176,192)"
+  }],
+  cinderella: {build: 1872, version: [2, 9, 1872]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -743,6 +743,9 @@ geoOps._helper.projectPointToArc = function(arc, P) {
 geoOps.PointOnArc = {};
 geoOps.PointOnArc.kind = "P";
 geoOps.PointOnArc.signature = ["C"];
+geoOps.PointOnArc.signatureConstraints = function(el) {
+    return csgeo.csnames[el.args[0]].isArc; 
+}; 
 geoOps.PointOnArc.isMovable = true;
 geoOps.PointOnArc.initialize = function(el) {
     var arc = csgeo.csnames[el.args[0]];
@@ -2303,6 +2306,9 @@ geoOps.TrMoebiusC.updatePosition = function(el) {
 geoOps.TrMoebiusArc = {};
 geoOps.TrMoebiusArc.kind = "C";
 geoOps.TrMoebiusArc.signature = ["Mt", "C"];
+geoOps.TrMoebiusArc.signatureConstraints = function(el) {
+    return csgeo.csnames[el.args[0]].isArc; 
+}; 
 geoOps.TrMoebiusArc.updatePosition = function(el) {
     var t = csgeo.csnames[(el.args[0])];
     var Arc = csgeo.csnames[(el.args[1])];
@@ -2561,6 +2567,9 @@ geoOps.TransformC.updatePosition = function(el) {
 geoOps.TransformArc = {};
 geoOps.TransformArc.kind = "C";
 geoOps.TransformArc.signature = ["Tr", "C"];
+geoOps.TransformArc.signatureConstraints = function(el) {
+    return csgeo.csnames[el.args[0]].isArc; 
+}; 
 geoOps.TransformArc.updatePosition = function(el) {
     var t = csgeo.csnames[(el.args[0])].matrix;
     var Arc = csgeo.csnames[(el.args[1])];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -482,7 +482,7 @@ geoOps.PointOnCircle.isMovable = true;
 geoOps.PointOnCircle.initialize = function(el) {
     var circle = csgeo.csnames[el.args[0]];
     var pos = List.normalizeZ(geoOps._helper.initializePoint(el));
-    var mid = List.normalizeZ(geoOps._helper.CenterOfConic(circle.matrix));
+    var mid = List.normalizeZ(geoOps._helper.CenterOfCircle(circle.matrix));
     var dir = List.sub(pos, mid);
     var param = List.turnIntoCSList([
         dir.value[1],
@@ -515,7 +515,7 @@ geoOps.PointOnCircle.getParamFromState = function(el) {
 };
 geoOps.PointOnCircle.getParamForInput = function(el, pos, type) {
     var circle = csgeo.csnames[el.args[0]];
-    var mid = List.normalizeZ(geoOps._helper.CenterOfConic(circle.matrix));
+    var mid = List.normalizeZ(geoOps._helper.CenterOfCircle(circle.matrix));
     var dir = List.sub(pos, mid);
     stateInIdx = el.stateIdx;
     var oldparam = getStateComplexVector(3);
@@ -691,7 +691,7 @@ geoOps._helper.PointOnArcCr = function(arc, P) {
 
 geoOps._helper.projectPointToCircle = function(cir, P) {
 
-    var cen = geoOps._helper.CenterOfConic(cir.matrix);
+    var cen = geoOps._helper.CenterOfCircle(cir.matrix);
     cen = List.normalizeMax(cen);
     var l = List.normalizeMax(List.cross(P, cen));
 
@@ -811,6 +811,16 @@ geoOps.PointOnArc.updatePosition = function(el) {
 };
 geoOps.PointOnArc.stateSize = 4;
 
+
+geoOps._helper.CenterOfCircle = function(c) {
+    // Treating this special case of CenterOfConic avoids some computation
+    // and also allows dealing with the degenerate case of center at infinity
+    return List.turnIntoCSList([
+        c.value[2].value[0],
+        c.value[2].value[1],
+        CSNumber.neg(c.value[0].value[0])
+    ]);
+};
 
 geoOps._helper.CenterOfConic = function(c) {
     // The center is the pole of the dual conic of the line at infinity

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -607,9 +607,8 @@ geoOps._helper.projectPointToSegmentCR = function(seg, pos, infseg) {
     var cr = List.crossratio3(
         farpoint, seg.startpos, seg.endpos, pos, tt);
 
-    //handle case if we have infinite segment
+    //handle case if segment passes through infinity
     if (infseg) {
-        // 0 <  cr(FP, A, C, D) < 1 -> not in infinite segment 
         // probably needs tracing 
         if ((cr.value.real > 0) && (cr.value.real <= 0.5))
             cr = CSNumber.complex(0, cr.value.imag);
@@ -737,11 +736,10 @@ geoOps._helper.projectPointToArc = function(arc, P) {
             "homog": List.cross(A, C)
         };
 
-        // infinite segment?
+        // segment passing through infinity?
         var far = List.sub(AA, CC);
         var tmpcr = List.crossratio3(A, C, B, far, List.ii).value.real;
 
-        // cr(a,c,b,fp) is > 0 if B lies between A and C
         var infseg = tmpcr > 0;
 
         var cr = geoOps._helper.projectPointToSegmentCR(seg, P, infseg);
@@ -760,7 +758,6 @@ geoOps.PointOnArc.isMovable = true;
 geoOps.PointOnArc.initialize = function(el) {
     var arc = csgeo.csnames[el.args[0]];
     var p = geoOps._helper.initializePoint(el);
-    //p = geoOps._helper.projectPointToCircle(arc, p);
     p = geoOps._helper.projectPointToArc(arc, p);
 
     var cr = geoOps._helper.PointOnArcCr(arc, p);

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2307,7 +2307,7 @@ geoOps.TrMoebiusArc = {};
 geoOps.TrMoebiusArc.kind = "C";
 geoOps.TrMoebiusArc.signature = ["Mt", "C"];
 geoOps.TrMoebiusArc.signatureConstraints = function(el) {
-    return csgeo.csnames[el.args[0]].isArc;
+    return csgeo.csnames[el.args[1]].isArc;
 };
 geoOps.TrMoebiusArc.updatePosition = function(el) {
     var t = csgeo.csnames[(el.args[0])];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -664,30 +664,19 @@ geoOps.PointOnSegment.updatePosition = function(el) {
 geoOps.PointOnSegment.stateSize = 2;
 
 geoOps._helper.PointOnArcCr = function(arc, P) {
-    var A = arc.startPoint,
-        B = arc.viaPoint,
-        C = arc.endPoint;
+    var A = arc.startPoint;
+    var B = arc.viaPoint;
+    var C = arc.endPoint;
     var cr = List.crossratio3harm(P, A, B, C, List.ii);
 
+    cr = List.normalizeMax(cr);
     var m = cr.value[0];
     var n = cr.value[1];
 
-    if (!CSNumber._helper.isAlmostZero(m)) {
-        n = CSNumber.div(n, m);
-        m = CSNumber.real(1);
-    } else {
-        m = CSNumber.div(m, n);
-        n = CSNumber.real(1);
-    }
+    var tmpcr = n.value.real / m.value.real;
 
-
-    var prod = m.value.real * n.value.real;
-
-    if (prod >= 0 && prod <= 1) {
-        var d1 = List.projectiveDistMinScal(P, A);
-        var d2 = List.projectiveDistMinScal(P, C);
-
-        if (d1 < d2) {
+    if (tmpcr >= 0 && tmpcr <= 1) {
+        if (tmpcr > 0.5) {
             m = CSNumber.real(1);
             n = CSNumber.real(1);
         } else {

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -744,8 +744,8 @@ geoOps.PointOnArc = {};
 geoOps.PointOnArc.kind = "P";
 geoOps.PointOnArc.signature = ["C"];
 geoOps.PointOnArc.signatureConstraints = function(el) {
-    return csgeo.csnames[el.args[0]].isArc; 
-}; 
+    return csgeo.csnames[el.args[0]].isArc;
+};
 geoOps.PointOnArc.isMovable = true;
 geoOps.PointOnArc.initialize = function(el) {
     var arc = csgeo.csnames[el.args[0]];
@@ -2307,8 +2307,8 @@ geoOps.TrMoebiusArc = {};
 geoOps.TrMoebiusArc.kind = "C";
 geoOps.TrMoebiusArc.signature = ["Mt", "C"];
 geoOps.TrMoebiusArc.signatureConstraints = function(el) {
-    return csgeo.csnames[el.args[0]].isArc; 
-}; 
+    return csgeo.csnames[el.args[0]].isArc;
+};
 geoOps.TrMoebiusArc.updatePosition = function(el) {
     var t = csgeo.csnames[(el.args[0])];
     var Arc = csgeo.csnames[(el.args[1])];
@@ -2568,8 +2568,8 @@ geoOps.TransformArc = {};
 geoOps.TransformArc.kind = "C";
 geoOps.TransformArc.signature = ["Tr", "C"];
 geoOps.TransformArc.signatureConstraints = function(el) {
-    return csgeo.csnames[el.args[0]].isArc; 
-}; 
+    return csgeo.csnames[el.args[0]].isArc;
+};
 geoOps.TransformArc.updatePosition = function(el) {
     var t = csgeo.csnames[(el.args[0])].matrix;
     var Arc = csgeo.csnames[(el.args[1])];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -598,6 +598,43 @@ geoOps.OtherPointOnCircle.updatePosition = function(el) {
     el.homog = General.withUsage(pos, "Point");
 };
 
+
+// start and end assumed to be normalized at once!
+geoOps._helper.projectPointToSegmentCR = function(seg, pos, infseg) {
+    var line = seg.homog;
+    var tt = List.turnIntoCSList([line.value[0], line.value[1], CSNumber.zero]);
+    var farpoint = List.sub(seg.startpos, seg.endpos);
+    var cr = List.crossratio3(
+        farpoint, seg.startpos, seg.endpos, pos, tt);
+
+    //handle case if we have infinite segment
+    if (infseg) {
+        // 0 <  cr(FP, A, C, D) < 1 -> not in infinite segment 
+        // probably needs tracing 
+        if ((cr.value.real > 0) && (cr.value.real <= 0.5))
+            cr = CSNumber.complex(0, cr.value.imag);
+        if ((cr.value.real < 1) && (cr.value.real > 0.5))
+            cr = CSNumber.complex(1, cr.value.imag);
+    }
+    // normal case
+    else {
+        if (cr.value.real < 0)
+            cr = CSNumber.complex(0, cr.value.imag);
+        if (cr.value.real > 1)
+            cr = CSNumber.complex(1, cr.value.imag);
+    }
+
+    return cr;
+};
+
+geoOps._helper.projectPointToSegment = function(seg, param) {
+    var start = seg.startpos;
+    var end = seg.endpos;
+    var far = List.sub(end, start);
+    var homog = List.add(start, List.scalmult(param, far));
+    return List.normalizeMax(homog);
+};
+
 geoOps.PointOnSegment = {};
 geoOps.PointOnSegment.kind = "P";
 geoOps.PointOnSegment.signature = ["S"];
@@ -609,16 +646,7 @@ geoOps.PointOnSegment.initialize = function(el) {
 };
 geoOps.PointOnSegment.getParamForInput = function(el, pos) {
     var seg = csgeo.csnames[el.args[0]];
-    var line = seg.homog;
-    var tt = List.turnIntoCSList([line.value[0], line.value[1], CSNumber.zero]);
-    var farpoint = List.sub(seg.startpos, seg.endpos);
-    var cr = List.crossratio3(
-        farpoint, seg.startpos, seg.endpos, pos, tt);
-    if (cr.value.real < 0)
-        cr = CSNumber.complex(0, cr.value.imag);
-    if (cr.value.real > 1)
-        cr = CSNumber.complex(1, cr.value.imag);
-    return cr;
+    return geoOps._helper.projectPointToSegmentCR(seg, pos);
 };
 geoOps.PointOnSegment.getParamFromState = function(el) {
     return getStateComplexNumber();
@@ -630,14 +658,169 @@ geoOps.PointOnSegment.updatePosition = function(el) {
     var param = getStateComplexNumber();
     putStateComplexNumber(param); // copy parameter
     var seg = csgeo.csnames[el.args[0]];
-    var start = seg.startpos;
-    var end = seg.endpos;
-    var far = List.sub(end, start);
-    var homog = List.add(start, List.scalmult(param, far));
-    homog = List.normalizeMax(homog);
+
+    var homog = geoOps._helper.projectPointToSegment(seg, param);
     el.homog = General.withUsage(homog, "Point");
 };
 geoOps.PointOnSegment.stateSize = 2;
+
+geoOps._helper.PointOnArcCr = function(arc, P) {
+    var A = arc.startPoint,
+        B = arc.viaPoint,
+        C = arc.endPoint;
+    var cr = List.crossratio3harm(P, A, B, C, List.ii);
+
+    var m = cr.value[0];
+    var n = cr.value[1];
+
+    if (!CSNumber._helper.isAlmostZero(m)) {
+        n = CSNumber.div(n, m);
+        m = CSNumber.real(1);
+    } else {
+        m = CSNumber.div(m, n);
+        n = CSNumber.real(1);
+    }
+
+
+    var prod = m.value.real * n.value.real;
+
+    if (prod >= 0 && prod <= 1) {
+        var d1 = List.projectiveDistMinScal(P, A);
+        var d2 = List.projectiveDistMinScal(P, C);
+
+        if (d1 < d2) {
+            m = CSNumber.real(1);
+            n = CSNumber.real(1);
+        } else {
+            m = CSNumber.real(1);
+            n = CSNumber.real(0);
+        }
+
+    }
+
+    return List.turnIntoCSList([m, n]);
+};
+
+geoOps._helper.projectPointToCircle = function(cir, P) {
+
+    var cen = geoOps._helper.CenterOfConic(cir.matrix);
+    cen = List.normalizeMax(cen);
+    var l = List.normalizeMax(List.cross(P, cen));
+
+    var isec = geoOps._helper.IntersectLC(l, cir.matrix);
+
+    var d1 = List.projectiveDistMinScal(P, isec[0]);
+    var d2 = List.projectiveDistMinScal(P, isec[1]);
+
+    var erg = d1 < d2 ? isec[0] : isec[1];
+
+    return erg;
+};
+
+geoOps._helper.projectPointToArc = function(arc, P) {
+    var A = arc.startPoint;
+    var C = arc.endPoint;
+    var B = arc.viaPoint;
+
+    var det = List.det(List.turnIntoCSList([A, B, C]));
+
+    if (CSNumber._helper.isAlmostZero(det)) {
+        // arc is segment
+        var AA = List.scalmult(C.value[2], A);
+        var CC = List.scalmult(A.value[2], C);
+        var startend = List.turnIntoCSList([AA, CC]);
+        startend = List.normalizeMax(startend); // Normalize together!
+
+        var seg = {
+            "startpos": startend.value[0],
+            "endpos": startend.value[1],
+            "homog": List.cross(A, C)
+        };
+
+        // infinite segment?
+        var far = List.sub(AA, CC);
+        var tmpcr = List.crossratio3(A, C, B, far, List.ii).value.real;
+
+        // cr(a,c,b,fp) is > 0 if B lies between A and C
+        var infseg = tmpcr > 0;
+
+        var cr = geoOps._helper.projectPointToSegmentCR(seg, P, infseg);
+        return geoOps._helper.projectPointToSegment(seg, cr);
+
+    } else {
+        return geoOps._helper.projectPointToCircle(arc, P);
+    }
+};
+
+
+geoOps.PointOnArc = {};
+geoOps.PointOnArc.kind = "P";
+geoOps.PointOnArc.signature = ["C"];
+geoOps.PointOnArc.isMovable = true;
+geoOps.PointOnArc.initialize = function(el) {
+    var arc = csgeo.csnames[el.args[0]];
+    var p = geoOps._helper.initializePoint(el);
+    //p = geoOps._helper.projectPointToCircle(arc, p);
+    p = geoOps._helper.projectPointToArc(arc, p);
+
+    var cr = geoOps._helper.PointOnArcCr(arc, p);
+    putStateComplexVector(cr);
+};
+geoOps.PointOnArc.getParamForInput = function(el, pos) {
+    var arc = csgeo.csnames[el.args[0]];
+    var npos = geoOps._helper.projectPointToArc(arc, pos);
+    var cr = geoOps._helper.PointOnArcCr(arc, npos);
+
+    return cr;
+};
+geoOps.PointOnArc.getParamFromState = function(el) {
+    return getStateComplexVector(2);
+};
+geoOps.PointOnArc.putParamToState = function(el, param) {
+    putStateComplexVector(param);
+};
+geoOps.PointOnArc.updatePosition = function(el) {
+    var arc = csgeo.csnames[el.args[0]];
+    var A = arc.startPoint;
+    var C = arc.endPoint;
+    var B = arc.viaPoint;
+    var II = List.ii;
+
+    var conic = arc.matrix;
+
+    var cr = getStateComplexVector(2);
+    putStateComplexVector(cr);
+    var cr1 = cr.value[0];
+    var cr2 = cr.value[1];
+
+
+    var erg;
+
+    // l = ([A,C,I]*B-cr*[A,B,I]*C) x I
+    var aciB = List.det(List.turnIntoCSList([A, C, II]));
+    aciB = CSNumber.mult(cr2, aciB);
+    aciB = List.scalmult(aciB, B);
+
+    var dabiC = List.det(List.turnIntoCSList([A, B, II]));
+    dabiC = CSNumber.mult(cr1, dabiC);
+    dabiC = List.scalmult(dabiC, C);
+
+    var ll = List.sub(aciB, dabiC);
+    ll = List.normalizeMax(ll);
+    ll = List.cross(ll, List.ii);
+    ll = List.normalizeMax(ll);
+
+
+    erg = geoOps._helper.IntersectLC(ll, arc.matrix);
+    var d1 = List.projectiveDistMinScal(erg[0], II);
+    var d2 = List.projectiveDistMinScal(erg[1], II);
+
+    erg = d1 < d2 ? erg[1] : erg[0];
+    erg = List.normalizeMax(erg);
+
+    el.homog = General.withUsage(erg, "Point");
+};
+geoOps.PointOnArc.stateSize = 4;
 
 
 geoOps._helper.CenterOfConic = function(c) {

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -598,42 +598,6 @@ geoOps.OtherPointOnCircle.updatePosition = function(el) {
     el.homog = General.withUsage(pos, "Point");
 };
 
-
-// start and end assumed to be normalized at once!
-geoOps._helper.projectPointToSegmentCR = function(seg, pos, infseg) {
-    var line = seg.homog;
-    var tt = List.turnIntoCSList([line.value[0], line.value[1], CSNumber.zero]);
-    var farpoint = List.sub(seg.startpos, seg.endpos);
-    var cr = List.crossratio3(
-        farpoint, seg.startpos, seg.endpos, pos, tt);
-
-    //handle case if segment passes through infinity
-    if (infseg) {
-        // probably needs tracing 
-        if ((cr.value.real > 0) && (cr.value.real <= 0.5))
-            cr = CSNumber.complex(0, cr.value.imag);
-        if ((cr.value.real < 1) && (cr.value.real > 0.5))
-            cr = CSNumber.complex(1, cr.value.imag);
-    }
-    // normal case
-    else {
-        if (cr.value.real < 0)
-            cr = CSNumber.complex(0, cr.value.imag);
-        if (cr.value.real > 1)
-            cr = CSNumber.complex(1, cr.value.imag);
-    }
-
-    return cr;
-};
-
-geoOps._helper.projectPointToSegment = function(seg, param) {
-    var start = seg.startpos;
-    var end = seg.endpos;
-    var far = List.sub(end, start);
-    var homog = List.add(start, List.scalmult(param, far));
-    return List.normalizeMax(homog);
-};
-
 geoOps.PointOnSegment = {};
 geoOps.PointOnSegment.kind = "P";
 geoOps.PointOnSegment.signature = ["S"];
@@ -645,7 +609,16 @@ geoOps.PointOnSegment.initialize = function(el) {
 };
 geoOps.PointOnSegment.getParamForInput = function(el, pos) {
     var seg = csgeo.csnames[el.args[0]];
-    return geoOps._helper.projectPointToSegmentCR(seg, pos);
+    var line = seg.homog;
+    var tt = List.turnIntoCSList([line.value[0], line.value[1], CSNumber.zero]);
+    var farpoint = List.sub(seg.startpos, seg.endpos);
+    var cr = List.crossratio3(
+        farpoint, seg.startpos, seg.endpos, pos, tt);
+    if (cr.value.real < 0)
+        cr = CSNumber.complex(0, cr.value.imag);
+    if (cr.value.real > 1)
+        cr = CSNumber.complex(1, cr.value.imag);
+    return cr;
 };
 geoOps.PointOnSegment.getParamFromState = function(el) {
     return getStateComplexNumber();
@@ -657,88 +630,25 @@ geoOps.PointOnSegment.updatePosition = function(el) {
     var param = getStateComplexNumber();
     putStateComplexNumber(param); // copy parameter
     var seg = csgeo.csnames[el.args[0]];
-
-    var homog = geoOps._helper.projectPointToSegment(seg, param);
+    var start = seg.startpos;
+    var end = seg.endpos;
+    var far = List.sub(end, start);
+    var homog = List.add(start, List.scalmult(param, far));
+    homog = List.normalizeMax(homog);
     el.homog = General.withUsage(homog, "Point");
 };
 geoOps.PointOnSegment.stateSize = 2;
 
-geoOps._helper.PointOnArcCr = function(arc, P) {
-    var A = arc.startPoint;
-    var B = arc.viaPoint;
-    var C = arc.endPoint;
-    var cr = List.crossratio3harm(P, A, B, C, List.ii);
-
-    cr = List.normalizeMax(cr);
-    var m = cr.value[0];
-    var n = cr.value[1];
-
-    var tmpcr = n.value.real / m.value.real;
-
-    if (tmpcr >= 0 && tmpcr <= 1) {
-        if (tmpcr > 0.5) {
-            m = CSNumber.real(1);
-            n = CSNumber.real(1);
-        } else {
-            m = CSNumber.real(1);
-            n = CSNumber.real(0);
-        }
-
-    }
-
-    return List.turnIntoCSList([m, n]);
-};
-
 geoOps._helper.projectPointToCircle = function(cir, P) {
-
     var cen = geoOps._helper.CenterOfCircle(cir.matrix);
     cen = List.normalizeMax(cen);
     var l = List.normalizeMax(List.cross(P, cen));
-
     var isec = geoOps._helper.IntersectLC(l, cir.matrix);
-
     var d1 = List.projectiveDistMinScal(P, isec[0]);
     var d2 = List.projectiveDistMinScal(P, isec[1]);
-
     var erg = d1 < d2 ? isec[0] : isec[1];
-
     return erg;
 };
-
-geoOps._helper.projectPointToArc = function(arc, P) {
-    var A = arc.startPoint;
-    var C = arc.endPoint;
-    var B = arc.viaPoint;
-
-    var det = List.det(List.turnIntoCSList([A, B, C]));
-
-    if (CSNumber._helper.isAlmostZero(det)) {
-        // arc is segment
-        var AA = List.scalmult(C.value[2], A);
-        var CC = List.scalmult(A.value[2], C);
-        var startend = List.turnIntoCSList([AA, CC]);
-        startend = List.normalizeMax(startend); // Normalize together!
-
-        var seg = {
-            "startpos": startend.value[0],
-            "endpos": startend.value[1],
-            "homog": List.cross(A, C)
-        };
-
-        // segment passing through infinity?
-        var far = List.sub(AA, CC);
-        var tmpcr = List.crossratio3(A, C, B, far, List.ii).value.real;
-
-        var infseg = tmpcr > 0;
-
-        var cr = geoOps._helper.projectPointToSegmentCR(seg, P, infseg);
-        return geoOps._helper.projectPointToSegment(seg, cr);
-
-    } else {
-        return geoOps._helper.projectPointToCircle(arc, P);
-    }
-};
-
 
 geoOps.PointOnArc = {};
 geoOps.PointOnArc.kind = "P";
@@ -748,19 +658,27 @@ geoOps.PointOnArc.signatureConstraints = function(el) {
 };
 geoOps.PointOnArc.isMovable = true;
 geoOps.PointOnArc.initialize = function(el) {
-    var arc = csgeo.csnames[el.args[0]];
-    var p = geoOps._helper.initializePoint(el);
-    p = geoOps._helper.projectPointToArc(arc, p);
-
-    var cr = geoOps._helper.PointOnArcCr(arc, p);
+    var pos = geoOps._helper.initializePoint(el);
+    var cr = geoOps.PointOnArc.getParamForInput(el, pos);
     putStateComplexVector(cr);
 };
 geoOps.PointOnArc.getParamForInput = function(el, pos) {
     var arc = csgeo.csnames[el.args[0]];
-    var npos = geoOps._helper.projectPointToArc(arc, pos);
-    var cr = geoOps._helper.PointOnArcCr(arc, npos);
-
-    return cr;
+    var P = geoOps._helper.projectPointToCircle(arc, pos);
+    var A = arc.startPoint;
+    var B = arc.viaPoint;
+    var C = arc.endPoint;
+    var crh = List.normalizeMax(List.crossratio3harm(A, C, B, P, List.ii));
+    // Now restrict cross ratio to the range [0,∞]
+    var cr = CSNumber.div(crh.value[0], crh.value[1]);
+    if (cr.value.real < 0) {
+        if (cr.value.real < -1) {
+            crh = List.realVector([1, 0]); // ∞, use end point
+        } else {
+            crh = List.realVector([0, 1]); // 0, use start point
+        }
+    }
+    return crh;
 };
 geoOps.PointOnArc.getParamFromState = function(el) {
     return getStateComplexVector(2);
@@ -771,46 +689,33 @@ geoOps.PointOnArc.putParamToState = function(el, param) {
 geoOps.PointOnArc.updatePosition = function(el) {
     var arc = csgeo.csnames[el.args[0]];
     var A = arc.startPoint;
-    var C = arc.endPoint;
     var B = arc.viaPoint;
-    var II = List.ii;
-
-    var conic = arc.matrix;
-
-    var cr = getStateComplexVector(2);
-    putStateComplexVector(cr);
-    var cr1 = cr.value[0];
-    var cr2 = cr.value[1];
-
-
-    var erg;
-
-    // l = ([A,C,I]*B-cr*[A,B,I]*C) x I
-    var aciB = List.det(List.turnIntoCSList([A, C, II]));
-    aciB = CSNumber.mult(cr2, aciB);
-    aciB = List.scalmult(aciB, B);
-
-    var dabiC = List.det(List.turnIntoCSList([A, B, II]));
-    dabiC = CSNumber.mult(cr1, dabiC);
-    dabiC = List.scalmult(dabiC, C);
-
-    var ll = List.sub(aciB, dabiC);
-    ll = List.normalizeMax(ll);
-    ll = List.cross(ll, List.ii);
-    ll = List.normalizeMax(ll);
-
-
-    erg = geoOps._helper.IntersectLC(ll, arc.matrix);
-    var d1 = List.projectiveDistMinScal(erg[0], II);
-    var d2 = List.projectiveDistMinScal(erg[1], II);
-
-    erg = d1 < d2 ? erg[1] : erg[0];
-    erg = List.normalizeMax(erg);
-
-    el.homog = General.withUsage(erg, "Point");
+    var C = arc.endPoint;
+    var I = List.ii;
+    var AI = List.cross(A, I);
+    var BI = List.cross(B, I);
+    var CI = List.cross(C, I);
+    // Now we want to scale AI and CI such that λ⋅BI = AI + CI.
+    // a*AI + c*CI = BI => [AI, CI]*(a,c) = BI but [AI, CI] is not square so
+    // we solve this least-squares-style (see Moore-Penrose pseudoinverse),
+    // multiplying both sides by M2x3c and then using the adjoint to solve.
+    var M2x3 = List.turnIntoCSList([AI, CI]);
+    var M3x2 = List.transpose(M2x3);
+    var M2x3c = List.conjugate(M2x3);
+    var M2x2 = List.productMM(M2x3c, M3x2);
+    var v2x1 = List.productMV(M2x3c, BI);
+    var ab = List.productMV(List.adjoint2(M2x2), v2x1);
+    var a = ab.value[0];
+    var c = ab.value[1];
+    var crh = getStateComplexVector(2);
+    putStateComplexVector(crh);
+    var Q = List.normalizeMax(List.add(
+        List.scalmult(CSNumber.mult(a, crh.value[0]), A),
+        List.scalmult(CSNumber.mult(c, crh.value[1]), C)));
+    var P = geoOps._helper.conicOtherIntersection(arc.matrix, I, Q);
+    el.homog = General.withUsage(P, "Point");
 };
 geoOps.PointOnArc.stateSize = 4;
-
 
 geoOps._helper.CenterOfCircle = function(c) {
     // Treating this special case of CenterOfConic avoids some computation


### PR DESCRIPTION
This is intended to supersede #469. Since I reverted quite a number of the changes there, and since I'm still not sure I understood why @strobelm handled segments through infinity the way he did, I'm proposing this as a separate pull request even though it builds on the commits from there (might be squashed, though, if you prefer).

My main motivation was to avoid case distinctions as far as possible:
1. No case distinction to distinguish between arc with finite center and arc which degenerates into a straight segment
2. No case distinction to distinguish segments which pass through infinity from those which don't
3. No circle-line intersection with a case distinction to choose the right solution

Avoiding all of these should help make tracing more stable. There are of course still case distinctions for restricting the point to the extent of the arc. Contrary to the PointOnSegment case, I don't preserve the imaginary part here. There is also a circle-line-intersection followed by a case distinction when projecting the point to the circle. But both of these operations only occur when moving the point along the arc, not when the arc moves from under the point. So it's only affected by free movement, not by dependent movement, and therefore should not impact complex tracing.

@strobelm, please have a look at this, perhaps compare it with what you have, and let me know whether you think I'm simplifying too much. In particular, whether there is some situation related to straight line segments through infinity, which my code doesn't handle correctly.

@kortenkamp, can you please have a look at my use of conjugation here? I would assume this to be all right, but I would feel better if you could confirm that.

In the long run we might want to look into sharing code between the `projectPointToCircle` helper and `PointOnCircle` methods, but I got bogged down when I tried this so I'd like to see the current state merged before investigating that aspect.
