### PR TITLE
add local bindings for variables in CindyGL

### DIFF
--- a/examples/cindygl/40_waveintersection.html
+++ b/examples/cindygl/40_waveintersection.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Interference</h1>
+    
+    
+    <script id="csdraw" type="text/x-cindyscript">
+      A.x=55;
+      B.x=65;
+      C.x=75;
+      if(A.y<-40,A.y=-40);
+      if(A.y>40,A.y=40);
+      if(B.y<-40,B.y=-40);
+      if(B.y>40,B.y=40);
+      if(C.y<-40,C.y=-40);
+      if(C.y>40,C.y=40);
+      zoom=(C.y+40)/40+.1;
+      t = seconds()-t0;
+      n=round((A.y+40)/80*8+1);
+      amp=(B.y+40)/80*3;
+      k=if(mod(n,2)==0,1,2);
+
+      waves(z) := (
+         ans=0;
+         repeat(n,l,
+           ans=ans+sin(t+re(z*exp(l*k*pi*i/n)));
+         );
+         (ans*amp)/2+.5;
+      );
+      
+      colorplot(col(waves(complex(#*zoom))));
+      fillpoly([[50,-50],[80,-50],[80,50],[50,50]],color->(0,0,0),alpha->.5); 
+      draw((55,-40),(55,40),color->(1,1,1),size->2);
+      draw((65,-40),(65,40),color->(1,1,1),size->2);
+      draw((75,-40),(75,40),color->(1,1,1),size->2);
+      drawtext((54,45),n,color->(1,1,1));
+    </script>
+               
+    <script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+      t0 = seconds();
+      col(x):=(sin(x)*.5+.5,sin(x),sin(x)^3*.3);
+      //col(x):=hue(x);
+    </script>
+    
+
+    <div  id="CSCanvas"></div>
+    
+    <script type="text/javascript">
+        
+        var gslp=[
+                  {name:"A", kind:"P", type:"Free", pos:[-20,-1,1],color:[1,1,1]},
+                  {name:"B", kind:"P", type:"Free", pos:[20,5,1],color:[1,1,1]},
+                  {name:"C", kind:"P", type:"Free", pos:[20,5,1],color:[1,1,1]},
+                  ];
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:gslp,
+                    animation: {autoplay: true},
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 780,
+                      height: 600,
+                      transform: [ { visibleRect: [-50,-50, 80, 50] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -3,9 +3,8 @@
  */
 function CodeBuilder(api) {
     this.variables = {};
-    this.assigments = {};
-    this.T = {};
     this.uniforms = {};
+    this.scopes = {};
 
     this.sections = {};
 
@@ -69,20 +68,8 @@ CodeBuilder.prototype.myfunctions;
 /** @dict @type {boolean} */
 CodeBuilder.prototype.precompileDone;
 
-/** list of names of variables
- *@dict @type {Object} */
+/** @dict @type {Object} */
 CodeBuilder.prototype.variables;
-
-/**
- * variables -> list of assigments in the form of {expr: expression, fun: in which functions this expression will be eval}
- * @dict @type {Object} */
-CodeBuilder.prototype.assigments;
-
-
-/**
- * T: scope -> (variables -> types)
- * @dict @type {Object} */
-CodeBuilder.prototype.T;
 
 /** @dict @type {Object} */
 CodeBuilder.prototype.uniforms;
@@ -119,36 +106,30 @@ CodeBuilder.prototype.castType = function(term, fromType, toType) {
     }
 };
 
+/**
+ * Initializes the entry in this.variables for the variable with given name if it is not initialized yet.
+ */
+CodeBuilder.prototype.initvariable = function(vname, declareglobal) {
+    if (!this.variables[vname]) this.variables[vname] = {};
+    if (!this.variables[vname].assigments) this.variables[vname].assigments = [];
+    if (!this.variables[vname].T) this.variables[vname].T = false;
+    if (!this.hasOwnProperty('global')) this.variables[vname]['global'] = declareglobal;
+};
 
 /**
- * computes the type of the expr, assuming it is evaluated in the scope of fun.
- * It might consider the type of variables (T)
+ * computes the type of the expr, assuming it is evaluated with the given variable-bindings
+ * It might consider the type of variables (variables[name].T)
  */
-//@TODO: Consider stack of this.variables. e.g. repeat(3, i, e = 32+i);
-CodeBuilder.prototype.computeType = function(expr, fun) { //expression, current function
+CodeBuilder.prototype.computeType = function(expr) { //expression, current function
+    let bindings = expr.bindings;
     if (expr['isuniform']) {
         return this.uniforms[expr['uvariable']].type;
-    }
-
-    if (expr['ctype'] === 'variable') {
+    } else if (expr['ctype'] === 'variable') {
         let name = expr['name'];
-
-        //@rethink: use stack instead of scopes? # # #...
-        if (name === '#') {
-            /*if(modifs[generatecomplexresult]) { //better as uniform type handling
-              return type.complex;
-            }*/
-            return type.vec2; //type.complex if complex->true
-
-        }
-
-        if (this.T.hasOwnProperty(fun) && this.T[fun].hasOwnProperty(name)) { //is there some local variable
-            return this.T[fun][name];
-        } else if (this.T.hasOwnProperty('') && this.T[''].hasOwnProperty(name)) { //interpret as global variable
-            return this.T[''][name];
-        }
+        name = bindings[name] || name;
+        return this.variables[name].T;
     } else if (expr['ctype'] === 'function' && this.myfunctions.hasOwnProperty(expr['oper'])) {
-        if (this.T.hasOwnProperty('') && this.T[''].hasOwnProperty(expr['oper'])) return this.T[''][expr['oper']];
+        return this.variables[bindings[expr['oper']]].T;
     } else if (expr['ctype'] === 'number') {
         return constant(expr);
     } else if (expr['ctype'] === 'void') {
@@ -157,124 +138,103 @@ CodeBuilder.prototype.computeType = function(expr, fun) { //expression, current 
         return type.float; //so far we only have field indexes vor vec2, vec3, vec4
     } else if (expr['ctype'] === 'string') {
         return type.image;
-    } else {
+    } else if (expr['ctype'] === 'function' || expr['ctype'] === 'infix') {
         var argtypes = new Array(expr['args'].length);
         for (let i = 0; i < expr['args'].length; i++) {
-            argtypes[i] = this.getType(expr['args'][i], fun);
+            argtypes[i] = this.getType(expr['args'][i]);
         }
-        //console.log(f);
-        //console.log(argtypes);
         let f = getPlainName(expr['oper']);
-        //let signature = matchSignature(f, argtypes);
-        //console.log(signature);
-        //if (signature === undefined || !signature) return false;
-        //return signature.res;
         let implementation = webgl[f] ? webgl[f](argtypes) : false;
         if (!implementation && argtypes.every(a => a)) //no implementation found and all args are set
             console.error(`Could not find an implementation for ${f} with args (${argtypes.map(typeToString).join(', ')})`);
         return implementation ? implementation.res : false;
     }
+    console.error("Don't know how to compute type of");
+    console.log(expr);
     return false;
 };
 
 /**
  * gets the type of the expr, trying to use cached results. Otherwise it will call computeType
  */
-//@TODO: Consider stack of this.variables. e.g. repeat(3, i, e = 32+i);
-CodeBuilder.prototype.getType = function(expr, fun) { //expression, current function
-    //return computeType(expr, fun);
-    /////TODO: update expr["computedType"] in determineVariables
+CodeBuilder.prototype.getType = function(expr) { //expression, current function
     if (!this.precompileDone || !expr.hasOwnProperty("computedType"))
-        expr["computedType"] = this.computeType(expr, fun);
+        expr["computedType"] = this.computeType(expr);
     return expr["computedType"];
 };
 
 /**
- * finds the occuring variables, saves them to this.variables and its occuring assigments to this.assigments
+ * finds the occuring variables, saves them to this.variables with their occuring assigmets.
+ * Furthermore attaches an bindings-dictionary to each expression that is tranversed.
  */
-CodeBuilder.prototype.determineVariables = function(expr) {
-
+CodeBuilder.prototype.determineVariables = function(expr, bindings) {
     //for some reason this reference does not work in local function. Hence generate local variables
-    let variables = {}; //functionname -> list of variables occuring in this scope. global corresponds to ''-function
-    let assigments = {};
+    let variables = this.variables; //functionname -> list of variables occuring in this scope. global corresponds to ''-function
     let myfunctions = this.myfunctions;
+    var self = this;
 
-    rec(expr, ''); //global
-    this.variables = variables;
-    this.assigments = assigments;
+    rec(expr, bindings, 'global');
 
-    function rec(expr, fun) { //dfs over executed code
-        if (!variables.hasOwnProperty(fun)) {
-            variables[fun] = []; //list of variables
-        }
-        if (!assigments.hasOwnProperty(fun)) {
-            assigments[fun] = {}; //map variables -> list of expressions
-        }
+    //clones the a bindings-dict and addes one variable of given type to it
+    function addvar(bindings, varname, type) {
+        let ans = {}; //clone bindings
+        for (let i in bindings) ans[i] = bindings[i];
+        let ivar = generateUniqueHelperString();
+        self.initvariable(ivar, false);
+        variables[ivar].T = type;
+        variables[ivar].iterationvariable = true;
+        ans[varname] = ivar;
+        return ans;
+    }
 
-        for (let i in expr['args']) {
-            rec(expr['args'][i], fun);
-        }
+    //dfs over executed code
+    function rec(expr, bindings, scope) {
+        expr.bindings = bindings;
+        bindings = (expr['oper'] === "repeat$2") ? addvar(bindings, '#', type.int) :
+            (expr['oper'] === "repeat$3") ? addvar(bindings, expr['args'][1]['name'], type.int) :
+            bindings;
+
+        for (let i in expr['args']) rec(expr['args'][i], bindings, scope);
+        if (expr['ctype'] === 'field') rec(expr['obj'], bindings, scope);
 
         //was there something happening to the (return)variables?
         if (expr['oper'] === '=') { //assignment to variable
             let vname = expr['args'][0]['name'];
-            var scope = fun;
-            if (variables[fun].indexOf(vname) === -1) { //no regional function found
-                scope = ''; //consider global variable
-                if (variables[scope].indexOf(vname) === -1) {
-                    variables[scope].push(vname);
-                    assigments[scope][vname] = [];
-                }
-            }
-            //the scope of vname is scope
-            assigments[scope][vname].push({
-                expr: expr['args'][1], //variable in expr will interpreted in the scope of fun
-                fun: fun
-            });
-            //rec(expr['args'][1], fun);
+            vname = bindings[vname] || vname;
+
+            self.initvariable(vname, true);
+            variables[vname].assigments.push(expr['args'][1]);
         } else if (expr['oper'] && getPlainName(expr['oper']) === 'regional') {
-            for (let i = 0; i < expr['args'].length; i++) {
-                if (expr['args'][i]['ctype'] === 'variable') {
-                    let vname = expr['args'][i]['name'];
-                    if (variables[fun].indexOf(vname) === -1) {
-                        variables[fun].push(vname);
-                        assigments[fun][vname] = [];
-                    }
-                }
+            for (let i in expr['args']) {
+                let vname = expr['args'][i]['name'];
+                let iname = generateUniqueHelperString();
+                bindings[vname] = iname;
+
+                if (!myfunctions[scope].variables) myfunctions[scope].variables = [];
+                myfunctions[scope].variables.push(iname);
+                self.initvariable(iname, false);
             }
         } else if (expr['ctype'] === 'function' && myfunctions.hasOwnProperty(expr['oper'])) { // call of user defined function
-            let rfun = expr['oper']; //@TODO: Remove $...?
-            if (!variables.hasOwnProperty(rfun)) {
-                variables[rfun] = []; //list of variables
-            }
-            if (!assigments.hasOwnProperty(rfun)) {
-                assigments[rfun] = {}; //map variables -> list of expressions
-            }
+            let rfun = expr['oper'];
+            let pname = rfun.replace('$', '_'); //remove $
+            self.initvariable(pname, false);
+            bindings[rfun] = pname;
 
+            let localbindungs = {};
             for (let i in myfunctions[rfun]['arglist']) {
-                let a = myfunctions[rfun]['arglist'][i]['name'];
-                variables[rfun].push(a);
-                if (!assigments[rfun].hasOwnProperty(a)) assigments[rfun][a] = [];
+                let localname = myfunctions[rfun]['arglist'][i]['name'];
+                let a = pname + '_' + localname;
+                localbindungs[localname] = a;
 
-                assigments[rfun][a].push({
-                    expr: expr['args'][i],
-                    fun: fun //the scope in which the function is called
-                });
+                self.initvariable(a, false);
+                variables[a].assigments.push(expr['args'][i]);
             }
             if (!myfunctions[rfun].visited) {
                 myfunctions[rfun].visited = true;
-                rec(myfunctions[rfun].body, rfun);
-            }
+                rec(myfunctions[rfun]['body'], localbindungs, rfun);
 
-
-            //oh yes, the return variable of the function should be added as well
-            //functions are always global
-            if (variables[''].indexOf(rfun) === -1) {
-                variables[''].push(rfun);
-                assigments[''][rfun] = [{
-                    expr: myfunctions[rfun]['body'],
-                    fun: rfun //the expression above will be evalueted in scope of rfun
-                }];
+                //the return variable of the function should be added as well
+                variables[pname].assigments.push(myfunctions[rfun]['body']); //the expression will be evalueted in scope of rfun
             }
         }
     }
@@ -286,40 +246,32 @@ CodeBuilder.prototype.determineVariables = function(expr) {
 CodeBuilder.prototype.determineTypes = function() {
     let changed = true;
 
-    for (let s in this.assigments) {
-        this.T[s] = {};
-        for (let v in this.assigments[s]) this.T[s][v] = false; //no type yet
+    for (let v in this.variables) {
+        this.variables[v].T = this.variables[v].T || false; //false corresponds no type yet
     }
 
-    while (changed) {
+    while (changed) { //TODO: implement queue to make this faster
         changed = false;
-        //iterate over all scopes, their this.variables(and functions), and their rethis.assigments
-        for (let s in this.assigments)
-            for (let v in this.assigments[s])
-                for (let i in this.assigments[s][v]) {
-                    // variable  v (which lives in scope s) <- expression e in function f
-                    let e = this.assigments[s][v][i].expr;
-                    let f = this.assigments[s][v][i].fun;
-                    let othertype = generalize(this.getType(e, f)); //type of expression e in function f
-
-                    let oldtype = false;
-                    if (this.T.hasOwnProperty(s) && this.T[s].hasOwnProperty(v)) oldtype = this.T[s][v];
-                    let newtype = oldtype;
-                    if (othertype) {
-                        if (!oldtype) newtype = othertype;
-                        else {
-                            if (issubtypeof(othertype, oldtype)) newtype = oldtype; //dont change anything
-                            else newtype = lca(oldtype, othertype);
-                        }
-                        if (newtype && newtype !== oldtype) {
-                            if (!this.T.hasOwnProperty(s)) this.T[s] = {};
-
-                            this.T[s][v] = newtype;
-                            //console.log(`variable ${v} in scope ${s} got type ${typeToString(newtype)} (oltype/othertype is ${typeToString(oldtype)}/${typeToString(othertype)})`);
-                            changed = true;
-                        }
+        for (let v in this.variables) {
+            for (let i in this.variables[v].assigments) {
+                let e = this.variables[v].assigments[i];
+                let othertype = generalize(this.getType(e)); //type of expression e in function f
+                let oldtype = this.variables[v].T || false;
+                let newtype = oldtype;
+                if (othertype) {
+                    if (!oldtype) newtype = othertype;
+                    else {
+                        if (issubtypeof(othertype, oldtype)) newtype = oldtype; //dont change anything
+                        else newtype = lca(oldtype, othertype);
+                    }
+                    if (newtype && newtype !== oldtype) {
+                        this.variables[v].T = newtype;
+                        //console.log(`variable ${v} got type ${typeToString(newtype)} (oltype/othertype is ${typeToString(oldtype)}/${typeToString(othertype)})`);
+                        changed = true;
                     }
                 }
+            }
+        }
     }
 };
 
@@ -330,38 +282,41 @@ CodeBuilder.prototype.determineTypes = function() {
  * for all terms that have no child dependent on # or any variable dependent on #
  */
 CodeBuilder.prototype.determineUniforms = function(expr) {
-    var variableDependendsOnPixel = {
-        '': {
-            '#': true
-        }
-    }; //scope -> dict of this.variables being dependent on #
-
-    //@rethink: include this.variables that change during plot call(like running this.variables in loops) as well.
-    //variableDependendsOnPixel -> varyingVariable
-
-    //@simplefix: assume wlog that every variable that appears on left sign of assigment is dependent on varying this.variables (if might be called or not, depending on #)
-
     let variables = this.variables;
     let myfunctions = this.myfunctions;
 
+    var variableDependendsOnPixel = {
+        'cgl_pixel': true
+    }; //dict of this.variables being dependent on #
 
-    function dependsOnPixel(expr, fun) {
+    //KISS-Fix: every variable appearing on left side of assigment is varying
+    for (let v in variables)
+        if (variables[v].assigments.length >= 1 || variables[v].iterationvariable)
+            variableDependendsOnPixel[v] = true;
+        //run expression to get all expr["dependsOnPixel"]
+    dependsOnPixel(expr);
+
+
+    let visitedFunctions = {
+        '': true
+    };
+
+    let uniforms = this.uniforms;
+    computeUniforms(expr, false);
+
+
+    function dependsOnPixel(expr) {
         //Have we already found out that expr depends on pixel?
-        if (expr.hasOwnProperty("dependsOnPixel") && expr["dependsOnPixel"] === true) {
-            return true;
+        if (expr.hasOwnProperty("dependsOnPixel")) {
+            return expr["dependsOnPixel"];
         }
 
         //Is expr a variable that depends on pixel? (according the current variableDependendsOnPixel)
         if (expr['ctype'] === 'variable') {
             let vname = expr['name'];
-
-            if (variableDependendsOnPixel.hasOwnProperty(fun) && variableDependendsOnPixel[fun][vname]) { //local variable
+            vname = expr.bindings[vname] || vname;
+            if (variableDependendsOnPixel[vname]) {
                 return expr["dependsOnPixel"] = true;
-            }
-            if (variables[fun].indexOf(vname) === -1) { //no regional function found
-                if ((variableDependendsOnPixel.hasOwnProperty('') && variableDependendsOnPixel[''][vname])) { //global variable
-                    return expr["dependsOnPixel"] = true;
-                }
             }
             return expr["dependsOnPixel"] = false;
         }
@@ -374,84 +329,53 @@ CodeBuilder.prototype.determineUniforms = function(expr) {
             return expr["dependsOnPixel"] = true;
         }
 
+        //repeat is pixel dependent iff it's code is pixel dependent. Then it also makes the running variable pixel dependent.
+        if (expr['oper'] === "repeat$2") {
+            if (dependsOnPixel(expr['args'][1])) {
+                variableDependendsOnPixel[expr['args'][1].bindings['#']] = true;
+                return expr["dependsOnPixel"] = true;
+            } else return expr["dependsOnPixel"] = false;
+        } else if (expr['oper'] === "repeat$3") {
+            if (dependsOnPixel(expr['args'][2])) {
+                variableDependendsOnPixel[expr['args'][2].bindings[expr['args'][1]['name']]] = true;
+                expr['args'][1]["dependsOnPixel"] = true;
+                return expr["dependsOnPixel"] = true;
+            } else return expr["dependsOnPixel"] = false;
+        }
+
         //run recursion on all dependent arguments
         for (let i in expr['args']) {
-            if (dependsOnPixel(expr['args'][i], fun)) {
+            if (dependsOnPixel(expr['args'][i])) {
                 return expr["dependsOnPixel"] = true;
             }
         }
 
-
         //Oh yes, it also might be a user-defined function!
         if (expr['ctype'] === 'function' && myfunctions.hasOwnProperty(expr['oper'])) {
             let rfun = expr['oper'];
-            if (!variableDependendsOnPixel.hasOwnProperty(rfun)) {
-                variableDependendsOnPixel[rfun] = {}; //dict of dependent variables
-            }
-            if (dependsOnPixel(myfunctions[rfun].body, rfun)) {
+            if (dependsOnPixel(myfunctions[rfun].body)) {
                 return expr["dependsOnPixel"] = true;
             }
         }
 
         //p.x
         if (expr['ctype'] === 'field') {
-            return expr["dependsOnPixel"] = dependsOnPixel(expr['obj'], fun);
+            return expr["dependsOnPixel"] = dependsOnPixel(expr['obj']);
         }
-        return false;
+        return expr["dependsOnPixel"] = false;
     }
 
-
-    /*
-    //try to expand the set of variablesDependentOnPixel as long as possible
-    var changed = true;
-    while(changed) {
-      changed = false;
-      //iterate over all scopes, their variables(and functions), and their reassigments
-      for(let s in assigments) for(let v in assigments[s]) for(let i in assigments[s][v]) {
-        // variable  v (which lives in scope s) <- expression e in function f
-        let e = assigments[s][v][i].expr;
-        let f = assigments[s][v][i].fun;
-        if(!variableDependendsOnPixel.hasOwnProperty(s)) {
-          variableDependendsOnPixel[s] = {}; //dict of dependent variables
-        }
-        if(!variableDependendsOnPixel[s][v]) {
-          //try weather it actually is dependent
-          if(dependsOnPixel(e, f)) {
-            variableDependendsOnPixel[s][v] = true;
-            changed = true;
-          }
-        }
-      }
-    }
-    */
-    //KISS-Fix: every variable appearing on left side of assigment is varying
-    for (let s in this.assigments)
-        for (let v in this.assigments[s]) { //scope s, variable v
-            if (!variableDependendsOnPixel.hasOwnProperty(s)) {
-                variableDependendsOnPixel[s] = {}; //dict of dependent variables
-            }
-            variableDependendsOnPixel[s][v] = true;
-        }
-
-    //run expression to get all expr["dependsOnPixel"]
-    dependsOnPixel(expr, '');
-
-    let visitedFunctions = {
-        '': true
-    };
-
-    let uniforms = {};
     //now find use those elements in expression trees that have no expr["dependsOnPixel"] and as high as possible having that property
-    function computeUniforms(expr, fun, forceconstant) {
-        if (dependsOnPixel(expr, fun)) {
+    function computeUniforms(expr, forceconstant) {
+        if (dependsOnPixel(expr)) {
             //then run recursively on all childs
             for (let i in expr['args']) {
-                let needtobeconstant = forceconstant || (expr['oper'] === "repeat$2" && i == 0) || (expr['oper'] === "_" && i == 1);
-                computeUniforms(expr['args'][i], fun, needtobeconstant);
+                let needtobeconstant = forceconstant || (expr['oper'] === "repeat$2" && i == 0) || (expr['oper'] === "repeat$3" && i == 0) || (expr['oper'] === "_" && i == 1);
+                computeUniforms(expr['args'][i], needtobeconstant);
             }
 
             if (expr['ctype'] === 'field') {
-                computeUniforms(expr['obj'], fun, forceconstant);
+                computeUniforms(expr['obj'], forceconstant);
             }
 
             //Oh yes, it also might be a user-defined function!
@@ -459,7 +383,7 @@ CodeBuilder.prototype.determineUniforms = function(expr) {
                 let rfun = expr['oper'];
                 if (!visitedFunctions.hasOwnProperty(rfun)) { //only do this once per function
                     visitedFunctions[rfun] = true;
-                    computeUniforms(myfunctions[rfun].body, rfun, forceconstant);
+                    computeUniforms(myfunctions[rfun].body, forceconstant);
                 }
             }
         } else {
@@ -495,8 +419,6 @@ CodeBuilder.prototype.determineUniforms = function(expr) {
             expr["uvariable"] = uname;
         }
     }
-    computeUniforms(expr, '', false);
-    this.uniforms = uniforms;
 };
 
 
@@ -523,11 +445,10 @@ CodeBuilder.prototype.copyRequiredFunctions = function(expr) {
 }
 
 
-CodeBuilder.prototype.precompile = function(expr) {
+CodeBuilder.prototype.precompile = function(expr, bindings) {
     this.precompileDone = false;
-
     this.copyRequiredFunctions(expr);
-    this.determineVariables(expr);
+    this.determineVariables(expr, bindings);
     this.determineUniforms(expr);
     this.determineUniformTypes();
     this.determineTypes();
@@ -542,7 +463,7 @@ CodeBuilder.prototype.precompile = function(expr) {
  * [if generateTerm then also with the additional keys] term: expression in webgl, type: type of expression }
  */
 
-CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
+CodeBuilder.prototype.compile = function(expr, generateTerm) {
     var self = this; //for some reason recursion on this does not work, hence we create a copy; see http://stackoverflow.com/questions/18994712/recursive-call-within-prototype-function
     if (expr['isuniform']) {
         let uname = expr['uvariable'];
@@ -555,20 +476,7 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
         } : {
             code: ''
         };
-    }
-    if (expr['oper'] === ";") {
-        /*
-        let r0 = this.compile(expr['args'][0], scope, false);
-        let r1 = this.compile(expr['args'][1], scope, generateTerm);
-        let code = r0.code + r1.code;// + ((c.hasOwnProperty(expr)) ? '' : (c.expr + ';\n'));
-        //let r = generateTerm ? this.compile(expr['args'][1], true) : this.compile(expr['args'][1], false);
-        return generateTerm ? {code: code, term: r1.term, type:r1.type} : {code: code};
-        */
-
-
-        //arbitrary number of arguments, e.g. only 1
-
-        //let r = new Array(expr['args'].length);
+    } else if (expr['oper'] === ";") {
         let r = {
             type: type.voidt,
             term: ''
@@ -580,7 +488,7 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
         }
 
         for (let i = 0; i <= lastindex; i++) {
-            r = this.compile(expr['args'][i], scope, generateTerm && (i === lastindex)); //last one is responsible to generate term if required
+            r = this.compile(expr['args'][i], generateTerm && (i === lastindex)); //last one is responsible to generate term if required
             code += r.code;
         }
 
@@ -593,31 +501,32 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
         };
 
     } else if (expr['oper'] === "=") {
-        let r = this.compile(expr['args'][1], scope, true);
+        let r = this.compile(expr['args'][1], true);
         let varname = expr['args'][0]['name']
-            //console.log(scope);
-            //console.log(varname);
-        let t = `${varname} = ${this.castType(r.term, r.type, this.getType(expr['args'][0], scope))}`;
+        varname = expr.bindings[varname] || varname;
+        let t = `${varname} = ${this.castType(r.term, r.type, this.getType(expr['args'][0]))}`;
         if (generateTerm) {
             return {
                 code: r.code,
                 term: t,
-                type: this.T[scope][varname]
+                type: this.variables[varname].T
             };
         } else {
             return {
                 code: `${r.code + t};\n`
             }
         }
-    } else if (expr['oper'] === "repeat$2") {
-        let number = this.compile(expr['args'][0], scope, true);
+    } else if (expr['oper'] === "repeat$2" || expr['oper'] === "repeat$3") {
+        let number = this.compile(expr['args'][0], true);
         if (number.type.type !== 'constant') {
             console.error('repeat possible only for fixed constant number in GLSL');
             return false;
         }
-        let it = generateUniqueHelperString();
+        let it = (expr['oper'] === "repeat$2") ? expr['args'][1].bindings['#'] :
+            expr['args'][2].bindings[expr['args'][1]['name']] //(expr['oper'] === "repeat$3")
+        ;
         let n = number.term;
-        let r = this.compile(expr['args'][1], scope, generateTerm);
+        let r = this.compile(expr['args'][(expr['oper'] === "repeat$2") ? 1 : 2], generateTerm);
 
         let code = '';
         let ans = '';
@@ -640,18 +549,15 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
         } : {
             code: code
         });
-    } else if (expr['oper'] === "repeat$3") {
-        console.error("TODO");
-        //@TODO implement with manual variable
     } else if (expr['oper'] === "if$2" || expr['oper'] === "if$3") {
-        let cond = this.compile(expr['args'][0], scope, true);
-        let ifbranch = this.compile(expr['args'][1], scope, generateTerm);
+        let cond = this.compile(expr['args'][0], true);
+        let ifbranch = this.compile(expr['args'][1], generateTerm);
 
         let code = '';
         let ans = '';
         let ansvar = '';
 
-        let termtype = this.getType(expr, scope);
+        let termtype = this.getType(expr);
 
         if (generateTerm) {
             ansvar = generateUniqueHelperString();
@@ -665,7 +571,7 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
         }
 
         if (expr['oper'] === "if$3") {
-            let elsebranch = this.compile(expr['args'][2], scope, generateTerm);
+            let elsebranch = this.compile(expr['args'][2], generateTerm);
             code += '} else {\n';
             code += elsebranch.code;
             if (generateTerm) {
@@ -684,10 +590,6 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
     } else if (expr['ctype'] === "function" || expr['ctype'] === "infix") {
         let fname = expr['oper'];
 
-        //console.log(JSON.stringify(expr));
-        //console.log("this:" + JSON.stringify(this));
-
-
         if (getPlainName(fname) === 'verbatimglsl') {
             let glsl = this.api.evaluateAndVal(expr['args'][0]).value;
             return (generateTerm ? {
@@ -699,15 +601,9 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
             });
         }
 
-        let r = expr['args'].map(e => self.compile(e, scope, true)); //recursion on all arguments
+        let r = expr['args'].map(e => self.compile(e, true)); //recursion on all arguments
 
         let termGenerator;
-
-
-        //console.log('recursion in scope ' + scope);
-        //console.log(expr);
-        //console.log(fname);
-        //console.log(r);//TODO remove
 
         let currenttype = r.map(c => c.type);
         let targettype;
@@ -717,11 +613,9 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
             termGenerator = this.usemyfunction(fname);
             targettype = new Array(r.length)
             for (let i = 0; i < r.length; i++) {
-                targettype[i] = this.T[fname][this.myfunctions[fname]['arglist'][i]['name']];
+                targettype[i] = this.variables[this.myfunctions[fname].body.bindings[this.myfunctions[fname]['arglist'][i]['name']]].T;
             }
-
-            restype = this.T[''][fname];
-
+            restype = this.variables[expr.bindings[fname]].T;
         } else { //cindyscript-function
             fname = getPlainName(fname);
             if (fname === 'regional')
@@ -760,8 +654,6 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
         }
         //console.log("Running Term Generator with arguments" + JSON.stringify(argterms) + " and this: " + JSON.stringify(this));
         let term = termGenerator(argterms, expr['modifs'], this);
-        //console.log(termGenerator);
-        //console.log(termGenerator([1]));
         //console.log("generated the following term:" + term);
         if (generateTerm)
             return {
@@ -774,7 +666,7 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
                 code: `${code + term};\n`
             };
     } else if (expr['ctype'] === 'number') { //write numbers(int, float, complex) directly in code
-        let termtype = this.getType(expr, scope);
+        let termtype = this.getType(expr);
         let term = pastevalue(expr, guessTypeOfValue(expr));
         return (generateTerm ? {
             term: term,
@@ -796,13 +688,9 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
         console.error("Cannot compile strings to WebGL.");
         return false;
     } else if (expr['ctype'] === "variable") {
-        let termtype = this.getType(expr, scope);
-
+        let termtype = this.getType(expr);
         let term = expr['name'];
-
-        if (term === '#') { //TODO: This could be passed by some additional argument: Or # could be inside repeat-loop... Better use stack
-            term = 'cgl_pixel';
-        }
+        term = expr.bindings[term] || term;
         return (generateTerm ? {
             term: term,
             type: termtype,
@@ -820,8 +708,8 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
         });
     } else if (expr['ctype'] === 'field') {
         //TODO: finish implementation once cindyJS got implementation
-        let termtype = this.getType(expr, scope);
-        let term = self.compile(expr['obj'], scope, true).term;
+        let termtype = this.getType(expr);
+        let term = self.compile(expr['obj'], true).term;
         term += `.${expr['key']}`; //for .x .y. z .r .g .b things are same in cindyjs and glsl
         return (generateTerm ? {
             term: term,
@@ -838,7 +726,7 @@ CodeBuilder.prototype.compile = function(expr, scope, generateTerm) {
 
 CodeBuilder.prototype.usemyfunction = function(fname) {
     this.compileFunction(fname, this.myfunctions[fname]['arglist'].length);
-    return usefunction(fname);
+    return usefunction(fname.replace('$', '_'));
 };
 
 
@@ -847,25 +735,24 @@ CodeBuilder.prototype.compileFunction = function(fname, nargs) {
     if (this.mark('compiledfunctions', fname)) return; //visited
 
     let m = this.myfunctions[fname];
+    let pname = fname.replace('$', '_'); //remove $
+    let bindings = m.body.bindings;
 
     let vars = new Array(nargs);
     for (let i = 0; i < nargs; i++) {
         vars[i] = m['arglist'][i]['name'];
     }
-    let isvoid = (this.T[''][fname] === type.voidt);
+    let isvoid = (this.variables[pname].T === type.voidt);
 
-    let code = `${webgltype(this.T[''][fname])} ${getPlainName(fname)}(${vars.map(varname => webgltype(self.T[fname][varname]) + ' ' + varname).join(', ')}){\n`;
-    for (let i in this.variables[fname]) {
-        let doprint = true;
-        let varname = this.variables[fname][i];
-        for (let j = 0; j < vars.length; j++) doprint &= (varname !== vars[j]);
-        if (doprint) code += `${webgltype(this.T[fname][varname])} ${varname};\n`;
+    let code = `${webgltype(this.variables[pname].T)} ${pname}(${vars.map(varname => webgltype(self.variables[bindings[varname]].T) + ' ' + bindings[varname]).join(', ')}){\n`;
+    for (let i in m.variables) {
+        let iname = m.variables[i];
+        code += `${webgltype(this.variables[iname].T)} ${iname};\n`;
     }
-    let r = self.compile(m.body, fname, !isvoid);
+    let r = self.compile(m.body, !isvoid);
     code += r.code;
-    //console.log(r);
     if (!isvoid)
-        code += `return ${this.castType(r.term, r.type, this.T[''][fname])};\n`; //TODO REPL
+        code += `return ${this.castType(r.term, r.type, this.variables[pname].T)};\n`; //TODO REPL
     code += '}\n';
 
     this.add('compiledfunctions', fname, () => code);
@@ -884,8 +771,13 @@ CodeBuilder.prototype.generateColorPlotProgram = function(expr) { //TODO add arg
     helpercnt = 0;
     expr = cloneExpression(expr); //then we can write dirty things on expr...
 
-    this.precompile(expr); //determine this.variables, types etc.
-    let r = this.compile(expr, '', true);
+    this.initvariable('cgl_pixel', false);
+    this.variables['cgl_pixel'].T = type.vec2;
+    let bindings = {
+        '#': 'cgl_pixel'
+    }
+    this.precompile(expr, bindings); //determine this.variables, types etc.
+    let r = this.compile(expr, true);
     let colorterm = this.castType(r.term, r.type, type.color);
 
     if (!issubtypeof(r.type, type.color)) {
@@ -898,11 +790,10 @@ CodeBuilder.prototype.generateColorPlotProgram = function(expr) { //TODO add arg
     code += this.generateSection('functions');
     code += this.generateSection('includedfunctions');
 
-    for (let i in this.variables['']) { //global this.variables
-        let varname = this.variables[''][i];
-        if (this.myfunctions.hasOwnProperty(varname)) continue; //only consider real this.variables
-        code += `${webgltype(this.T[''][varname])} ${varname};\n`;
-    }
+    for (let iname in this.variables)
+        if (this.variables[iname]['global']) {
+            code += `${webgltype(this.variables[iname].T)} ${iname};\n`;
+        }
 
     code += this.generateSection('compiledfunctions');
 

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -132,10 +132,10 @@ webgl[';'] = (argtypes) => ({ //generator not used yet
     generator: args => `${args[0]} ; ${args[1]};`
 });
 
-webgl['repeat'] = argtypes => isconstantint(argtypes[0]) ? ({ //generator not used yet
+webgl['repeat'] = argtypes => (argtypes.length == 2 || argtypes.length == 3) && isconstantint(argtypes[0]) ? ({ //generator not used yet
     args: argtypes,
-    res: argtypes[1],
-    generator: args => `${args[0]} ; ${args[1]};`
+    res: argtypes[argtypes.length - 1],
+    generator: args => ''
 }) : false;
 
 webgl['regional'] = argtypes => ({ //generator not used yet


### PR DESCRIPTION
This enables to have locally defined variables within CindyGL. We require this to access # within repeat(n,expr). Furthermore repeat(n, k,expr) has been implemented.
An modified example http://cindyjs.org/gallery/main/WaveIntersection/ has been included which demonstrates the usage of the repeat(n, k,expr)-loop.