### PR TITLE
Create a tag in the deploy repo for every release

### DIFF
--- a/tools/travis-deploy.sh
+++ b/tools/travis-deploy.sh
@@ -49,6 +49,10 @@ if ! git diff --staged --quiet; then
     git config --local user.email "travis-ci@cinderella.de"
     git commit -m "Build of CindyJS ${name}"
     git push origin "HEAD:${branch}"
+    if [[ ${TRAVIS_TAG} ]]; then
+        git tag "${TRAVIS_TAG}"
+        git push origin tag "${TRAVIS_TAG}"
+    fi
 fi
 rm -rf ../prevdeploy "${preserve[@]}"
 


### PR DESCRIPTION
This allows easy downloading of the whole released archive from the deployment repository.  The tags are not annotated, since they carry no information that isn't already included in the commit they tag.

I've just manually added tags for all the releases we had so far. The idea is that we can suggest download locations like https://github.com/CindyJS/deploy/archive/v0.8.2.zip to let people download all the files comprising a given CindyJS release.

The code in this Pull Request is *untested!* It will get tested during the next release after this here gets merged in. I think it should be short enough to get it correct without testing, but please check carefully whether you see any stupid mistakes I missed. (In the worst case, the next release may require some manual steps to complete deployment.)