### PR TITLE
Exception on moving docked texts

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -57,7 +57,7 @@ function getmover(mouse) {
             }
             dist = dist + 25 / sc;
         } else if (el.kind === "Text") {
-            if (!el._bbox) continue;
+            if (!el.homog || el.dock || !el._bbox) continue;
             p = csport.from(mouse.x, mouse.y, 1);
             dx = Math.max(0, p[0] - el._bbox.right, el._bbox.left - p[0]);
             dy = Math.max(0, p[1] - el._bbox.bottom, el._bbox.top - p[1]);


### PR DESCRIPTION
A docked text usually doesn't have an el.homog coordinate vector, which will lead to an exception if the getmover code attempts to normalize that.
As docked texts aren't movable at the moment anyway (see #488), let's just skip these.

This issue was introduced by 1de6e451439733149fdf91048a07061d2b5f0579 so it affects versions starting at 0.8.1 resp. 0.7.5.