### PR TITLE
Check result from fs.writeFile calls in build script

### DIFF
--- a/tools/prepare-deploy.js
+++ b/tools/prepare-deploy.js
@@ -47,6 +47,13 @@ process.once('beforeExit', function() {
     process.exit(exitStatus);
 });
 
+function check(err) {
+    if (err) {
+        console.error(err.stack);
+        exitStatus = 1;
+    }
+}
+
 child_process.execFile("git", ["rev-parse", "HEAD"], function(err, stdout, stderr) {
     if (err) {
         console.log(stdout);
@@ -84,7 +91,7 @@ function subst(name, err, content) {
     if (err) throw err;
     content = content.toString();
     content = content.replace(/\$gitid\$/, head);
-    fs.writeFile(path.join(outDir, name), content);
+    fs.writeFile(path.join(outDir, name), content, check);
 }
 
 var mapKeys = ["version", "file", "sourceRoot", "sources", "sourcesContent", "names", "mappings"];
@@ -114,7 +121,7 @@ function map(name, err, content) {
     content = "{" + keys.map(function(key) {
         return JSON.stringify(key) + ":" + JSON.stringify(map[key]);
     }).join(",\n ") + "}\n";
-    fs.writeFile(path.join(outDir, name), content);
+    fs.writeFile(path.join(outDir, name), content, check);
 }
 
 function copy(inPath, outPath, err, stats) {


### PR DESCRIPTION
This avoids a warning which otherwise gets issued by Node 7:

> DeprecationWarning: Calling an asynchronous function without callback is deprecated.

Another such warning can be avoided by upgrading whole-line-stream to 0.1.1. `npm update --depth 0` should do the trick, although the depth option is not needed for npm >= 2.6.1.