### PR TITLE
Combine moves of the same mover

### DIFF
--- a/examples/EllipseWithPaper.html
+++ b/examples/EllipseWithPaper.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Drawing an ellipse with a strip of paper</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <link rel="stylesheet" href="../build/js/CindyJS.css">
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csmove" type="text/x-cindyscript">
+d = A.x - B.y;
+if(Y.y > d, Y.y = d + 1; continue from here(); Y.y = d);
+if(Y.y < -d, Y.y = -d - 1; continue from here(); Y.y = -d);
+</script>
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  geometry: [
+    {name: "a", type: "HorizontalLine", pos: [0.0, -4.0, 0.0], color: [0.0, 0.0, 1.0], pinned: true},
+    {name: "b", type: "VerticalLine", pos: [4.0, -0.0, 0.0], color: [0.0, 0.0, 1.0], pinned: true},
+    {name: "A", type: "PointOnLine", pos: [4.0, -0.0, 0.7194244604316548], color: [1.0, 0.0, 0.0], args: ["a"], size: 2.0},
+    {name: "B", type: "PointOnLine", pos: [0.0, -4.0, -1.1235955056179776], color: [1.0, 0.0, 0.0], args: ["b"], size: 2.0},
+    {name: "O", type: "Meet", color: [1.0, 0.0, 0.0], args: ["a", "b"], size: 2.0},
+    {name: "C0", type: "CircleMP", color: [1.0, 1.0, 1.0], args: ["O", "A"], size: 0, printname: "$C_{0}$"},
+    {name: "A'", type: "OtherIntersectionCL", color: [1.0, 0.0, 0.0], args: ["C0", "a", "A"], size: 2.0},
+    {name: "C1", type: "CircleMP", color: [0.0, 0.0, 1.0], args: ["O", "B"], visible: false, printname: "$C_{1}$"},
+    {name: "B'", type: "OtherIntersectionCL", color: [1.0, 0.0, 0.0], args: ["C1", "b", "B"], size: 2.0},
+    {name: "C2", type: "ConicFromPrincipalDirections", color: [0.467, 0.0, 0.718], args: ["O", "A", "B"], size: 3, printname: "$C_{2}$"},
+    {name: "Y", type: "PointOnLine", pos: [0.0, -4.0, 2.4999999999999996], color: [1.0, 0.0, 0.0], args: ["b"], labeled: true, size: 4.0},
+    {name: "Collection__1", type: "IntersectionConicLine", args: ["C1", "a"]},
+    {name: "C", type: "SelectP", pos: [4.0, -0.0, 1.1235955056179776], color: [1.0, 0.0, 0.0], args: ["Collection__1"], visible: false, labeled: true},
+    {name: "C3", type: "Compass", color: [0.0, 0.0, 1.0], args: ["C", "A", "Y"], visible: false, printname: "$C_{3}$"},
+    {name: "Collection__2", type: "IntersectionConicLine", args: ["C3", "a"]},
+    {name: "X", type: "SelectP", pos: [4.0, -0.0, 3.333333333333334], color: [1.0, 0.0, 0.0], args: ["Collection__2"], labeled: true, size: 4.0},
+    {name: "c", type: "Join", color: [0.098, 0.62, 0.306], args: ["Y", "X"], size: 3, clip: "inci"},
+    {name: "Collection__3", type: "IntersectionConicLine", args: ["C2", "c"]},
+    {name: "P", type: "SelectP", pos: [4.0, 3.4148681055155876, 1.1990407673860926], color: [1.0, 0.0, 0.0], args: ["Collection__3"], labeled: true, size: 4.0},
+    {name: "d", type: "Segment", color: [0.098, 0.62, 0.306], args: ["O", "A"], size: 3},
+    {name: "e", type: "Segment", color: [1.0, 0.784, 0.0], args: ["O", "B"], size: 3},
+    {name: "f", type: "Orthogonal", color: [0.0, 0.0, 1.0], args: ["c", "X"], visible: false, labeled: true},
+    {name: "C4", type: "CircleByRadius", pos: {xx: {r: 0.7054673721340389, i: 4.170729853286927E-17}, yy: {r: 0.7054673721340389, i: 4.170729853286927E-17}, zz: 1.0, xy: 0.0, xz: {r: -1.6931216931216932, i: -1.0009751647888623E-16}, yz: 0.0}, color: [0.0, 0.0, 1.0], radius: 0.1499999999999999, args: ["X"], visible: false, pinned: true},
+    {name: "Collection__4", type: "IntersectionConicLine", args: ["C4", "f"]},
+    {name: "D", type: "SelectP", pos: [4.0, {r: 0.33333333333333226, i: 6.897344494873272E-16}, {r: 3.7037037037037024, i: 7.663716105414752E-16}], color: [1.0, 0.0, 0.0], args: ["Collection__4"], visible: false, labeled: true},
+    {name: "g", type: "Parallel", color: [1.0, 0.784, 0.0], args: ["c", "D"], size: 3, clip: "inci"},
+    {name: "h", type: "Orthogonal", color: [0.0, 0.0, 1.0], args: ["g", "P"], visible: false, labeled: true},
+    {name: "E", type: "Meet", color: [1.0, 0.0, 0.0], args: ["g", "h"], visible: false, labeled: true}
+  ],
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 350,
+    transform: [{visibleRect: [-12.54, 7.38, 14.66, -6.62]}],
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  cinderella: {build: 1892, version: [2, 9, 1892]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/examples/moverSwitching.html
+++ b/examples/moverSwitching.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csmove" type="text/x-cindyscript">
+
+if(mover() == B,
+  if(B.y < -2, B.y = -2);
+);
+
+if(mover() == C,
+  if(C.y < -2, C.y = -3; err(Q3.x); continue from here(); C.y = -2);
+);
+
+</script>
+<script type="text/javascript">
+
+var cdy = CindyJS({
+  ports: [{
+    id: "CSCanvas",
+    width: 400,
+    height: 250,
+    transform: [{visibleRect: [-3, 4, 13, -6]}],
+    axes: false,
+    grid: 1.0,
+    snap: true
+  }],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+    dimDependent: 0.7,
+  },
+  geometry: [
+    {name: "h", type: "HorizontalLine", pos: [0,1,0]},
+
+    {name: "P1", type: "PointOnLine", args: ["h"], pos: [0,0], visible: false},
+    {name: "v1", type: "Perp", args: ["h", "P1"], visible: false},
+    {name: "A", type: "Free", pos: [0,-1], labeled: true},
+    {name: "C1", type: "CircleByRadius", radius: 2.0, args: ["A"], pinned: true},
+    {name: "Pts1", type: "IntersectionConicLine", args: ["C1", "h"]},
+    {name: "Q1", type: "SelectP", pos: [2,0], args: ["Pts1"]},
+    
+    {name: "P2", type: "PointOnLine", args: ["h"], pos: [5,0], visible: false},
+    {name: "v2", type: "Perp", args: ["h", "P2"], visible: false},
+    {name: "B", type: "PointOnLine", args: ["v2"], pos: [0,-1], labeled: true},
+    {name: "C2", type: "CircleByRadius", radius: 2.0, args: ["B"], pinned: true},
+    {name: "Pts2", type: "IntersectionConicLine", args: ["C2", "h"]},
+    {name: "Q2", type: "SelectP", pos: [7,0], args: ["Pts2"]},
+
+    {name: "P3", type: "PointOnLine", args: ["h"], pos: [10,0], visible: false},
+    {name: "v3", type: "Perp", args: ["h", "P3"], visible: false},
+    {name: "C", type: "PointOnLine", args: ["v3"], pos: [0,-1], labeled: true},
+    {name: "C3", type: "CircleByRadius", radius: 2.0, args: ["C"], pinned: true},
+    {name: "Pts3", type: "IntersectionConicLine", args: ["C3", "h"]},
+    {name: "Q3", type: "SelectP", pos: [12,0], args: ["Pts3"]}
+  ],
+  tracingStateReport: "tracingStateReport"
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+  <p>Tracing state: <span id="tracingStateReport"></span></p>
+  <p>
+    This demo relies on the fact that currently free points snap to
+    grid, but points on lines do not. This allows observing snapping
+    and non-snapping behavior in a single widget.
+  </p>
+  <p>Things to check:</p>
+  <ol>
+    <li>
+      <p>
+        Moving <em>A</em> down so that the circle no longer intersects
+        the line, and then back up so that it intersects the line
+        again, the point of intersection switches between left and
+        right half of the circle. This demonstrates the basic
+        operation of tracing.
+      </p>
+    </li>
+    <li>
+      <p>
+        Moving <em>A</em> to the tangential situation should snap to
+        that position thanks to the snap to grid feature. Releasing
+        the mouse there and then pressing it again to move the point
+        back should leave the point on the same half of the circle
+        where it was before, as tracing continues from a position
+        before the tangential one even if the mouse was released in
+        between.
+      </p>
+    </li>
+    <li>
+      <p>
+        Conversely, releasing <em>A</em> in the tangential situation
+        and then dragging the point further down before going up again
+        will cause the point to change sides. One may release the
+        point again in the singular situation while going back,
+        without affecting the outcome. Note that the mouse has to move
+        down far enough to actually move <em>A</em> away from the
+        snapped singular situation.
+      </p>
+    </li>
+    <li>
+      <p>
+        As <em>B</em> is restricted to a line, it currently does not
+        snap to the grid. Moving the point down to the singular
+        situation, the script will restrict its movement. As the mouse
+        movement and the script are taken together, the last
+        non-singular position has to be one where <em>B</em> is
+        located further up. Since tracing continues from that, it will
+        preserve the side of the point of intersection.
+      </p>
+    </li>
+    <li>
+      <p>
+        Moving <em>C</em> is similar to moving <em>B</em>. But instead
+        of just restricting the movement, the script for <em>C</em>
+        deliberately moves the point a good deal into the complex
+        situation, and explicitely requests that the next tracing
+        operation starts from that situation. As a consequence, moving
+        the point to the tangential situation and back up again should
+        cause the point of intersection to always switch sides.  The
+        complex situation used as a checkpoint will get printed to the
+        web console.
+      </p>
+    </li>
+  </ol>
+</body>
+
+</html>

--- a/ref/Interaction_with_Geometry.md
+++ b/ref/Interaction_with_Geometry.md
@@ -354,3 +354,24 @@ As `repaint` but with a time delay of as many milliseconds as given by he parame
 
 **Description:**
 This operator returns a list of points in *xy*-coordinates that are all on a locus given by the name `‹locus›` of a geometric element.
+
+------
+
+------
+
+#### Creating a continuity checkpoint: `continuefromhere()`
+
+**Description:**
+
+Usually if a mouse moves a geometric element, and then a script moves
+the same element to another position (and does not move any other
+element), then both of these moves are combined.  If one of them
+encounters a singular situation, then the whole operation will be
+considered singular, and subsequent moves will continue from the last
+non-singular situation before that move.
+
+Sometimes however it is desirable for a script to deliberately split
+that operation: move to some (preferrably non-singular) situation in a
+controlled way, then create a checkpoint there so that subsequent
+moves will start from this situation instead of the one before the
+mouse move to some singular situation.

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -193,7 +193,6 @@ function setuplisteners(canvas, data) {
     addAutoCleaningEventListener(canvas, "mouseup", function(e) {
         mouse.down = false;
         cindy_cancelmove();
-        stateContinueFromHere();
         cs_mouseup();
         manage("mouseup");
         scheduleUpdate();
@@ -439,7 +438,6 @@ function setuplisteners(canvas, data) {
         activeTouchID = -1;
         mouse.down = false;
         cindy_cancelmove();
-        stateContinueFromHere();
         cs_mouseup();
         manage("mouseup");
         scheduleUpdate();

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1783,7 +1783,6 @@ evaluator.moveto$2 = function(args, modifs) {
 
 evaluator.continuefromhere$0 = function(args, modifs) {
     stateContinueFromHere();
-    tracingFailed = false;
     return nada;
 };
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1781,6 +1781,12 @@ evaluator.moveto$2 = function(args, modifs) {
     return nada;
 };
 
+evaluator.continuefromhere$0 = function(args, modifs) {
+    stateContinueFromHere();
+    tracingFailed = false;
+    return nada;
+};
+
 evaluator.matrixrowcolumn$1 = function(args, modifs) {
     var v0 = evaluate(args[0]);
     var n = List._helper.colNumb(v0);

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -159,7 +159,8 @@ function addElementNoProof(el) {
         console.log("Element name '" + el.name + "' already exists");
 
         var existingEl = csgeo.csnames[el.name];
-        if (geoOps[existingEl.type].isMovable)
+        if (geoOps[existingEl.type].isMovable &&
+            geoOps[existingEl.type].kind === "P")
             movepointscr(existingEl, el.pos, "homog");
 
         return {

--- a/src/js/libgeo/Tracing.js
+++ b/src/js/libgeo/Tracing.js
@@ -51,6 +51,7 @@ function stateAlloc(newSize) {
  */
 function stateContinueFromHere() {
     stateLastGood.set(stateIn);
+    tracingFailed = false;
     tracingStateReport(false);
 
     // Make numbers which are almost real totally real. This avoids
@@ -96,7 +97,6 @@ function traceMouseAndScripts() {
         traceLog.currentMouseAndScripts = [];
     }
     inMouseMove = true;
-    tracingFailed = false;
     if (move) {
         var mover = move.mover;
         var sx = mouse.x + move.offset.x;
@@ -126,16 +126,9 @@ function traceMouseAndScripts() {
 }
 
 function movepointscr(mover, pos, type) {
-    if (inMouseMove) {
-        // traceMouseAndScripts will handle tracingFailed
-        traceMover(mover, pos, type);
-    } else {
-        tracingFailed = false;
-        traceMover(mover, pos, type);
-        if (!tracingFailed) {
-            stateContinueFromHere();
-        }
-    }
+    traceMover(mover, pos, type);
+    if (!inMouseMove && !tracingFailed)
+        stateContinueFromHere();
 }
 
 // Remember the last point which got moved.
@@ -151,10 +144,10 @@ function traceMover(mover, pos, type) {
     }
     if (mover === previousMover) {
         stateIn.set(stateLastGood); // copy stateLastGood and use it as input
+        tracingFailed = false;
     } else {
         previousMover = mover;
         stateContinueFromHere(); // make changes up to now permanent
-        tracingFailed = false; // can't handle previous failure any more
     }
     stateOut.set(stateIn); // copy in to out, for elements we don't recalc
     var traceLimit = 10000; // keep UI responsive in evil situations


### PR DESCRIPTION
This fixes #539.

Switching the mover breaks complex tracing: as we only move one object at a time, we have to abandon the saved state and make the current state persistent if the mover changes. Up till now, CindyJS would perform this kind of mover change upon mouse up, and around scripted moves. So multiple mouse moves of the same object would not get traced correctly if the mouse was released in a singular situation in between. And multiple script commands moving the same object, or perhaps the same object that was also moved by the mouse, also caused this mover switch behavior.

This commit here reduces the number of such mover switches to when the mover actually changes. One consequence is that it's now possible to release the mouse in a singular situation without loosing tracing information. Only when another point gets moved afterwards the information is lost.

As discussed in https://github.com/CindyJS/CindyJS/issues/539#issuecomment-262991267, Cinderella apparently treats mouse move and script move as independent operations, and will take a checkpoint in between these two if the situation there is not singular. CindyJS, on the other hand, does treat mouse move and script moves as one entity, if they refer to the same object. So the automatic checkpointing will only occur before the mouse move. However, to allow more control to power users, this change introduces a function `continuefromhere()` (alternatively spelled `continue from here()` or `continueFromHere()`) which allows manual checkpointing. The example file demonstrates its use.