### PR TITLE
Add apply, forall and sum to CindyGL

### DIFF
--- a/examples/cindygl/10_gol_sumapply.html
+++ b/examples/cindygl/10_gol_sumapply.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+    <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+    <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Game of Life on GPU</h1>
+    
+               
+    <script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+      
+      
+      L = [0, 0]; //bottom left corner
+      R = [128, 0]; //bottom right corner
+      
+      createimage("gol", 128, 128);
+      
+      animate = true;
+      colorplot(L, R, "gol", if(random()>.6,1,0)); //random stuff as starting image
+    </script>
+    
+    <script id="csmousedown" type="text/x-cindyscript">
+      animate = false;
+    </script>
+    <script id="csmouseup" type="text/x-cindyscript">
+      animate = true;
+    </script>
+    
+    <script id="cskeydown" type="text/x-cindyscript">
+      print("pressed key" + keycode());
+      if(keycode()==32, colorplot(L, R, "gol", 0)); //space -> black
+      if(keycode()==82, colorplot(L, R, "gol", if(random()>.6,1,0))); //R -> random image
+    </script>
+
+    <script id="csdraw" type="text/x-cindyscript">
+      if(!animate, setpixel("gol", floor(mouse().x), floor(mouse().y), (1,1,1)));
+      
+      get(x, y) :=  imagergb((0,0), (128,0), "gol", (mod(x,128),mod(y,128)), interpolate->false).r; //Tourus world
+      
+			nbh = [(-1,-1), (-1,0), (-1,+1), (0,-1),  (0,+1), (+1,-1), (+1,0), (+1,+1)];
+      newstate(x, y) := (
+        //number of living neighbours
+        number = sum( apply(nbh, get(#.x + x, #.y + y)));
+        if(get(x,y)==1,
+        
+          //if the cell lives then it will die if it has less than 2 neighbours or more than 3 neighbours
+          if((number < 2) % (number > 3), 0, 1),
+          
+          //if cell was dead then 3 are required to be born
+          if(number==3, 1, 0)
+        )
+      );
+      
+      if(animate, colorplot(L, R, "gol", newstate(#.x, #.y)));
+      
+      //plots to canvas using no interpolation
+      colorplot(imagergb(L, R, "gol", #, interpolate->false));
+    </script>
+    
+   <ul>
+     <li>
+    Click on canvas to interact!
+     </li>
+      <li>
+    Press R to reset to some random configuration.
+      </li>
+      <li>
+    Press SPACE to reset to blank configuration.
+      </li>
+    </ul>
+  <div id="CSCanvas" style="position:relative; top:10px;"></div>
+    
+
+    
+    <script type="text/javascript">     
+        cdy = CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:[],
+                    animation: {autoplay: true},
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 512,
+                      height: 512,
+                      transform: [ { visibleRect: [0, 0, 128, 128] } ]
+                    }]
+                  });
+        
+        var canvas = document.getElementById("CSCanvas");
+        canvas.focus();
+          
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/14_reactiondiffusion.html
+++ b/examples/cindygl/14_reactiondiffusion.html
@@ -18,7 +18,7 @@
 
         createimage("state", 512, 512);
 
-        initialimage(x) := if(abs(#.x-256)<30 &abs(#.y-256)<30 ,.7*(random(),random(),0),(1,0,0));
+        initialimage(x) := if(abs(x.x-256)<30 &abs(x.y-256)<30 ,.7*(random(),random(),0),(1,0,0));
         colorplot(L, R, "state", initialimage(#));
 
         pressed=false;

--- a/examples/cindygl/36_raycasting_kummer.html
+++ b/examples/cindygl/36_raycasting_kummer.html
@@ -188,12 +188,12 @@
       
       //traces the ray for the pixel at pos and returns the distance to the first intersection point of ray with (F^{-1}\{0\} intersected with ball with radius 4)
       getDistanceToObj(pos) := (
-        spolyvalues = [S(ray(pos, -1)), S(ray(pos, 0)), S(ray(pos, 1))];
+        spolyvalues =  apply([-1,0,1], S(ray(pos, #)));
         spoly = B3*spolyvalues; // interpolate
         
         D = (spoly_2*spoly_2)-4.*spoly_3*spoly_1; //discriminant of spoly
         if(D>=0, //ray intersects ball
-          polyvalues = [F(ray(pos, li_1)), F(ray(pos, li_2)), F(ray(pos, li_3)), F(ray(pos, li_4)), F(ray(pos, li_5))];
+          polyvalues = apply(li, F(ray(pos, #)));
           poly = B*polyvalues; // interpolate
           firstroot(poly,
             (-spoly_2-re(sqrt(D)))/(2.*spoly_3), //intersection entering the ball

--- a/examples/cindygl/40_waveintersection_forall.html
+++ b/examples/cindygl/40_waveintersection_forall.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Interference</h1>
+    
+    
+    <script id="csdraw" type="text/x-cindyscript">
+      A.x=55;
+      B.x=65;
+      C.x=75;
+      if(A.y<-40,A.y=-40);
+      if(A.y>40,A.y=40);
+      if(B.y<-40,B.y=-40);
+      if(B.y>40,B.y=40);
+      if(C.y<-40,C.y=-40);
+      if(C.y>40,C.y=40);
+      zoom=(C.y+40)/40+.1;
+      t = seconds()-t0;
+      n=round((A.y+40)/80*8+1);
+      amp=(B.y+40)/80*3;
+      k=if(mod(n,2)==0,1,2);
+
+      waves(z) := (
+         ans=0;
+         forall(1..n,l,
+           ans=ans+sin(t+re(z*exp(l*k*pi*i/n)));
+         );
+         (ans*amp)/2+.5;
+      );
+      
+      colorplot(col(waves(complex(#*zoom))));
+      fillpoly([[50,-50],[80,-50],[80,50],[50,50]],color->(0,0,0),alpha->.5); 
+      draw((55,-40),(55,40),color->(1,1,1),size->2);
+      draw((65,-40),(65,40),color->(1,1,1),size->2);
+      draw((75,-40),(75,40),color->(1,1,1),size->2);
+      drawtext((54,45),n,color->(1,1,1));
+    </script>
+               
+    <script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+      t0 = seconds();
+      col(x):=(sin(x)*.5+.5,sin(x),sin(x)^3*.3);
+      //col(x):=hue(x);
+    </script>
+    
+
+    <div  id="CSCanvas"></div>
+    
+    <script type="text/javascript">
+        
+        var gslp=[
+                  {name:"A", kind:"P", type:"Free", pos:[-20,-1,1],color:[1,1,1]},
+                  {name:"B", kind:"P", type:"Free", pos:[20,5,1],color:[1,1,1]},
+                  {name:"C", kind:"P", type:"Free", pos:[20,5,1],color:[1,1,1]},
+                  ];
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:gslp,
+                    animation: {autoplay: true},
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 780,
+                      height: 600,
+                      transform: [ { visibleRect: [-50,-50, 80, 50] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/40_waveintersection_sumapply.html
+++ b/examples/cindygl/40_waveintersection_sumapply.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Interference</h1>
+    
+    
+    <script id="csdraw" type="text/x-cindyscript">
+      A.x=55;
+      B.x=65;
+      C.x=75;
+      if(A.y<-40,A.y=-40);
+      if(A.y>40,A.y=40);
+      if(B.y<-40,B.y=-40);
+      if(B.y>40,B.y=40);
+      if(C.y<-40,C.y=-40);
+      if(C.y>40,C.y=40);
+      zoom=(C.y+40)/40+.1;
+      t = seconds()-t0;
+      n=round((A.y+40)/80*8+1);
+      amp=(B.y+40)/80*3;
+      k=if(mod(n,2)==0,1,2);
+
+      waves(z) := (
+         sum(
+					 apply(1..n, l,
+ 						sin(t+re(z*exp(l*k*pi*i/n)))
+ 					);
+				)*amp/2 +.5;
+      );
+      
+      colorplot(col(waves(complex(#*zoom))));
+      fillpoly([[50,-50],[80,-50],[80,50],[50,50]],color->(0,0,0),alpha->.5); 
+      draw((55,-40),(55,40),color->(1,1,1),size->2);
+      draw((65,-40),(65,40),color->(1,1,1),size->2);
+      draw((75,-40),(75,40),color->(1,1,1),size->2);
+      drawtext((54,45),n,color->(1,1,1));
+    </script>
+               
+    <script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+      t0 = seconds();
+      col(x):=(sin(x)*.5+.5,sin(x),sin(x)^3*.3);
+      //col(x):=hue(x);
+    </script>
+    
+
+    <div  id="CSCanvas"></div>
+    
+    <script type="text/javascript">
+        
+        var gslp=[
+                  {name:"A", kind:"P", type:"Free", pos:[-20,-1,1],color:[1,1,1]},
+                  {name:"B", kind:"P", type:"Free", pos:[20,5,1],color:[1,1,1]},
+                  {name:"C", kind:"P", type:"Free", pos:[20,5,1],color:[1,1,1]},
+                  ];
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:gslp,
+                    animation: {autoplay: true},
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 780,
+                      height: 600,
+                      transform: [ { visibleRect: [-50,-50, 80, 50] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/41_apply.html
+++ b/examples/cindygl/41_apply.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: apply within CindyGL</h1>
+    
+    
+    <script id="csdraw" type="text/x-cindyscript">
+    colorplot(
+			a = [#.x, #.y,1];
+			apply(a, k, .5*sin(k))
+		);
+    </script>
+               
+    <script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+    </script>
+    
+    <div  id="CSCanvas"></div>
+		
+    <script type="text/javascript">
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry: [],
+                    animation: {autoplay: true},
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 500,
+                      height: 500,
+                      transform: [ { visibleRect: [-10,-10, 10, 10] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/41_sum.html
+++ b/examples/cindygl/41_sum.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: sum within CindyGL</h1>
+		
+		<script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+    </script>
+    
+    <script id="csdraw" type="text/x-cindyscript">
+		colorplot(
+    	sum([sin(#.x),sin(#.y),1,-1,1,-1]);
+		);
+    </script>
+
+
+    <div  id="CSCanvas"></div>
+    
+    <script type="text/javascript">
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:[],
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 500,
+                      height: 500,
+                      transform: [ { visibleRect: [-10,-10,10,10] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/42_taylor.html
+++ b/examples/cindygl/42_taylor.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+    <link rel="stylesheet" href="../../build/js/CindyJS.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Taylor series of complex functions</h1>
+    
+		<script id="csinit" type="text/x-cindyscript">			
+			hsvToRGB(h, s, v) := (
+			  regional(j, p, q, t, f);
+
+			  h = (h-floor(h))*6;
+
+			  j = floor(h);
+			  f = h - j;
+
+			  p = 1 - s;
+			  q = 1 - s*f;
+			  t = 1 - s*(1-f);
+
+			  if(j == 0, [1, t, p],
+			  if(j == 1, [q, 1, p],
+			  if(j == 2, [p, 1, t],
+			  if(j == 3, [p, q, 1],
+			  if(j == 4, [t, p, 1],
+			  if(j == 5, [1, p, q]))))))*v
+			);
+
+			color(z) := ( //what color should be given to a complex number z?
+			  regional(n, grey1, grey2);
+			  n = 12;
+			  z = log(z)/2/pi;
+
+			  zfract = n*z - floor(n*z); //value of n*z in C mod Z[i]
+
+			  grey1 = im(zfract);
+			  grey2 = re(zfract);
+
+			  hsvToRGB(im(z), 1., .5+.5*re(sqrt(grey1*grey2)))
+			);
+
+			n = 5;
+			
+			lastf = "";
+
+    </script>
+		
+    <script id="csdraw" type="text/x-cindyscript">
+		if(Input.text!=lastf & Input.text!="", 
+			parse("f(z) :=" + Input.text);
+			lastf = Input.text;
+		);
+	
+		
+		factorial(n) := if(n==0, 1, n*factorial(n-1));
+		
+		coeff = autodiff(f(z), [complex(A)], n)_1;
+		forall(0..n, k, coeff_(k+1)=coeff_(k+1)/factorial(k));
+		
+		t(z) := coeff*apply(0..n, k, (z-complex(A))^k);
+		
+
+    colorplot(
+			z = complex(#);
+			color(t(z));
+			,
+			(-2,-2),(2,2)
+		);
+		
+		colorplot(
+			z = complex(#)+4;
+			color(f(z));
+			,
+			(-6,-2),(-2,2)
+		);
+		
+		drawtext((-5.9,1.7), "$f(z) =$");
+		
+		drawtext((-1.7,1.7), "$\sum_{k=0}^{"+n+"} \frac{f^{(k)}(a)}{k!} (z-a)^k$");
+		
+		draw((1.8,-1.8),(1.8,1.8), color->[0,0,0]);
+		N.x = 1.8;
+		n = round(5*(N.y+1.8));
+		n = max(1, n);
+		N.y = n/5-1.8;
+    </script>
+               
+
+    
+    <div  id="CSCanvas"></div>
+		
+    <script type="text/javascript">
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry: [
+											{name:"A", type:"Free", pos:[1.1, 0.1],color:[1,0,0]},
+	    								{name:"N", type:"Free", pos:[1, -.3],color:[1,1,1], size:8},
+											
+											{name: "Input", type: "EditableText", pos: [-5.2, 1.7], color: [0.0, 0.0, 0.0], fillcolor: [1.0, 0.784, 0.0], fillalpha: 0.5, minwidth: 123, text: "1/(z^2+1)"},										
+											{name: "sqrt", type: "Button", pos: [-3.8, 1.7], color: [0.0, 0.0, 0.0], text: "z^(1/2)", align: "left", alpha: 0.5, script: 'Input.text = "z^(1/2)"'},
+											{name: "log", type: "Button", pos: [-3, 1.7], color: [0.0, 0.0, 0.0], text: "log(z)", align: "left", script: 'Input.text = "log(z)"'},
+										],
+                    animation: {autoplay: true},
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 800,
+                      height: 400,
+                      transform: [ { visibleRect: [-6,-2, 2, 2] } ]
+                    }],
+										use: ["CindyGL", "katex"]
+                  });
+    </script>              
+	</body>
+</html>

--- a/plugins/cindygl/src/js/General.js
+++ b/plugins/cindygl/src/js/General.js
@@ -140,6 +140,7 @@ function guessTypeOfValue(tval) {
             for (let i = 1; i < l.length; i++) {
                 ctype = lca(ctype, guessTypeOfValue(l[i]));
             }
+            if (isprimitive(ctype)) ctype = lca(ctype, type.float); // we do not have vectors of bool/float
             if (ctype) return {
                 type: 'list',
                 length: l.length,
@@ -159,7 +160,7 @@ var helpercnt = 0;
 
 function generateUniqueHelperString() {
     helpercnt++;
-    return `_helper${helpercnt}`;
+    return `_h${helpercnt}`;
 }
 
 function enlargeCanvasIfRequired(sizeX, sizeY) {

--- a/plugins/cindygl/src/js/LinearAlgebra.js
+++ b/plugins/cindygl/src/js/LinearAlgebra.js
@@ -20,24 +20,17 @@ let computeidx = (k, n) => {
 function genchilds(t) {
     let fp = finalparameter(t);
     let d = depth(t);
-    if (fp === type.complex) {
-        let rt = replaceCbyR(t);
-        return (d === 0 ? ["x", "y"] : ["real", "imag"]).map(name => ({
-            type: rt,
-            name: name
+
+    if (d == 1 && issubtypeof(fp, type.float)) {
+        return sizes(t.length).map((k, i) => ({
+            type: type.vec(k),
+            name: `a${i}`
         }));
-    } else if (issubtypeof(fp, type.float)) {
-        if (d == 1) {
-            return sizes(t.length).map((k, i) => ({
-                type: type.vec(k),
-                name: `a${i}`
-            }));
-        } else if (d => 2) {
-            return range(t.length).map(i => ({
-                type: t.parameters,
-                name: `a${i}`
-            }));
-        }
+    } else if (d >= 1) {
+        return range(t.length).map(i => ({
+            type: t.parameters,
+            name: `a${i}`
+        }));
     }
     return [];
 }
@@ -56,46 +49,58 @@ function generatematmult(t, modifs, codebuilder) {
   if(isnativeglsl(t)) return;
   let n = t.length;
   let m = t.parameters.length;
-    createstruct(type.vec(m), codebuilder);
-    createstruct(type.vec(n), codebuilder);
-    createstruct(t, codebuilder);
     let name = `mult${n}_${m}`;
     codebuilder.add('functions', name, () =>  `vec${n} mult${n}_${m}(mat${n}_${m} a, vec${m} b){` +
         'return ' + usevec(n)(range(n).map(k => usedot(m)([`a.a${k}`, 'b'], modifs, codebuilder)), modifs, codebuilder) + ';' +
         '}');
 }
 
+function generatesum(t, modifs, codebuilder) {
+  if(isnativeglsl(t)) return;
+  let n = t.length;
+    let name = `sum${webgltype(t)}`;
+        
+    codebuilder.add('functions', name, () =>  `${webgltype(t.parameters)} ${name}(${webgltype(t)} a){` +
+      `${webgltype(t.parameters)} res = ${constantreallist(t.parameters, 0)([],modifs,codebuilder)};
+      ${
+        range(n).map(k =>
+          useadd(t.parameters)(['res',
+          accesslist(t, k)(['a',k], modifs, codebuilder)
+        ],modifs,codebuilder)
+        ).join('\n')
+      }
+        return res;
+    }`);
+}
+
 function generatecmatmult(t, modifs, codebuilder) {
   let n = t.length;
   let m = t.parameters.length;
-    createstruct(type.vec(m), codebuilder);
-    createstruct(type.vec(n), codebuilder);
-    createstruct(t, codebuilder);
-    let rt = replaceCbyR(t);
-    let name = `cmult${n}_${m}`;
-    //(A.real+i*A.imag)*(b.real+i*b.imag) = (A.real*b.real - A.imag*b.imag) + i *(A.real*b.imag+A.imag*b.real)
-    // from measurements it turend that this is the fastest for 2x2 matrices (better than component wise complex multiplication or using [[a, -b], [b, a]] submatrices)
-    codebuilder.add('functions', name, () =>  `cvec${n} cmult${n}_${m}(cmat${n}_${m} a, cvec${m} b){
-      return cvec${n}(${
-        usesub(rt.parameters)([
-          usemult(rt)(['a.real','b.real'], modifs, codebuilder),
-          usemult(rt)(['a.imag','b.imag'], modifs, codebuilder)
-        ], modifs, codebuilder)
-      },${
-        useadd(rt.parameters)([
-          usemult(rt)(['a.real','b.imag'], modifs, codebuilder),
-          usemult(rt)(['a.imag','b.real'], modifs, codebuilder)
-        ], modifs, codebuilder)
-      });
-    }`);
+    let name = `multc${n}_${m}`;
+    codebuilder.add('functions', name, () =>  `cvec${n} multc${n}_${m}(cmat${n}_${m} a, cvec${m} b){
+        return cvec${n}(${
+          range(n).map(k => usecdot(m)([`a.a${k}`, 'b'], modifs, codebuilder))
+        });
+    }
+    `);
 }
 
 function generatedot(n, codebuilder) {
     if((2 <= n && n<=4)) return;
-    createstruct(type.vec(n), codebuilder);
     let name = `dot${n}`;
     codebuilder.add('functions', name, () =>  `float dot${n}(vec${n} a, vec${n} b) {
-    return ${ sizes(n).map((size, k) => `dot(a.a${k},b.a${k})`).join('+')}; }`);
+    return ${ sizes(n).map((size, k) => `dot(a.a${k},b.a${k})`).join('+')}; }
+    `);
+}
+
+function generatecdot(n, modifs, codebuilder) {
+    let name = `cdot${n}`; //TODO: do hardware tricks for accelleration
+    codebuilder.add('functions', name, () =>  `vec2 cdot${n}(cvec${n} a, cvec${n} b) {
+      return ${
+        range(n).map(k => `vec2(dot(a.a${k},vec2(b.a${k}.x,-b.a${k}.y)), dot(a.a${k},b.a${k}.yx))`).join('+\n')
+      };
+    }
+    `);
 }
 
 function generateadd(t, modifs, codebuilder) {
@@ -104,9 +109,9 @@ function generateadd(t, modifs, codebuilder) {
     return ${webgltype(t)}(${
         genchilds(t).map(ch => `${webgltype(ch.type)}(${
           useadd(ch.type)([`a.${ch.name}`,`b.${ch.name}`], modifs, codebuilder)
-        })`).join(',')
-      });
-    }`);
+        })`).join(',')});
+      }`
+    );
 }
 
 function generatesub(t, modifs, codebuilder) {
@@ -132,35 +137,33 @@ function generatescalarmult(t, modifs, codebuilder) {
 }
 
 function generatecscalarmult(t, modifs, codebuilder) {
+    includefunction('multc', modifs, codebuilder);
     let name = `cscalarmult${webgltype(t)}`;
-    let rt = replaceCbyR(t);
-
     codebuilder.add('functions', name, () =>  `${webgltype(t)} ${name}(vec2 a, ${webgltype(t)} b) {
     return ${webgltype(t)}(${
-      usesub(rt)([
-        usescalarmult(rt)(['a.x','b.real'], modifs, codebuilder),
-        usescalarmult(rt)(['a.y','b.imag'], modifs, codebuilder)
-      ], modifs, codebuilder)
-    },${
-      useadd(rt)([
-        usescalarmult(rt)(['a.x','b.imag'], modifs, codebuilder),
-        usescalarmult(rt)(['a.y','b.real'], modifs, codebuilder)
-      ], modifs, codebuilder)
-    });}`);
+          genchilds(t).map(ch => `${
+            usecscalarmult(ch.type)([`a`,`b.${ch.name}`], modifs, codebuilder)
+          }`).join(',')
+        });
+    }`);
 }
 
 function usemult(t) {
+  if(t === type.complex) return useincludefunction('multc');
   if (isnativeglsl(t)) return useinfix('*');
   let fp = finalparameter(t);
   if(issubtypeof(fp, type.float))
     return (args, modifs, codebuilder) => generatematmult(t, modifs, codebuilder) || `mult${t.length}_${t.parameters.length}(${args.join(',')})`;
   else if(fp === type.complex)
-    return (args, modifs, codebuilder) => generatecmatmult(t, modifs, codebuilder) || `cmult${t.length}_${t.parameters.length}(${args.join(',')})`;
-  
+    return (args, modifs, codebuilder) => generatecmatmult(t, modifs, codebuilder) || `multc${t.length}_${t.parameters.length}(${args.join(',')})`;
 }
 
 function usedot(n) {
   return (args, modifs, codebuilder) => generatedot(n, codebuilder) || `dot${(2 <= n && n<=4) ? '' : n}(${args.join(',')})`;
+}
+
+function usecdot(n) {
+  return (args, modifs, codebuilder) => generatecdot(n, modifs, codebuilder) || `cdot${n}(${args.join(',')})`;
 }
 
 function useadd(t) {
@@ -172,45 +175,62 @@ function usesub(t) {
   if(isnativeglsl(t)) return useinfix('-');
   else return (args, modifs, codebuilder) => generatesub(t, modifs, codebuilder) || `sub${webgltype(t)}(${args.join(',')})`;
 }
+
+function usesum(t) {
+  if(isrvectorspace(t) && depth(t)==1) return (args, modifs, codebuilder) => usedot(t.length)(
+    [args[0], usevec(t.length)(Array(t.length).fill('1.'), modifs, codebuilder)], modifs, codebuilder);
+  else return (args, modifs, codebuilder) => generatesum(t, modifs, codebuilder) || `sum${webgltype(t)}(${args.join(',')})`;
+}
   
 function usevec(n) {
     if(2 <= n && n <= 4) return args => `vec${n}(${args.join(',')})`;
+    if(n == 1) return args => `float(${args.join(',')})`;
     let cum = 0;
-    return (args, modifs, codebuilder) => createstruct(type.vec(n), codebuilder) ||
-        `vec${n}(${
+    return (args, modifs, codebuilder) => createstruct(type.vec(n), codebuilder) || `vec${n}(${
         sizes(n).map( s =>
           `vec${s}(${range(s).map(l => ++cum && args[cum-1]).join(',')})`
         ).join(',')
       })`;
 }
 
-function usemat(n, m) { //create a nxm matrix by given n row-vectors of length m
-    if(n == m && 2 <= n && n <= 4) //transpose by hand as it is not supported in WebGL
-      return args => `mat${n}(${range(n).map(k => `vec${n}(${ //col k
-      range(n).map(i => `${args[i]}[${k}]`).join(',') 
-    })`).join(',')}`;
-    let cum = 0;
-    return (args, modifs, codebuilder) => createstruct(list(n, type.vec(m)), codebuilder) ||
-      `cmat${n}_${m}(${
-          args.join(',')
-      })`;
+function uselist(t) {
+  let d = depth(t);
+  if(isnativeglsl(t)) {
+    if(d==2) {
+       let n = t.length, m = t.parameters.length;
+      if(n == m && 2 <= n && n <= 4) //transpose by hand as it is not supported in WebGL
+        return args => `mat${n}(${range(n).map(k => `vec${n}(${ //col k
+          range(n).map(i => `${args[i]}[${k}]`).join(',') 
+        })`).join(',')}`;
+      }
+    return (args, modifs, codebuilder) => `${webgltype(t)}(${args.join(',')})`;
+  }
+  if(d == 1 && isrvectorspace(t)) return usevec(t.length);  
+  return (args, modifs, codebuilder) => createstruct(t, codebuilder) ||  `${webgltype(t)}(${args.join(',')})`;
 }
 
-function usecvec(n) {
-    return (args, modifs, codebuilder) => createstruct(type.cvec(n), codebuilder) ||
-        `cvec${n}(${
-          usevec(n)(args.map(a => `(${a}).x`), modifs, codebuilder)
-        },${
-          usevec(n)(args.map(a => `(${a}).y`), modifs, codebuilder)
-        })`;
+function accesslist(t, k) {
+  let d = depth(t);
+  if(d==1 && isrvectorspace(t)) {
+    return accessvecbyshifted(t.length, k);
+  }
+  return (args, modifs, codebuilder) => `(${args[0]}).a${k}`;
 }
 
+/** creates a reallist of type t that has everywhere value val */
+function constantreallist(t, val) {
+  if(isnativeglsl(t))
+    return (args, modifs, codebuilder) => `${webgltype(t)}(float(${val}))`;
+  else
+    return (args, modifs, codebuilder) => `${uselist(t)}(${
+      genchilds(t).map(ch => constantreallist(ch.type, val)(args, modifs, codebuilder)).join(',')
+    })`;
+}
 
 function accessvecbyshifted(n, k) {
   return (args, modifs, codebuilder) => { //works only for hardcoded glsl
-      createstruct(type.vec(n), codebuilder);
-      //let k = Number(args[1]) - 1;
-      //console.log(`k = ${k};`);
+      if(n == 1)
+          return `(${args[0]})`;
       if(2 <= n && n <= 4)
           return `(${args[0]})[${k}]`;
       let idx = computeidx(k, n);
@@ -228,11 +248,12 @@ function accesscvecbyshifted(n, k) {
   };
 }
 
-function usescalarmult(t) { //assume t is a R or C-vectorspace
+function usescalarmult(t) { //assume t is a R or C-vectorspace, multiply with real number
   if(isnativeglsl(t)) return useinfix('*');
   return (args, modifs, codebuilder) => generatescalarmult(t,modifs, codebuilder) || `scalarmult${webgltype(t)}(${args.join(',')})`;
 }
 
-function usecscalarmult(t) { //assume t is a C-vectorspace
+function usecscalarmult(t) { //assume t is a R or C-vectorspace, multiply with complex number
+  if(t === type.complex) return useincludefunction('multc');
   return (args, modifs, codebuilder) => generatecscalarmult(t,modifs, codebuilder) || `cscalarmult${webgltype(t)}(${args.join(',')})`;
 }

--- a/plugins/cindygl/src/js/Renderer.js
+++ b/plugins/cindygl/src/js/Renderer.js
@@ -130,7 +130,7 @@ Renderer.prototype.setTransformMatrix = function(a, b, c) {
 
 
 Renderer.prototype.setUniforms = function() {
-    function setUniform(setter, t, val, part = 'real') {
+    function setUniform(setter, t, val) {
         if (!setter) return; //skip inactive uniforms
 
         if (typeof(setter) === 'function') {
@@ -146,17 +146,17 @@ Renderer.prototype.setUniforms = function() {
                     break;
                 case type.int:
                 case type.float:
-                    setter([val['value'][part]]);
+                    setter([val['value']['real']]);
                     break;
                 default:
                     if (t.type === 'list' && issubtypeof(t.parameters, type.float)) { //float-list
-                        setter(val['value'].map(x => x['value'][part]));
+                        setter(val['value'].map(x => x['value']['real']));
                         break;
                     } else if (t.type === 'list' && t.parameters.type === 'list' && issubtypeof(t.parameters.parameters, type.float)) { //float matrix
                         //probably: if isnativeglsl?
                         let m = [];
                         for (let i = 0; i < t.parameters.length; i++)
-                            for (let j = 0; j < t.length; j++) m.push(val['value'][j]['value'][i]['value'][part]);
+                            for (let j = 0; j < t.length; j++) m.push(val['value'][j]['value'][i]['value']['real']);
                         setter(m);
                         break;
                     }
@@ -164,44 +164,36 @@ Renderer.prototype.setUniforms = function() {
                     console.error(`Don't know how to set uniform of type ${typeToString(t)}, to ${val}`);
                     break;
             }
-        } else {
-            if (isrvectorspace(t)) {
-                let d = depth(t);
-                if (d === 1) {
-                    let n = t.length;
-                    let s = sizes(n);
+        } else if (t.type === 'list') {
 
-                    let cum = 0;
-                    for (let k in s) {
-                        setUniform(setter[`a${k}`], type.vec(s[k]), {
-                            'ctype': 'list',
-                            'value': range(s[k]).map(l => val['value'][cum + l])
-                        });
-                        cum += s[k];
-                    }
-                    return;
-                } else if (d >= 2) {
-                    for (let k = 0; k < t.length; k++) {
-                        setUniform(setter[`a${k}`], t.parameters, {
-                            'ctype': 'list',
-                            'value': val['value'][k]['value']
-                        });
-                    }
-                    return;
+            let d = depth(t);
+            if (d === 1 && isrvectorspace(t)) {
+                let n = t.length;
+                let s = sizes(n);
+
+                let cum = 0;
+                for (let k in s) {
+                    setUniform(setter[`a${k}`], type.vec(s[k]), {
+                        'ctype': 'list',
+                        'value': range(s[k]).map(l => val['value'][cum + l])
+                    });
+                    cum += s[k];
                 }
-            } else if (iscvectorspace(t)) {
-                let converttofloat = t => issubtypeof(t, type.complex) ? type.float : list(t.length, converttofloat(t.parameters));
-                let st = converttofloat(t);
-
-                setUniform(setter['real'], st, val, part = 'real');
-                setUniform(setter['imag'], st, val, part = 'imag');
                 return;
             }
-
+            for (let k = 0; k < t.length; k++) {
+                setUniform(setter[`a${k}`], t.parameters, {
+                    'ctype': 'list',
+                    'value': val['value'][k]['value']
+                });
+            }
+            return;
+        } else {
             console.error(`Don't know how to set uniform of type ${typeToString(t)}, to`);
             console.log(val);
         }
     }
+
 
     for (let uname in this.cpguniforms) {
 

--- a/plugins/cindygl/src/str/divc.glsl
+++ b/plugins/cindygl/src/str/divc.glsl
@@ -1,3 +1,3 @@
 vec2 divc(vec2 a, vec2 b){
-  return 1./(b.x*b.x+b.y*b.y)*multc(a,vec2(b.x,-b.y));
+  return vec2(dot(a,b), dot(a,vec2(-b.y,b.x)))/dot(b,b);
 }

--- a/plugins/cindygl/src/str/multc.glsl
+++ b/plugins/cindygl/src/str/multc.glsl
@@ -1,3 +1,3 @@
 vec2 multc(vec2 a, vec2 b){
-   return vec2(a.x*b.x-a.y*b.y+0.0000000000000001,a.y*b.x+a.x*b.y); 
+   return vec2(dot(a,vec2(b.x,-b.y)), dot(a,b.yx));
 }


### PR DESCRIPTION
With this commit apply$2 and apply$3, forall$2 and forall$3 and sum$1 is implemented within colorplot.

This commit changes the handling of complex vectors: Now it is is literally a list of complex numbers instead of having both a real vector for the real and the complex part respectively. Probably the programs making use of complex matrix-vector multiplications get a little bit more slow as internal matrix-vector products cannot be used anymore.

A set of examples has also been included.

Under the hood, the expressions within apply or forall are unrolled. This is necessary as there is no way access entries of a list generically (as they are implemented as struct)