### PR TITLE
Unwrap result from isNumberMatrix as required

### DIFF
--- a/ref/Vectors_and_Matrices.md
+++ b/ref/Vectors_and_Matrices.md
@@ -44,6 +44,15 @@ The following table summarizes the different admissible uses of the multiplicati
 | vector of length *n* | *n* × *r* matrix     | vector of length *r* | vector × matrix               |
 | *n* × *r* matrix     | *r*× *m* matrix      | *n* × *m* matrix     | matrix multiplication         |
 
+If some of the elements of a matrix are not numbers, the result will be `___`.
+
+    > [[1,2],[3,4],[5,6]] * [[1,2,3,4],[5,6,7,8]]
+    < [[11, 14, 17, 20], [23, 30, 37, 44], [35, 46, 57, 68]]
+    > [[1,2],[3,4],[5,6]] * [[1,2,3,4],[5,6,7,"8"]]
+    < ___
+    > [[1,2],[3,4],[5,false]] * [[1,2,3,4],[5,6,7,8]]
+    < ___
+
 ------
 
 ------

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -1029,7 +1029,7 @@ List.mult = function(a, b) {
         return List.productVM(a, b);
     }
 
-    if (List.isNumberMatrix(a).value && List.isNumberMatrix(b) && b.value.length === a.value[0].value.length) {
+    if (List.isNumberMatrix(a).value && List.isNumberMatrix(b).value && b.value.length === a.value[0].value.length) {
         return List.productMM(a, b);
     }
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1570,30 +1570,12 @@ evaluator.isgeometric$1 = function(args, modifs) {
 
 evaluator.isnumbermatrix$1 = function(args, modifs) {
     var v0 = evaluate(args[0]);
-    if ((List.isNumberMatrix(v0)).value) {
-        return {
-            'ctype': 'boolean',
-            'value': true
-        };
-    }
-    return {
-        'ctype': 'boolean',
-        'value': false
-    };
+    return List.isNumberMatrix(v0);
 };
 
 evaluator.isnumbervector$1 = function(args, modifs) {
     var v0 = evaluate(args[0]);
-    if ((List.isNumberVector(v0)).value) {
-        return {
-            'ctype': 'boolean',
-            'value': true
-        };
-    }
-    return {
-        'ctype': 'boolean',
-        'value': false
-    };
+    return List.isNumberVector(v0);
 };
 
 
@@ -2414,7 +2396,7 @@ function hungarianMethod(w) {
 
 evaluator.mincostmatching$1 = function(args, modifs) {
     var costMatrix = evaluate(args[0]);
-    if (List.isNumberMatrix(costMatrix)) {
+    if (List.isNumberMatrix(costMatrix).value) {
         var nr = costMatrix.value.length;
         var nc = List._helper.colNumb(costMatrix);
         var size = (nr < nc ? nc : nr);


### PR DESCRIPTION
I noticed that there were two occasions where the result of `isNumberMatrix` was not unwrapped, but used as a native boolean-like value. I also noticed that if the result here is wrapped, we can avoid unwrapping and re-wrapping it in the corresponding CindyScript operators.

Personally I think that using these wrapped types for internal interfaces should be avoided in all cases where a corresponding native type exists. But doing that consistently would affect many more functions, so it should be discussed in some meeting before making any changes.