### PR TITLE
De-randomize ConicBy2Foci1P, implement ConicBy2Foci1L

### DIFF
--- a/examples/156_Conic_by_2Foci_1L.html
+++ b/examples/156_Conic_by_2Foci_1L.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>conic by 2 foci and 1 line</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+
+// Initialization code, executed once up front.
+
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+
+// Drawing code, executed whenever the canvas gets redrawn.
+
+</script>
+
+<script type="text/javascript">
+
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
+  canvasname: "CSCanvas",
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+    // See GeoBasics.js for possible attributes.
+  },
+  geometry: [
+    {name:"F1", type:"Free", pos:[-3,0]},
+    {name:"F2", type:"Free", pos:[3,0]},
+    {name:"l", type:"FreeLine", pos:[-0.28888888888888886,-0.8555555555555555,4.0], color:[1,0,0]},
+
+    {name: "C0", type:"ConicBy2Foci1L", args: ["F1","F2","l"]}
+    // For allowed types, see GeoOps.js.
+    // For allowed properties, see csinit in GeoBasics.js.
+  ] // End of geometry array.
+});
+
+// Remove all comments after adjusting this template for your use case.
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="width:500px; height:500px; border:2px solid black"></div>
+</body>
+
+</html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1319,33 +1319,33 @@ geoOps.ConicBy2Foci1P.updatePosition = function(el) {
     var F2 = csgeo.csnames[(el.args[1])].homog;
     var PP = csgeo.csnames[(el.args[2])].homog;
 
-    // i and j
-    var II = List.ii;
-    var JJ = List.jj;
+    var sp = List.scalproduct;
+    var cross = List.cross;
+    var linfty = List.linfty;
+    var mat = List.turnIntoCSList;
 
-    var b1 = List.normalizeMax(List.cross(F1, PP));
-    var b2 = List.normalizeMax(List.cross(F2, PP));
-    var a1 = List.normalizeMax(List.cross(PP, II));
-    var a2 = List.normalizeMax(List.cross(PP, JJ));
-
-    var har = geoOps._helper.coHarmonic(a1, a2, b1, b2);
-    var e1 = List.normalizeMax(har[0]);
-    var e2 = List.normalizeMax(har[1]);
-
-    // lists for transposed
-    var lII = List.turnIntoCSList([II]);
-    var lJJ = List.turnIntoCSList([JJ]);
-    var lF1 = List.turnIntoCSList([F1]);
-    var lF2 = List.turnIntoCSList([F2]);
-
-    var co1 = geoOps._helper.conicFromTwoDegenerates(lII, lJJ, lF1, lF2, e1);
-    co1 = List.normalizeMax(co1);
-    var co2 = geoOps._helper.conicFromTwoDegenerates(lII, lJJ, lF1, lF2, e2);
-    co2 = List.normalizeMax(co2);
+    var a = cross(cross(linfty, cross(F1, PP)), linfty);
+    var b = cross(cross(linfty, cross(F2, PP)), linfty);
+    var z = sp(linfty, PP);
+    var m = List.productMM(List.transpose(mat([F1])), mat([F2]));
+    var w = List.scalmult(CSNumber.mult(z, z), List.add(List.transpose(m), m));
+    var ab = sp(a, b);
+    var r = CSNumber.sqrt(CSNumber.mult(sp(a, a), sp(b, b)));
+    var zero = CSNumber.zero;
 
     // adjoint
-    co1 = List.normalizeMax(List.adjoint3(co1));
-    co2 = List.normalizeMax(List.adjoint3(co2));
+    var s = CSNumber.add(ab, r);
+    var co1 = List.normalizeMax(List.adjoint3(List.sub(w, List.matrix([
+        [s, zero, zero],
+        [zero, s, zero],
+        [zero, zero, zero]
+    ]))));
+    s = CSNumber.sub(ab, r);
+    var co2 = List.normalizeMax(List.adjoint3(List.sub(w, List.matrix([
+        [s, zero, zero],
+        [zero, s, zero],
+        [zero, zero, zero]
+    ]))));
 
     // return ellipsoid first 
     if (geoOps._helper.getConicType(co1) !== "ellipsoid") {

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1304,9 +1304,13 @@ geoOps.ConicBy2Foci1L.updatePosition = function(el) {
     var m = List.productMM(List.transpose(mat([F1])), mat([F2]));
     var s = CSNumber.realmult(2, CSNumber.mult(sp(F1, l), sp(F2, l)));
     var zero = CSNumber.zero;
-    var matrix = List.sub(List.scalmult(sp(dir, dir),
-        List.add(List.transpose(m), m)),
-        List.matrix([[s, zero, zero], [zero, s, zero], [zero, zero, zero]]));
+    var matrix = List.sub(
+        List.scalmult(sp(dir, dir), List.add(List.transpose(m), m)),
+        List.matrix([
+            [s, zero, zero],
+            [zero, s, zero],
+            [zero, zero, zero]
+        ]));
     matrix = List.normalizeMax(List.adjoint3(matrix));
     el.matrix = General.withUsage(matrix, "Conic");
 };

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1289,6 +1289,28 @@ geoOps.ConicParabolaPL.updatePosition = function(el) {
     el.matrix = General.withUsage(m, "Conic");
 };
 
+geoOps.ConicBy2Foci1L = {};
+geoOps.ConicBy2Foci1L.kind = "C";
+geoOps.ConicBy2Foci1L.signature = ["P", "P", "L"];
+geoOps.ConicBy2Foci1L.updatePosition = function(el) {
+    var F1 = csgeo.csnames[(el.args[0])].homog;
+    var F2 = csgeo.csnames[(el.args[1])].homog;
+    var l = csgeo.csnames[(el.args[2])].homog;
+
+    var sp = List.scalproduct;
+    var mat = List.turnIntoCSList;
+
+    var dir = List.cross(List.cross(List.linfty, l), List.linfty);
+    var m = List.productMM(List.transpose(mat([F1])), mat([F2]));
+    var s = CSNumber.realmult(2, CSNumber.mult(sp(F1, l), sp(F2, l)));
+    var zero = CSNumber.zero;
+    var matrix = List.sub(List.scalmult(sp(dir, dir),
+        List.add(List.transpose(m), m)),
+        List.matrix([[s, zero, zero], [zero, s, zero], [zero, zero, zero]]));
+    matrix = List.normalizeMax(List.adjoint3(matrix));
+    el.matrix = General.withUsage(matrix, "Conic");
+};
+
 geoOps.ConicBy2Foci1P = {};
 geoOps.ConicBy2Foci1P.kind = "Cs";
 geoOps.ConicBy2Foci1P.signature = ["P", "P", "P"];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -1519,26 +1519,6 @@ geoOps.ConicBy1Pol3L.updatePosition = function(el) {
     el.matrix = M;
 };
 
-geoOps._helper.coHarmonic = function(a1, a2, b1, b2) {
-    var poi = List.realVector([100 * Math.random(), 100 * Math.random(), 1]);
-
-    var ix = List.det3(poi, b1, a1);
-    var jx = List.det3(poi, b1, a2);
-    var iy = List.det3(poi, b2, a1);
-    var jy = List.det3(poi, b2, a2);
-
-    var sqj = CSNumber.sqrt(CSNumber.mult(jy, jx));
-    var sqi = CSNumber.sqrt(CSNumber.mult(iy, ix));
-
-    var mui = General.mult(a1, sqj);
-    var tauj = General.mult(a2, sqi);
-
-    var out1 = List.add(mui, tauj);
-    var out2 = List.sub(mui, tauj);
-
-    return [out1, out2];
-};
-
 geoOps.ConicInSquare = {};
 geoOps.ConicInSquare.kind = "C";
 geoOps.ConicInSquare.signature = ["P", "P", "P", "P"];


### PR DESCRIPTION
These changes implement `geoOps.ConicBy2Foci1L` which complements `geoOps.ConicBy2Foci1P` by providing a way to define a single conic given two focal points and a tangent line. `geoOps.ConicBy2Foci1P` is improved by removing calls to `Math.random()` and avoidable polynomial factors  (see #135).

For the de-randomization of ConicBy2Foci1P, initially this code involving `geoOps._helper.coHarmonic` shown here:
```JavaScript
    var b1 = List.normalizeMax(List.cross(F1, PP));
    var b2 = List.normalizeMax(List.cross(F2, PP));
    var a1 = List.normalizeMax(List.cross(PP, II));
    var a2 = List.normalizeMax(List.cross(PP, JJ));

    var har = geoOps._helper.coHarmonic(a1, a2, b1, b2);
    var e1 = List.normalizeMax(har[0]);
    var e2 = List.normalizeMax(har[1]);
```
was replaced with this simplified result (a1 & a2 were kept):
```JavaScript
    var sp = List.scalproduct;
    var a1 = List.cross(PP, II);
    var a2 = List.cross(PP, JJ);
    var i = CSNumber.sqrt(CSNumber.mult(sp(a1, F1), sp(a1, F2)));
    var j = CSNumber.sqrt(CSNumber.mult(sp(a2, F1), sp(a2, F2)));
    var a1j = List.scalmult(j, a1);
    var a2i = List.scalmult(i, a2);
    var e1 = List.add(a1j, a2i);
    var e2 = List.sub(a1j, a2i);
```
This led to the discovery of avoidable polynomial factors of the conic matrices. So the calls to `geoOps._helper.conicFromTwoDegenerates` had to be replaced. Later, during the simplification of the implementation of `geoOps.ConicBy2Foci1L` a pattern was seen which led to the simplification of the code for `geoOps.ConicBy2Foci1P`. Since `List.adjoint3` did not add any avoidable polynomial factors, that simplification is made to its input matrix.
