### PR TITLE
CindyGL: Unroll some loops at compile time

### DIFF
--- a/examples/cindygl/37_matrixtest.html
+++ b/examples/cindygl/37_matrixtest.html
@@ -14,7 +14,7 @@
     
     
     <script id="csmove" type="text/x-cindyscript">
-      colorplot([[1,2,-1,-2,0,0], [-2,1,0,0,2,-1], [0,10,4,1,2,3]]*[#.x, #.y, A.x,A.y,B.x,B.y])
+      colorplot([[1,2,-1,-2,0,0], [-2,1,0,0,2,-1], [0,10,4.1,1,2,3]]*[#.x, #.y, A.x,A.y,B.x,B.y])
     </script>
                
     <script id="csinit" type="text/x-cindyscript">

--- a/examples/cindygl/43_accessarrayindex.html
+++ b/examples/cindygl/43_accessarrayindex.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Accessing array indices within loop</h1>
+		
+		<script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+    </script>
+    
+    <script id="csdraw" type="text/x-cindyscript">
+		coeff = [2 , i, -3, 2];
+		
+		p(z) := (
+			sum = 0;
+			repeat(4,
+				sum = sum + (coeff_#) * z^(#-1)
+			);
+			sum
+		);
+		
+		colorplot(
+    	hue(im(log(p(complex(#))))/2/pi);
+		);
+    </script>
+
+
+    <div  id="CSCanvas"></div>
+    
+    <script type="text/javascript">
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:[],
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 500,
+                      height: 500,
+                      transform: [ { visibleRect: [-10,-10,10,10] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/43_accessarrayindex_forall.html
+++ b/examples/cindygl/43_accessarrayindex_forall.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Accessing array indices within loop</h1>
+		
+		<script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+    </script>
+    
+    <script id="csdraw" type="text/x-cindyscript">
+		coeff = [2 , i, -3, 2];
+		
+		p(z) := (
+			sum = 0;
+			forall(0..3,
+				sum = sum + coeff_(#+1) * z^#
+			);
+			sum
+		);
+		
+		colorplot(
+    	hue(im(log(p(complex(#))))/2/pi);
+		);
+    </script>
+
+
+    <div  id="CSCanvas"></div>
+    
+    <script type="text/javascript">
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:[],
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 500,
+                      height: 500,
+                      transform: [ { visibleRect: [-10,-10,10,10] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/43_accessarrayindex_repeat.html
+++ b/examples/cindygl/43_accessarrayindex_repeat.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Accessing array indices within loop</h1>
+		
+		<script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+    </script>
+    
+    <script id="csdraw" type="text/x-cindyscript">
+		coeff = [2 , i, -3, 2];
+		
+		p(z) := (
+			sum = 0;
+			repeat(4,
+				sum = sum + (coeff_#) * z^(#-1)
+			);
+			sum
+		);
+		
+		colorplot(
+    	hue(im(log(p(complex(#))))/2/pi);
+		);
+    </script>
+
+
+    <div  id="CSCanvas"></div>
+    
+    <script type="text/javascript">
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:[],
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 500,
+                      height: 500,
+                      transform: [ { visibleRect: [-10,-10,10,10] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/43_accessarrayindex_sumapply.html
+++ b/examples/cindygl/43_accessarrayindex_sumapply.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: Accessing array indices within loop</h1>
+		
+		<script id="csinit" type="text/x-cindyscript">
+      use("CindyGL");
+    </script>
+    
+    <script id="csdraw" type="text/x-cindyscript">
+		coeff = [2 , i, -3, 2];
+		
+		p(z) := 
+			sum(apply(reverse(0..3),
+				coeff_(#+1) * z^(#)
+			));
+		
+		colorplot(
+    	hue(im(log(p(complex(#))))/2/pi);
+		);
+    </script>
+
+
+    <div  id="CSCanvas"></div>
+    
+    <script type="text/javascript">
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry:[],
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 500,
+                      height: 500,
+                      transform: [ { visibleRect: [-10,-10,10,10] } ]
+                    }]
+                  });
+    </script>              
+	</body>
+</html>

--- a/examples/cindygl/44_raycasting_advanced.html
+++ b/examples/cindygl/44_raycasting_advanced.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Cindy JS</title>
+    <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+    <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+    <link rel="stylesheet" href="../../css/cindy.css">
+  </head>
+    
+  <body style="font-family:Arial;">
+    
+    <h1>CindyJS: Raycasting arbitrary algebraic surfaces</h1>
+    
+    <script id="csmousedown" type="text/x-cindyscript">
+    sx = mouse().x;
+    sy = mouse().y;
+    dragging = sx < .5;
+    </script>
+    <script id="csmouseup" type="text/x-cindyscript">
+    dragging = false;
+    </script>
+    <script id="csdraw" type="text/x-cindyscript">
+    time = seconds() - t0;
+
+    if (dragging,
+        dx = 3 * (sx - mouse().x); dy = 3 * (sy - mouse().y);,
+        dx = .005 * cos(time * .1); dy = .003 * sin(time * .1);
+    );
+
+    mat = mat * (
+        (1, 0, 0),
+        (0, cos(dy), -sin(dy)),
+        (0, sin(dy), cos(dy))
+    ) * (
+        (cos(dx), 0, -sin(dx)),
+        (0, 1, 0),
+        (sin(dx), 0, cos(dx))
+    );
+
+
+    sx = mouse().x;
+    sy = mouse().y;
+
+
+    PA.x = 0.55;
+    if (PA.y > .4, PA.y = .4);
+    if (PA.y < -.4, PA.y = -.4);
+    a = (.4 + PA.y) / .8 * 1.1;
+
+    PB.x = 0.6;
+    if (PB.y > .4, PB.y = .4);
+    if (PB.y < -.4, PB.y = -.4);
+    alpha = ((.4 + PB.y) / .8) * .7 + .3;
+
+    PC.x = 0.65;
+    if (PC.y > .4, PC.y = .4);
+    if (PC.y < -.4, PC.y = -.4);
+    zoom = exp(3 * PC.y - 1);
+
+    lightdirs = [
+        ray((.0, .0), -100),
+        ray((.0, .0), -100),
+        ray((.0, .0), 100),
+        ray((.0, .0), 100),
+        (-10, 10, -2.),
+        (-10, 10, -2.),
+        (10, -8, 3.),
+        (10, -8, 3.)
+    ];
+
+    gamma = [1, 20, 1, 20, 1, 10, 1, 10];
+
+    colors = [
+        (.2, .4, 1.),
+        (1, 2, 2) / 2,
+        (.8, 0.3, 0),
+        (2, 2, 1) / 2,
+        .4 * (.7, .8, .3),
+        .9 * (.7, .8, .3),
+        .4 * (.6, .1, .6),
+        .9 * (.6, .1, .6)
+    ];
+
+
+    colorplot(computeColor(#));
+    drawtext((-.65, -.45), "degree: " + ( N-1));
+
+    draw((.55, .4), (.55, -.4), color -> (0, 0, 0));
+    draw((.6, .4), (.6, -.4), color -> (0, 0, 0));
+    draw((.65, .4), (.65, -.4), color -> (0, 0, 0));
+    </script>
+               
+    <script id="csinit" type="text/x-cindyscript">
+    mat = [
+        [0.3513, -0.4908, -0.7973],
+        [-0.8171, -0.5765, -0.0051],
+        [-0.4571, 0.6533, -0.6036]
+    ];
+    sx = mouse().x;
+    sy = mouse().y;
+    dragging = false;
+
+    use("CindyGL");
+    oo = 1000; //"infinity"
+    t0 = seconds();
+
+
+    ray(pos, t) := mat * ((t + 2.2) * (pos.x, pos.y, 1) + (0, 0, -2.2));
+
+    fun(x, y, z) := (x ^ 2 + y ^ 2 + z ^ 2 - (0.5 + a) ^ 2) ^ 2 - (3.0 * ((0.5 + a) ^ 2) - 1.0) / (3.0 - ((0.5 + a) ^ 2)) * (1 - z - sqrt(2) * x) * (1 - z + sqrt(2) * x) * (1 + z + sqrt(2) * y) * (1 + z - sqrt(2) * y);
+    N = 5;
+    zoom = 2.2;
+    a = 0.3;
+
+    errc(N);
+
+    eps = .04;
+
+    alpha = .7;
+
+
+    F(p) := (
+        fun(p.x / zoom, p.y / zoom, p.z / zoom);
+    );
+
+    guessdeg() := max(apply(1 .. 10,
+        x = [random(), random(), random()]; r = [random(), random(), random()]; v = [F(x)];
+        while ( | v_(-1) | > .01 & length(v) < 100,
+            x = x + r; nv = [F(x)]++v; forall(2..length(nv),
+                nv_# = nv_(#-1) - v_(#-1);
+            ); v = nv;
+        ); length(v) - 2
+    ));
+
+
+    init() := (
+        N = guessdeg() + 1; errc(N); li = apply(1..N, k, cos((2 * k - 1) / (2 * N) * pi)); //Chebyshev nodes for interval (-1, 1)
+        //li = apply(1..N, (#-1)/(N-1)*2-1);
+        A = apply(li, c, apply(0.. N-1, i, c ^ i));
+        // A sends polynomials [a0, a1, a2...] = a0+a1*X+a2*X*X+... to [p(li_1), p(li_2), ...]
+        B = (inverse(A)); //B interpolates polynomials, given the values [p(li_1), p(li_2), ...]
+        B3 = inverse(apply([-2, 0, 2], c, apply(0 .. 2, i, c ^ i))); //B3 interpolates quadratic polynomials, given the values [p(-1), p(0), p(1)]
+    );
+    init();
+
+    dF(p) := (
+        (F(p + [eps, 0, 0]) - F(p - [eps, 0, 0])),
+        (F(p + [0, eps, 0]) - F(p - [0, eps, 0])),
+        (F(p + [0, 0, eps]) - F(p - [0, 0, eps]))
+    ) / (2 * eps);
+
+
+    S(r) := (r * r - 1); //sphere with radius 1
+
+    eval(poly, t) := ( //evals poly at time t by evaluating horner scheme         
+        ans = poly_N; forall(reverse(1 .. N-1), ans = ans * t + poly_#); ans
+    );
+
+    //computes derivative of polynomial
+    d(poly) := (forall(1 .. N-1, poly_# = # * poly_(#+1)); poly_N = 0; poly);
+
+    //finds root of poly in [x0, x1] using bisection.
+    //returns def if intermediate value theorem cannot be applied
+    bisect(poly, x0, x1, def) := (
+        regional(v0, v1, m, vm); v0 = eval(poly, x0); v1 = eval(poly, x1);
+        if (v0 * v1 <= 0,
+            repeat(10,
+                m = (x0 + x1) / 2; vm = eval(poly, m);
+                if (v0 * vm <= 0,
+                    (x1 = m; v1 = vm;),
+                    (x0 = m; v0 = vm;)
+                );
+            ); m,
+            def
+        )
+    );
+
+    bisectf(pos, x0, x1, def) := (
+        regional(v0, v1, m, vm); v0 = F(ray(pos, x0)); v1 = F(ray(pos, x1));
+        if (v0 * v1 <= 0,
+            repeat(12,
+                m = (x0 + x1) / 2; vm = F(ray(pos, m));
+                if (v0 * vm <= 0,
+                    (x1 = m; v1 = vm;),
+                    (x0 = m; v0 = vm;)
+                );
+            ); m,
+            def
+        )
+    );
+
+
+    computeColor(pos) := (
+        spolyvalues = apply([-2, 0, 2], S(ray(pos, #))); spoly = B3 * spolyvalues; // interpolate
+
+        D = (spoly_2 * spoly_2) - 4. * spoly_3 * spoly_1; //discriminant of spoly
+        color = gray(.7);
+
+
+        if (D >= 0, //ray intersects ball
+            polyvalues = apply(li, F(ray(pos, #))); poly = B * polyvalues; //interpolate
+            l = (-spoly_2 - re(sqrt(D))) / (2. * spoly_3); //intersection entering the ballu
+            u = (-spoly_2 + re(sqrt(D))) / (2. * spoly_3); //intersection leaving the ball
+
+            p = apply(1..N, poly); forall(reverse(1.. N-1), p_# = d(p_(#+1))); //p_k has degree k
+
+            roots = apply(1..N, u); oroots = roots; forall(1.. N-1, i,
+                roots_1 = bisect(p_i, l, oroots_1, l); forall(2.. N-1, j,
+                    roots_j = bisect(p_i, oroots_j, oroots_(j + 1), roots_(j - 1));
+                ); roots_N = bisect(p_i, oroots_N, u, roots_( N-1)); oroots = roots;
+            );
+
+
+            roots_1 = bisectf(pos, l, oroots_1, l); forall(2.. N-1, j,
+                roots_j = bisectf(pos, oroots_j, oroots_(j + 1), roots_(j - 1));
+            ); roots_N = bisectf(pos, oroots_N, u, roots_(N-1));
+
+            odst = u + 1;
+
+            forall(reverse(1..N),
+                dst = roots_#;
+                if (dst > l & dst < u & dst < odst,
+                    color = (1 - alpha) * color;
+
+                    odst = dst; x = ray(pos, dst); normal = dF(x); normal = normal / abs(normal);
+
+
+
+                    forall(1..length(lightdirs),
+                        illumination = max(0, (lightdirs_# / abs(lightdirs_#)) * normal); color = color + alpha * (illumination ^ gamma_#) * colors_#;
+                    );
+                )
+            );
+        ); color
+    );
+    </script>
+    
+
+    <div  id="CSCanvas" style="border:0px"></div>
+    
+    <script type="text/javascript">
+        var cdy = CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    animation: {autoplay: true},
+                    geometry: [ { name:"PA", kind:"P", type:"Free", pos: [.5,.4/1.1,1], narrow: true, color: [1,1,1], size:8 },
+                                { name:"PB", kind:"P", type:"Free", pos: [.5,.2,1], narrow: true, color: [1,1,1], size:8 },
+                                { name:"PC", kind:"P", type:"Free", pos: [.5,.1,1], narrow: true, color: [1,1,1], size:8 } ],
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 700,
+                      height: 500,
+                      transform: [ { visibleRect: [ -0.7, -0.5, 0.7, 0.5 ] } ]
+                    }]
+        });
+    </script>
+    
+    <div>
+<input type="text" id="inp" value="(x^2+y^2+z^2-(0.5+a)^2)^2-(3*((0.5+a)^2)-1)/(3-((0.5+a)^2))*(1-z-sqrt(2)*x)*(1-z+sqrt(2)*x)*(1+z+sqrt(2)*y)*(1+z-sqrt(2)*y)"  onkeypress="if((event.which ? event.which : event.keyCode)==13) { cdy.evokeCS('fun(x,y,z) := (' + this.value + '); init();'); }" size="80" style="font-size:18px">
+<select id="sel" onchange="document.getElementById('inp').value = this.value; cdy.evokeCS('fun(x,y,z) := (' + this.value + '); init();');" style="width:20em;">  
+  <option value="(x^2+y^2+z^2-(0.5+a)^2)^2-(3*((0.5+a)^2)-1)/(3-((0.5+a)^2))*(1-z-sqrt(2)*x)*(1-z+sqrt(2)*x)*(1+z+sqrt(2)*y)*(1+z-sqrt(2)*y)">Kummer Quartic</option>
+  <option value="4*((a*(1+sqrt(5))/2)^2*x^2-y^2)*((a*(1+sqrt(5))/2)^2*y^2-z^2)*((a*(1+sqrt(5))/2)^2*z^2-x^2)-1*(1+2*(a*(1+sqrt(5))/2))*(x^2+y^2+z^2-1)^2">Barth Sextic</option>
+  <option value="-2*a/125+x^8+y^8+z^8-2*x^6-2*y^6-2*z^6+1.25*x^4+1.25*y^4+1.25*z^4-0.25*x^2-0.25*y^2-0.25*z^2+0.03125">Chmutov Octic</option>
+  <option value="a*(-1/4*(1-sqrt(2))*(x^2+y^2)^2+(x^2+y^2)*((1-1/sqrt(2))*z^2+1/8*(2-7*sqrt(2)))-z^4+(0.5+sqrt(2))*z^2-1/16*(1-12*sqrt(2)))^2-(cos(0*pi/4)*x+sin(0*pi/4)*y-1)*(cos(pi/4)*x+sin(pi/4)*y-1)*(cos(2*pi/4)*x+sin(2*pi/4)*y-1)*(cos(3*pi/4)*x+sin(3*pi/4)*y-1)*(cos(4*pi/4)*x+sin(4*pi/4)*y-1)*(cos(5*pi/4)*x+sin(5*pi/4)*y-1)*(cos(6*pi/4)*x+sin(6*pi/4)*y-1)*(cos(7*pi/4)*x+sin(7*pi/4)*y-1)">
+    Endraß Octic
+  </option>
+  <option value="x^2+y^2+z^2-1">Ball</option>
+  <option value="x^2+z^2-1/3*(1+y)^3*(1-y)^3">Citric</option>
+  <option value="x^2+y^2+z^3-z^2">Ding Dong</option>
+  <option value="x^3+x^2*z^2-y^2">Hummingbird</option>
+  <option value="x^2-x^3+y^2+y^4+z^3-z^4">Vis a Vis</option>
+  <option value="(x^2+9/4*y^2+z^2-1)^3-x^2*z^3-9/80*y^2*z^3">Sweet</option>
+</select>
+</div>
+    Internally, Rolle's theorem and bisection method is used for finding roots.
+  </body>
+</html>

--- a/plugins/cindygl/src/js/General.js
+++ b/plugins/cindygl/src/js/General.js
@@ -140,7 +140,6 @@ function guessTypeOfValue(tval) {
             for (let i = 1; i < l.length; i++) {
                 ctype = lca(ctype, guessTypeOfValue(l[i]));
             }
-            if (isprimitive(ctype)) ctype = lca(ctype, type.float); // we do not have vectors of bool/float
             if (ctype) return {
                 type: 'list',
                 length: l.length,

--- a/plugins/cindygl/src/js/Renderer.js
+++ b/plugins/cindygl/src/js/Renderer.js
@@ -149,14 +149,15 @@ Renderer.prototype.setUniforms = function() {
                     setter([val['value']['real']]);
                     break;
                 default:
-                    if (t.type === 'list' && issubtypeof(t.parameters, type.float)) { //float-list
+                    if (t.type === 'list' && t.parameters === type.float) { //float-list
                         setter(val['value'].map(x => x['value']['real']));
                         break;
-                    } else if (t.type === 'list' && t.parameters.type === 'list' && issubtypeof(t.parameters.parameters, type.float)) { //float matrix
+                    } else if (t.type === 'list' && t.parameters.type === 'list' && t.parameters.parameters === type.float) { //float matrix
                         //probably: if isnativeglsl?
                         let m = [];
-                        for (let i = 0; i < t.parameters.length; i++)
-                            for (let j = 0; j < t.length; j++) m.push(val['value'][j]['value'][i]['value']['real']);
+                        for (let j = 0; j < t.length; j++)
+                            for (let i = 0; i < t.parameters.length; i++)
+                                m.push(val['value'][j]['value'][i]['value']['real']);
                         setter(m);
                         break;
                     }
@@ -167,7 +168,8 @@ Renderer.prototype.setUniforms = function() {
         } else if (t.type === 'list') {
 
             let d = depth(t);
-            if (d === 1 && isrvectorspace(t)) {
+            let fp = finalparameter(t);
+            if (d === 1 && fp === type.float) {
                 let n = t.length;
                 let s = sizes(n);
 

--- a/plugins/cindygl/src/js/TypeHelper.js
+++ b/plugins/cindygl/src/js/TypeHelper.js
@@ -165,7 +165,7 @@ function lca(a, b) {
             parameters: st
         };
     }
-    
+
     return false;
 }
 

--- a/plugins/cindygl/src/js/TypeHelper.js
+++ b/plugins/cindygl/src/js/TypeHelper.js
@@ -1,3 +1,73 @@
+/* types */
+let list = (n, type) => ({
+    type: 'list',
+    length: n,
+    parameters: type
+});
+
+let constant = (value) => ({ /* variables that are constant in GLSL */
+    type: 'constant',
+    value: value
+});
+
+
+let constint = n => constant({
+    "ctype": "number",
+    "value": {
+        "real": n,
+        "imag": 0
+    }
+});
+const type = { //assert all indices are different
+    bool: 1,
+    int: 2,
+    float: 3,
+    complex: 4,
+    voidt: 5,
+    color: 6, //color is the color type of glsl. CindyJS-colors are vec3
+    point: 7,
+    line: 8,
+    coordinate2d: 9, //for accessing 2D textures
+    image: 10,
+
+    vec2: list(2, 3),
+    vec3: list(3, 3),
+    vec4: list(4, 3),
+    vec: n => list(n, 3),
+    cvec: n => list(n, 4),
+
+    mat2: list(2, list(2, 3)),
+    mat3: list(3, list(3, 3)),
+    mat4: list(4, list(4, 3)),
+    anytype: 18, // is subtype of any other type
+    // positivefloat: 14 //@TODO: positive int < int, positive real < real. positivefloat+ positivefloat = positivefloat...
+    // nonnegativefloat: 15 //@TODO: negative float...
+};
+Object.freeze(type);
+
+function typeToString(t) {
+    if (1 <= t && t <= 10) {
+        let l = [
+            'bool',
+            'int',
+            'float',
+            'complex',
+            'voidt',
+            'color',
+            'point',
+            'line',
+            'coordinate2d',
+            'image',
+        ];
+        return l[t - 1];
+    } else {
+        if (t.type === 'list') return `${typeToString(t.parameters)}[${t.length}]`;
+        if (t.type === 'constant') return `const[${JSON.stringify(t.value['value'])}]`;
+        return JSON.stringify(t); //TODO
+    }
+}
+
+
 /* checks wheather t can be embedded is a R-vectorspace (but not an C-vectorspace)*/
 let isrvectorspace = t => (t.type === 'list' && isrvectorspace(t.parameters)) || issubtypeof(t, type.float);
 /* checks wheather t can be embedded into an C-vectorspace*/
@@ -11,7 +81,7 @@ let generalize = t => t.type === 'constant' ? guessTypeOfValue(t.value) : t;
 
 /* depth of an list construct */
 let depth = t => (t.type === 'list') ? depth(t.parameters) + 1 : 0;
-let finalparameter = t => t.parameters ? finalparameter(t.parameters) : t;
+let finalparameter = t => t.parameters !== undefined ? finalparameter(t.parameters) : t;
 let dimensionsmatch = (a, b) => (depth(a) === depth(b) && (depth(a) === 0 || (a.length === b.length && dimensionsmatch(a.parameters, b.parameters))));
 
 /* get the smallest R-vectorspace that contains t */
@@ -43,10 +113,7 @@ let isnativeglsl = t =>
 let isprimitive = a => [type.bool, type.int, type.float, type.complex].indexOf(a) !== -1;
 
 let typesareequal = (a, b) => (a === b) ||
-    (a.type === 'constant' && b.type === 'constant' && a.value['ctype'] === b.value['ctype'] && (
-        (a.value['ctype'] === 'number' && a.value['value']['real'] === b.value['value']['real'] && a.value['value']['imag'] === b.value['value']['imag']) ||
-        (a.value['ctype'] === 'boolean' && a.value['value'] === b.value['value'])
-    )) ||
+    (a.type === 'constant' && b.type === 'constant' && expressionsAreEqual(a.value, b.value)) ||
     (a.type === 'list' && b.type === 'list' && a.length === b.length && typesareequal(a.parameters, b.parameters));
 
 
@@ -98,6 +165,7 @@ function lca(a, b) {
             parameters: st
         };
     }
+    
     return false;
 }
 
@@ -188,32 +256,20 @@ function inclusionfunction(toType) {
         default:
             if (toType.type === 'list') {
                 let fp = finalparameter(toType);
-                if (issubtypeof(fp, type.float)) { //real list
-                    return args => {
-                        let fromType = args[0];
-                        if (issubtypeof(fromType, toType)) {
-                            return {
-                                args: args,
-                                res: toType,
-                                generator: identity
-                            };
-                        }
+
+                return args => {
+                    let fromType = args[0];
+                    let rec = inclusionfunction(toType.parameters)([fromType.parameters]).generator;
+                    return {
+                        args: args,
+                        res: toType,
+                        generator: (list, modifs, codebuilder) => uselist(toType)(
+                            range(toType.length).map(k => rec(
+                                [accesslist(fromType, k)([list], modifs, codebuilder)],
+                                modifs, codebuilder)), modifs, codebuilder)
                     };
-                } else {
-                    return args => {
-                        let fromType = args[0];
-                        let rec = inclusionfunction(toType.parameters)([fromType.parameters]).generator;
-                        return {
-                            args: args,
-                            res: toType,
-                            generator: (list, modifs, codebuilder) => uselist(toType)([
-                                range(toType.length).map(k => rec(
-                                    [accesslist(fromType, k)([list], modifs, codebuilder)],
-                                    modifs, codebuilder))
-                            ], modifs, codebuilder)
-                        };
-                    }
                 }
+
             }
     }
 
@@ -245,13 +301,13 @@ function webgltype(ctype) {
         case type.line:
             return 'vec3';
     }
-    if (ctype.type === 'list' && issubtypeof(ctype.parameters, type.float)) {
+    if (ctype.type === 'list' && ctype.parameters === type.float) {
         if (ctype.length == 1) return 'float';
         else
             return `vec${ctype.length}`;
-    } else if (ctype.type === 'list' && issubtypeof(ctype.parameters, type.complex)) {
+    } else if (ctype.type === 'list' && ctype.parameters === type.complex) {
         return `cvec${ctype.length}`;
-    } else if (ctype.type === 'list' && ctype.parameters.type === 'list' && ctype.length === ctype.parameters.length && issubtypeof(ctype.parameters.parameters, type.float)) {
+    } else if (ctype.type === 'list' && ctype.parameters.type === 'list' && ctype.length === ctype.parameters.length && ctype.parameters.parameters === type.float) {
         switch (ctype.length) {
             case 2:
                 return 'mat2';
@@ -261,17 +317,9 @@ function webgltype(ctype) {
                 return 'mat4';
         }
     }
-    if (ctype.type === 'list' && ctype.parameters.type === 'list' && issubtypeof(ctype.parameters.parameters, type.float)) {
-        return `mat${ctype.length}_${ctype.parameters.length}`;
-    }
-    if (ctype.type === 'list' && ctype.parameters.type === 'list' && issubtypeof(ctype.parameters.parameters, type.complex)) {
-        return `cmat${ctype.length}_${ctype.parameters.length}`;
-    }
-
     if (ctype.type === 'list') {
         return `l${ctype.length}_${webgltype(ctype.parameters)}`;
     }
-
 
     console.error(`No WebGL implementation for type ${typeToString(ctype)} found`);
 }
@@ -281,7 +329,7 @@ function pastevalue(val, toType) {
         case type.bool:
             return `${webgltype(toType)}(${val['value']})`;
         case type.int:
-            return `${webgltype(toType)}(${val['value']['real'] | 0})`;
+            return `${val['value']['real'] | 0}`;
         case type.float:
             return `${webgltype(toType)}(${val['value']['real']})`;
         case type.complex:

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -1,64 +1,3 @@
-/* types */
-let list = (n, type) => ({
-    type: 'list',
-    length: n,
-    parameters: type
-});
-
-let constant = (value) => ({ /* variables that are constant in GLSL */
-    type: 'constant',
-    value: value
-});
-
-const type = { //assert all indices are different
-    bool: 1,
-    int: 2,
-    float: 3,
-    complex: 4,
-    voidt: 5,
-    color: 6, //color is the color type of glsl. CindyJS-colors are vec3
-    point: 7,
-    line: 8,
-    coordinate2d: 9, //for accessing 2D textures
-    image: 10,
-
-    vec2: list(2, 3),
-    vec3: list(3, 3),
-    vec4: list(4, 3),
-    vec: n => list(n, 3),
-    cvec: n => list(n, 4),
-
-    mat2: list(2, list(2, 3)),
-    mat3: list(3, list(3, 3)),
-    mat4: list(4, list(4, 3)),
-    anytype: 18, // is subtype of any other type
-    // positivefloat: 14 //@TODO: positive int < int, positive real < real. positivefloat+ positivefloat = positivefloat...
-    // nonnegativefloat: 15 //@TODO: negative float...
-};
-Object.freeze(type);
-
-function typeToString(t) {
-    if (1 <= t && t <= 10) {
-        let l = [
-            'bool',
-            'int',
-            'float',
-            'complex',
-            'voidt',
-            'color',
-            'point',
-            'line',
-            'coordinate2d',
-            'image',
-        ];
-        return l[t - 1];
-    } else {
-        if (t.type === 'list') return `${typeToString(t.parameters)}[${t.length}]`;
-        if (t.type === 'constant') return `const[${JSON.stringify(t.value['value'])}]`;
-        return JSON.stringify(t); //TODO
-    }
-}
-
 function usefunction(name) {
     return args => { //args?
         if (typeof 'args' === 'string')
@@ -139,15 +78,15 @@ webgl['repeat'] = argtypes => (argtypes.length == 2 || argtypes.length == 3) && 
 }) : false;
 
 
-webgl['forall'] = argtypes => (argtypes.length == 2 || argtypes.length == 3) && (argtypes[0].type === 'list') ? ({ //generator not used
+webgl['forall'] = argtypes => (argtypes.length == 2 || argtypes.length == 3) && (generalize(argtypes[0]).type === 'list') ? ({ //generator not used
     args: argtypes,
     res: argtypes[argtypes.length - 1],
     generator: args => ''
 }) : false;
 
-webgl['apply'] = argtypes => (argtypes.length == 2 || argtypes.length == 3) && (argtypes[0].type === 'list') ? ({ //generator not used
+webgl['apply'] = argtypes => (argtypes.length == 2 || argtypes.length == 3) && (generalize(argtypes[0]).type === 'list') ? ({ //generator not used
     args: argtypes,
-    res: list(argtypes[0].length, argtypes[argtypes.length - 1]),
+    res: list(generalize(argtypes[0]).length, argtypes[argtypes.length - 1]),
     generator: args => ''
 }) : false;
 
@@ -326,7 +265,7 @@ let rings = [type.int, type.float, type.complex, type.vec2, type.vec3, type.vec4
 
 
 webgl["_"] = args => {
-    let t = args[0];
+    let t = generalize(args[0]);
     if (t.type === 'list' && isconstantint(args[1])) {
         let k = Number(args[1].value["value"]["real"]);
         if (1 <= Math.abs(k) && Math.abs(k) <= t.length) {
@@ -336,6 +275,12 @@ webgl["_"] = args => {
                 args: args,
                 res: t.parameters,
                 generator: accesslist(t, k),
+            };
+        } else { //if the certain value is not clear yet.
+            return {
+                args: args,
+                res: t.parameters,
+                generator: x => console.error(`try to access ${k}-th Element of ${t.length}-list ${JSON.stringify(args[0])}`)
             };
         }
     }
@@ -643,7 +588,7 @@ webgl["%"] = first([
 ]);
 
 
-[">", "<", ">=", "<=", "=="].forEach(oper => {
+[">", "<", ">=", "<=", "==", "!="].forEach(oper => {
     webgl[oper] = first([
         [
             [type.int, type.int], type.bool, useinfix(oper)


### PR DESCRIPTION
This makes it possible to raycast algebraic surface generically.
Unrolling is required and done if the running variable is used as array index.

This commit contains the following changes:
-Move type functions from WebGL.js to TypeHelper.js
-Allow using iterationvariable as array index within repeat
-separate int list from float vec(n)
-Introduce typetime
-Compute constant operations in advance
-several bugfixes
-swaps the matrix vector multiplication order (and stop transposing matrix internally)
-and change change uniform setter accordingly (no transpose)
-added tech-demos.
-add raycasting example