### PR TITLE
Draw larger number of primitives using uint indexing

### DIFF
--- a/plugins/cindy3d/src/js/PrimitiveRenderer.js
+++ b/plugins/cindy3d/src/js/PrimitiveRenderer.js
@@ -236,7 +236,7 @@ PrimitiveRenderer.prototype.addPrimitive = function(attributes) {
         this.indexByteCount = 4;
         this.itemTotalByteCount = this.itemAttribByteCount +
           this.numElements * this.indexByteCount;
-        this.maxCount = Math.floor((1 << 31) / this.itemAttribByteCount);
+        this.maxCount = Math.floor(Math.pow(2, 32) / this.itemAttribByteCount);
       }
     }
     nd = new ArrayBuffer(c * this.itemTotalByteCount);


### PR DESCRIPTION
This requires the OES_element_index_uint extension.  If that is not available, nothing will be drawn at all since the drawElements call is invalid in that case.  So this is a partial solution to #552.