### PR TITLE
Make colorplot and reference manual match

### DIFF
--- a/examples/cindygl/03_complexplot.html
+++ b/examples/cindygl/03_complexplot.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
+  <head>
+    <meta charset="utf-8">
     <title>Cindy JS</title>
     <script type="text/javascript" src="../../build/js/Cindy.js"></script>
     <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>
     
-	<body style="font-family:Arial;">
+  <body style="font-family:Arial;">
     
     <h1>CindyJS: Complex Function Plot</h1>
     <script id="csinit" type="text/x-cindyscript">
@@ -19,12 +19,40 @@
         (z-complex(A))*(z-complex(B))*(z-complex(C))
       );
       
-      color(z) := (
-        z = log(z);
-        h = mod(re(z),1);
-        exp(-.1*re(z))*(.8+.2*h)*hue(im(z)/(2*pi));
+      hsvToRGB(h, s, v) := (
+        regional(j, p, q, t, f);
+
+        h = (h-floor(h))*6;
+
+        j = floor(h);
+        f = h - j;
+
+        p = 1 - s;
+        q = 1 - s*f;
+        t = 1 - s*(1-f);
+
+        if(j == 0, [1, t, p],
+        if(j == 1, [q, 1, p],
+        if(j == 2, [p, 1, t],
+        if(j == 3, [p, q, 1],
+        if(j == 4, [t, p, 1],
+        if(j == 5, [1, p, q]))))))*v
       );
-      colorplot(color(f(complex(#))));
+
+      color(z) := ( //what color should be given to a complex number z?
+        regional(n, grey1, grey2);
+        n = 12;
+        z = log(z)/2/pi;
+
+        zfract = n*z - floor(n*z); //value of n*z in C mod Z[i]
+
+        grey1 = im(zfract);
+        grey2 = re(zfract);
+
+        hsvToRGB(im(z), 1., .5+.5*re(sqrt(grey1*grey2)))
+      );
+      
+      colorplot(color(f(z)));
     </script>
     
 
@@ -42,5 +70,5 @@
                     }
         );
     </script>              
-	</body>
+  </body>
 </html>

--- a/examples/cindygl/10_gol.html
+++ b/examples/cindygl/10_gol.html
@@ -60,7 +60,7 @@
         )
       );
       
-      if(animate, colorplot(L, R, "gol", newstate(#.x, #.y)));
+      if(animate, colorplot(L, R, "gol", newstate(x, y)));
       
       //plots to canvas using no interpolation
       colorplot(imagergb(L, R, "gol", #, interpolate->false));

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -343,7 +343,9 @@ CodeBuilder.prototype.determineUniforms = function(expr) {
     let myfunctions = this.myfunctions;
 
     var variableDependendsOnPixel = {
-        'cgl_pixel': true
+        'cgl_pixel': true,
+        'cgl_pixel.x': true,
+        'cgl_pixel.y': true
     }; //dict of this.variables being dependent on #
 
     //KISS-Fix: every variable appearing on left side of assigment is varying
@@ -503,9 +505,87 @@ CodeBuilder.prototype.copyRequiredFunctions = function(expr) {
 }
 
 
-CodeBuilder.prototype.precompile = function(expr, bindings) {
+CodeBuilder.prototype.generatePixelBindings = function(expr) {
+    let bindings = {};
+    let free = {};
+
+    function clone(a) {
+        let c = {};
+        for (let i in a) c[i] = a[i];
+        return c;
+    };
+
+    function rec(expr, bounded) {
+        if (expr['oper'] === "repeat$2" || expr['oper'] === "forall$2" || expr['oper'] === "apply$2") {
+            bounded = clone(bounded);
+            bounded['#'] = true;
+        } else if (expr['oper'] === "repeat$3" || expr['oper'] === "forall$3" || expr['oper'] === "apply$3") {
+            bounded = clone(bounded);
+            bounded[expr['args'][1]['name']] = true;
+        } else if (expr['oper'] === "=") {
+            bounded[expr['args'][0]['name']] = true;
+        }
+
+        for (let i in expr['args']) {
+            rec(expr['args'][i], bounded);
+        }
+
+        if (expr['ctype'] === 'field') {
+            rec(expr['obj'], bounded);
+        }
+
+        if (expr['ctype'] === 'variable') {
+            let vname = expr['name'];
+            if (!bounded[vname]) free[vname] = true;
+        }
+    }
+
+    rec(expr, {});
+
+    this.initvariable('cgl_pixel', false);
+    this.variables['cgl_pixel'].T = type.vec2;
+    if (Object.keys(free).length == 1) {
+        bindings[Object.keys(free)[0]] = 'cgl_pixel';
+    } else if (free['#']) {
+        bindings['#'] = 'cgl_pixel';
+    } else if (free['x'] && free['y']) {
+        this.initvariable('cgl_pixel.x', false);
+        this.variables['cgl_pixel.x'].T = type.float;
+        bindings['x'] = 'cgl_pixel.x';
+
+        this.initvariable('cgl_pixel.y', false);
+        this.variables['cgl_pixel.y'].T = type.float;
+        bindings['y'] = 'cgl_pixel.y';
+    } else {
+        //generate list of not assigned. if length =1 .
+        let notassigned = [];
+
+        for (let v in free) {
+            if (this.api.nada == this.api.evaluateAndVal({
+                    "ctype": 'variable',
+                    "name": v
+                })) notassigned.push(v);
+        }
+
+        if (notassigned.length == 1) {
+            bindings[notassigned[0]] = 'cgl_pixel';
+        } else if (free['p']) {
+            bindings['p'] = 'cgl_pixel';
+        } else if (free['z']) {
+            bindings['z'] = 'cgl_pixel';
+        }
+    }
+
+    if (bindings['z'] === 'cgl_pixel') {
+        this.variables['cgl_pixel'].T = type.complex;
+    }
+
+    return bindings;
+}
+
+CodeBuilder.prototype.precompile = function(expr) {
     this.copyRequiredFunctions(expr);
-    this.determineVariables(expr, bindings);
+    this.determineVariables(expr, this.generatePixelBindings(expr));
     this.determineUniforms(expr);
     this.determineUniformTypes();
 
@@ -913,12 +993,7 @@ CodeBuilder.prototype.generateColorPlotProgram = function(expr) { //TODO add arg
     helpercnt = 0;
     expr = cloneExpression(expr); //then we can write dirty things on expr...
 
-    this.initvariable('cgl_pixel', false);
-    this.variables['cgl_pixel'].T = type.vec2;
-    let bindings = {
-        '#': 'cgl_pixel'
-    }
-    this.precompile(expr, bindings); //determine this.variables, types etc.
+    this.precompile(expr); //determine this.variables, types etc.
     let r = this.compile(expr, true);
     let rtype = this.getType(expr);
     let colorterm = this.castType(r.term, rtype, type.color);

--- a/ref/Function_Plotting.md
+++ b/ref/Function_Plotting.md
@@ -234,59 +234,57 @@ This statement supports exactly the same modifiers as `fillplot(…)`.
 ###  Colorplots
 
 Colorplots are useful to create visual information about functions defined in the entire plane.
-They can associate a color value to every point in a rectangle.
+They can associate a color value to every point within a specified area.
 
-#### Creating a colorplot: `colorplot(‹expr›,‹vec›,‹vec›)`
+In the Cinderella, colorplots will be computed on the CPU. In CindyJS, colorplots are compiled to WebGL at the first time when the command is called on a given expression. For consecutive calls of colorplot applied to the same expression, the compiled program is re-used as long as the occurring types have not changed. If the types have changed in the meantime, a recompilation is forced.
 
-**Not available in CindyJS yet!**
+Due to the compilation to WebGL, there are some restrictions for the expressions that can be used for `colorplot`.
+For example, the `while`-operator and recursive functions must not be used.
+
+For every variable that appears on the left side of an assignment within a `colorplot`-expression, it must be possible to determine its type in advance. Also, the type signature of a user defined functions must be determinable.
+
+The only allowed types are boolean values, integers, real numbers, complex numbers, points, vectors, and lists of fixed length. All members of a list must be of the same type and this type must be one of the allowed types. 
+
+In CindyJS, there are limitations for the terms that can be used within `colorplot`:
+  * Every CindyJS operation is allowed if the term does not depend on the pixel coordinate and does not contain an internal assignment of a variable.
+  * For all other terms, only the following operations are allowed:  `^`, `<`, `<=`, `=`, `==`, `>`, `>=`, `_`, `-`, `;`, `!=`, `/`, `&`, `%`, `+`, `abs`, `abs_infix`, `add`, `apply`, `arctan`, `arctan2`, `blue`, `ceil`, `complex`, `conjugate`, `cos`, `dist`, `dist_infix`, `div`, `exp`, `floor`, `forall`, `genList`, `green`, `grey`, `hue`, `if`, `im`, `imagergb`, `imagergba`, `join`, `log`, `max`, `meet`, `min`, `mod`, `mult`, `pow`, `random`, `re`, `red`, `regional`, `repeat`, `round`, `sin`, `sqrt`, `sub`, `sum`, `tan`.
+
+For technical reasons, both `repeat` (the number of iterations) and `_` (the index of the accessed field) require a constant argument. A term is considered to be constant if it is either a number or a function of constant terms. If an expression within a loop (`repeat`, `forall` or `apply`) that depends on the running variable is required to be constant, CindyJS tries to unroll the corresponding loop.
+
+#### Creating a colorplot on the entire drawing canvas `colorplot(‹expr›)`
 
 **Description:**
 The `colorplot` operator makes it possible to give a visualization of a planar function.
-To each point of a rectangle a color value can be assigned by a function.
+To each point of the entire drawing canvas a color value can be assigned by a function.
 In the function `‹expr›` the running variable may be chosen as `#` (for more on running variables, see below).
-However, it is important to notice that this variable describes now a point in the plane (this is a variable two dimensional coordinates).
-The return value of `‹expr›` should be either a real number (in which case a gray value is assigned) or a vector of three real numbers (in which case an RGB color value is assigned).
+However, it is important to notice that this variable describes now a point in the plane (this is a variable in two-dimensional coordinates).
+The return value of `‹expr›` should be either a real number (in which case a gray value is assigned) or a vector of three real numbers (in which case an RGB color value is assigned) or a vector of four real numbers (in which case an RGBA value is assigned -- The fourth component represents the alpha value).
 In any case, the values of the real numbers should lie between 0 and 1.
-The second and third argument determine the lower left and the upper right corners of the drawing area.
-
-**Example:**
-The following code and two points A and B produce the picture below.
-In the first line, a real-valued function is defined that assigns to two points the sine of the distance between them (shifted and scaled to fit into the interval [0, 1]).
-The first argument of the `colorplot` operator is now a vector of three numbers depending on the run variable `#` (the red part is a circular wave around A, the green part is zero, and the blue part is a circular wave around B).
-Finally, C and D mark the corners of the rectangle.
-
-    > f(A,B):=((1+sin(2*dist(A,B)))/2);
-    > colorplot(
-    >    (f(A,#),0,f(B,#)),
-    >    C,D
-    > )
-
-![Image](img/ColPlot2X.png)
 
 **Running Variables:**
 Usually `#` is a good choice for the running variable in the `colorplot` function.
-However also other choices are possible.
-The possibilites for running variables are checked in the following order:
+However, also other choices are possible.
+The possibilities for running variables are checked in the following order:
 
-*  If there is only one free variable in `‹expr›` then this variable is taken as running variable and interpreted as a two dimensional vector.
+*  If there is only one free variable in `‹expr›` then this variable is taken as running variable and interpreted as a two-dimensional vector (as long as it is different from `z`).
 
-*  If `‹expr›` contains `#` the `#` is taken as running variable (again as a two dimensional vector)
+*  If `‹expr›` contains `#` the `#` is taken as running variable (again as a two-dimensional vector)
 
-*  If `‹expr›` contains both `x` and `y` as free varaibles the these two variables can be used as running variables the together represent the vector `(x,y)`.
+*  If `‹expr›` contains both `x` and `y` as free variables the these two variables can be used as running variables the together represent the vector `(x,y)`.
 
 *  If exactly one free variable is not assigned yet, then this variable is taken (as vector)
 
 *  if none of the above happens also `p` (for point) and `z` (for complex number) are checked as running variables.
 
-For instance the following line
+*  In any case, if `z` is the running variable, it will be interpreted as complex number (instead of a two-dimensional vector).
 
-    > colorplot((sin(2*x),sin(2*y),0),A,B)
 
-produces the following picture:
 
-![Image](img/ColPlot4X.png)
 
 **Modifiers:**
+
+**Not available in CindyJS yet!**
+
 The `colorplot` operator supports three modifiers.
 The modifier `pxlres` can be set to an integer that determines the size in pixels of the elementary quadrangles of the color plot.
 The picture above was taken with `pxlres->2` which is the default value.
@@ -317,6 +315,50 @@ The picture below was generated by the following code, which is only a slight mo
 
 ![Image](img/ColPlot3X.png)
 
+
+#### Creating a colorplot on a rectangular area: `colorplot(‹expr›,‹vec›,‹vec›)`
+
+To each point of a rectangle a color value can be assigned by a function.
+The second and third argument determine the lower left and the upper right corners of the drawing area.
+
+**Example:**
+The following code and two points A and B produce the picture below.
+In the first line, a real-valued function is defined that assigns to two points the sine of the distance between them (shifted and scaled to fit into the interval [0, 1]).
+The first argument of the `colorplot` operator is now a vector of three numbers depending on the run variable `#` (the red part is a circular wave around A, the green part is zero, and the blue part is a circular wave around B).
+Finally, C and D mark the corners of the rectangle.
+
+    > f(A,B):=((1+sin(2*dist(A,B)))/2);
+    > colorplot(
+    >    (f(A,#),0,f(B,#)),
+    >    C,D
+    > )
+
+![Image](img/ColPlot2X.png)
+
+
+**Running Variables:**
+
+For `colorplot(‹expr›,‹vec›,‹vec›)` the same rules for the running variable apply as to `colorplot(‹expr›)`. For instance the following line
+
+  > colorplot((sin(2*x),sin(2*y),0),A,B)
+
+produces the following picture:
+
+![Image](img/ColPlot4X.png)
+
+
+#### Creating a colorplot on a canvas with two reference points: `colorplot(‹pos›,‹pos›,‹imagename›,‹expr›)`
+
+ This operator uses `‹imagename›` as a canvas and positions it with respect to two reference point identical to the rules of the `drawimage(‹pos›,‹pos›,‹imagename›)` operator. Then the two-dimensional function described by the expression in the last argument will be plotted to the canvas.
+ 
+ The rules for choosing the running variable within the expressions are the same as for `colorplot(‹expr›)`.
+
+#### Creating a colorplot on a canvas with no reference points: `colorplot(‹imagename›,‹expr›)`
+
+  This operator uses `‹imagename›` as a canvas. Then the two-dimensional function described by the expression in the second will be plotted to the canvas. For the coordinates, CindyJS will assume that the two lower corners of the given canvas and the main drawing area coincide.
+  
+  The rules for choosing the running variable within the expressions are the same as for `colorplot(‹expr›)`.
+  
 ------
 
 ------


### PR DESCRIPTION
This completes the reference manual such that it fits the implemented colorplot command.
Furthermore, colorplot now also supportes running varaibles different from # as it is documented.