### PR TITLE
Fix version of js-beautify

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "concat-with-sourcemaps": "^1.0.4",
     "glob": "^7.0.3",
     "http-proxy": "^1.11.2",
-    "js-beautify": "^1.5.10",
+    "js-beautify": "1.6.2",
     "jshint": "^2.8.0",
     "marked": "^0.3.5",
     "mocha": "^3.1.2",


### PR DESCRIPTION
Different versions of js-beautify will format our codebase in different ways, even for patch-level version increments.  So I suggest we fix the version the hard way, with the intention of bumping the version every now and then in a conscious update, containing all related code formatting changes in that same commit.

This commit does *not* use the latest version at the time of the commit. That would be 1.6.7 which improves [one line of code](https://github.com/CindyJS/CindyJS/blob/8422099f65445e3f67a12ece5c4e22638ca464d0/plugins/cindygl/src/js/CodeBuilder.js#L296) thanks to a fix for https://github.com/beautify-web/js-beautify/issues/1079, but in [other](https://github.com/CindyJS/CindyJS/blob/v0.8.2/src/js/libcs/OpDrawing.js#L325-L329) [places](https://github.com/CindyJS/CindyJS/blob/v0.8.2/src/js/Events.js#L496) it suffers from https://github.com/beautify-web/js-beautify/issues/1090 and https://github.com/beautify-web/js-beautify/issues/1085#issuecomment-269628467 even though I don't know why earlier versions don't affect us there, too.

I'd like to get this one here in soon, and then hope for the two issues mentioned above to get addressed. And then perhaps @montaga can have a look at bumping to something more recent, as most of the remaining differences are located in the CindyGL codebase.