### PR TITLE
Update mail map

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,3 +5,6 @@ Jürgen Richter-Gebert <richter@ma.tum.de>
 <jw@tophostingteam.de> <jens.wurster@codenic.de>
 <jw@tophostingteam.de> <wurster@cermat.org>
 <gagern@ma.tum.de> <Martin.vGagern@gmx.net>
+Ulrich Kortenkamp <kortenkamp@cinderella.de>
+<kortenkamp@cinderella.de> <kortenkamp@cermat.org>
+Stefan Hoch <stefan.hoch@tum.de>


### PR DESCRIPTION
Now `git shortlog -es` will again report every person only once, with full name and consistent mail address.