### PR TITLE
Restore renderBody function for manual

### DIFF
--- a/make/commands.js
+++ b/make/commands.js
@@ -182,7 +182,7 @@ exports.sass = function(src, dst) {
     this.addJob(function() {
         task.log(src + " \u219d " + dst);
         var basename = path.basename(dst);
-        return Q.ninvoke(require("node-sass"), "render", {
+        return Q.fcall(require, "node-sass").ninvoke("render", {
             file: src,
             outFile: basename,
             sourceMap: basename + ".map",

--- a/ref/js/md2html.js
+++ b/ref/js/md2html.js
@@ -374,8 +374,9 @@ function main() {
 
 // Backwards-compatibility since this was used in website creation
 module.exports.renderBody = function(md, cb) {
-  var page = new Page(null, md);
-  page.then(function() {
+  var page = new Page(null);
+  page.md = md;
+  page.renderBody().then(function() {
     cb(null, page.html);
   }, function(err) {
     cb(err, null);


### PR DESCRIPTION
Fixes #561. As a drive-by fix, also addresses issues where errors loading node-sass don't cent reported properly.