### PR TITLE
Allow attaching extra data to a newly created page

### DIFF
--- a/ref/js/md2html.js
+++ b/ref/js/md2html.js
@@ -235,9 +235,10 @@ InMemoryPipeline.prototype.createPage = function(name) {
   return new Page(name);
 };
 
-InMemoryPipeline.prototype.addPage = function(name, md) {
+InMemoryPipeline.prototype.addPage = function(name, md, extra) {
   var self = this;
   var page = this.createPage(name);
+  page.extra = extra;
   var res = Q(md)
       .then(function(md) {
         page.md = md;


### PR DESCRIPTION
I'd like to have the alphabetical index for the web site, but to achieve that I need to associate the Vinyl object used by gulp with the Page object used by our renderer. This is a generic way to do so, which might also be used for other applications, so it's not specific to the web site.