### PR TITLE
 Add bunch of examples for CindyGL + minor bugfixes

### DIFF
--- a/examples/cindygl/42_taylor.html
+++ b/examples/cindygl/42_taylor.html
@@ -7,32 +7,12 @@
 		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
     <link rel="stylesheet" href="../../build/js/CindyJS.css">
   </head>
-    
-	<body style="font-family:Arial;">
-    
-    <h1>CindyJS: Taylor series of complex functions</h1>
-    
-		<script id="csinit" type="text/x-cindyscript">			
-			hsvToRGB(h, s, v) := (
-			  regional(j, p, q, t, f);
-
-			  h = (h-floor(h))*6;
-
-			  j = floor(h);
-			  f = h - j;
-
-			  p = 1 - s;
-			  q = 1 - s*f;
-			  t = 1 - s*(1-f);
-
-			  if(j == 0, [1, t, p],
-			  if(j == 1, [q, 1, p],
-			  if(j == 2, [p, 1, t],
-			  if(j == 3, [p, q, 1],
-			  if(j == 4, [t, p, 1],
-			  if(j == 5, [1, p, q]))))))*v
-			);
-
+	
+		<body style="font-family:Arial;">
+			
+			<h1>CindyJS: Taylor series of complex functions</h1>
+			
+			<script id="csinit" type="text/x-cindyscript">			
 			color(z) := ( //what color should be given to a complex number z?
 			  regional(n, grey1, grey2);
 			  n = 12;
@@ -42,104 +22,112 @@
 
 			  grey1 = im(zfract);
 			  grey2 = re(zfract);
+				
+			  hue(im(z))*(.6+.4*re(sqrt(grey1*grey2)));
+		  );
+				n = 5;
+				
+				lastf = "";
+				
+				zoom = 1;
+				lzoom = zoom;
 
-			  hsvToRGB(im(z), 1., .5+.5*re(sqrt(grey1*grey2)))
+			</script>
+			
+			<script id="csdraw" type="text/x-cindyscript">
+			if(Input.text!=lastf & Input.text!="", 
+				parse("f(z) :=" + Input.text);
+				lastf = Input.text;
 			);
+			
+			factorial(n) := if(n==0, 1, n*factorial(n-1));
+			
+			coeff = autodiff(f(z), [complex(A*zoom)], n)_1;
+			forall(0..n, k, coeff_(k+1)=coeff_(k+1)/factorial(k));
+			
+			t(z) := coeff*apply(0..n, k, (z-complex(A*zoom))^k);
+			
 
-			n = 5;
+			colorplot(
+				z = zoom*complex(#);
+				color(t(z));
+				,
+				(-2,-2),(2,2)
+			);
 			
-			lastf = "";
+			colorplot(
+				z = zoom*(complex(#)+4);
+				color(f(z));
+				,
+				(-6,-2),(-2,2)
+			);
 			
-			zoom = 1;
+			drawtext((-5.9,1.7), "$f(z) =$");
+			
+			drawtext((-1.7,1.7), "$\sum_{k=0}^{"+n+"} \frac{f^{(k)}(a)}{k!} (z-a)^k$");
+			
+			draw((1.8,-1.8),(1.8,1.8), color->[0,0,0]);
+			N.x = 1.8;
+			n = round(5*(N.y+1.8));
+			n = max(1, n);
+			N.y = n/5-1.8;
+			
+			draw((-5,-1.8),(1,-1.8), color->[0,0,0]);
+			drawtext((1.1,N.y),"$n = " + n + "$");
+			Zoom.y = -1.8;
+			
+			Zoom.x = max(Zoom.x, -5);
+			Zoom.x = min(Zoom.x, 1);
+			
+			zoom = exp(.5*(Zoom.x+3));
+			
+			if(lzoom!=zoom,
+				A.xy = A.xy*lzoom/zoom;
+			);
 			lzoom = zoom;
-
-    </script>
-		
-    <script id="csdraw" type="text/x-cindyscript">
-		if(Input.text!=lastf & Input.text!="", 
-			parse("f(z) :=" + Input.text);
-			lastf = Input.text;
-		);
-	
-		
-		
-		factorial(n) := if(n==0, 1, n*factorial(n-1));
-		
-		coeff = autodiff(f(z), [complex(A*zoom)], n)_1;
-		forall(0..n, k, coeff_(k+1)=coeff_(k+1)/factorial(k));
-		
-		t(z) := coeff*apply(0..n, k, (z-complex(A*zoom))^k);
-		
-
-    colorplot(
-			z = zoom*complex(#);
-			color(t(z));
-			,
-			(-2,-2),(2,2)
-		);
-		
-		colorplot(
-			z = zoom*(complex(#)+4);
-			color(f(z));
-			,
-			(-6,-2),(-2,2)
-		);
-		
-		drawtext((-5.9,1.7), "$f(z) =$");
-		
-		drawtext((-1.7,1.7), "$\sum_{k=0}^{"+n+"} \frac{f^{(k)}(a)}{k!} (z-a)^k$");
-		
-		draw((1.8,-1.8),(1.8,1.8), color->[0,0,0]);
-		N.x = 1.8;
-		n = round(5*(N.y+1.8));
-		n = max(1, n);
-		N.y = n/5-1.8;
-		
-		draw((-5,-1.8),(1,-1.8), color->[0,0,0]);
-		drawtext((1.1,N.y),"$n = " + n + "$");
-		Zoom.y = -1.8;
-		
-		Zoom.x = max(Zoom.x, -5);
-		Zoom.x = min(Zoom.x, 1);
-		
-		zoom = exp(.5*(Zoom.x+3));
-		
-		if(lzoom!=zoom,
-			A.xy = A.xy*lzoom/zoom;
-		);
-		lzoom = zoom;
-		
-    </script>
-               
-		<select size="5" id="sel" onchange="cdy.evokeCS(this.value);" style="width:10em;">  
-			<option value='Input.text = "1/z";'>1/z</option>
-			<option value='Input.text = "z^(1/2)";'>square root</option>
-			<option value='Input.text = "log(z)";'>logarithm</option>
-			<option value='Input.text = "sin(z)";'>sine</option>
-			<option value='Input.text = "sin(z)/cos(z)";'>tangens</option>
-			<option value='Input.text = "exp(z)";'>exponential function</option>
-		</select>
-
-    <div id="CSCanvas"></div>
-		
-    <script type="text/javascript">
-        var cdy = CindyJS({canvasname:"CSCanvas",
-                    scripts: "cs*",
-                    geometry: [
-											{name:"A", type:"Free", pos:[1.1, 0.1],color:[1,0,0]},
-	    								{name:"N", type:"Free", pos:[1, 0],color:[1,1,1], size:8},
-											{name:"Zoom", type:"Free", pos:[-2, -.3],color:[1,1,1], size:8},
-											{name: "Input", type: "EditableText", pos: [-5.2, 1.7], color: [0.0, 0.0, 0.0], fillcolor: [1.0, 0.784, 0.0], fillalpha: 0.5, minwidth: 300, text: "1/(z^2+1)"}
-										],
-                    animation: {autoplay: true},
-                    ports: [{
-                      id: "CSCanvas",
-                      width: 800,
-                      height: 400,
-                      transform: [ { visibleRect: [-6,-2, 2, 2] } ]
-                    }],
-										use: ["CindyGL", "katex"]
-                  });
-    </script>              
-	</body>
-</html>
+			
+			</script>
+			<div>
+			<select size="5" id="sel" onchange="cdy.evokeCS(this.value);" style="width:10em;">  
+				<option value='Input.text = "1/z";'>1/z</option>
+				<option value='Input.text = "z^(1/2)";'>square root</option>
+				<option value='Input.text = "log(z)";'>logarithm</option>
+				<option value='Input.text = "sin(z)";'>sine</option>
+				<option value='Input.text = "sin(z)/cos(z)";'>tangent</option>
+				<option value='Input.text = "exp(z)";'>exponential function</option>
+			</select>
+			</div>
+			<div id="CSCanvas"></div>
+			
+			<script type="text/javascript">
+					var cdy = CindyJS({canvasname:"CSCanvas",
+											scripts: "cs*",
+											geometry: [
+												{name:"A", type:"Free", pos:[1.1, 0.1],color:[1,0,0]},
+												{name:"N", type:"Free", pos:[1, 0],color:[1,1,1], size:8},
+												{name:"Zoom", type:"Free", pos:[-2, -.3],color:[1,1,1], size:8},
+												{name: "Input", type: "EditableText", pos: [-5.2, 1.7], color: [0.0, 0.0, 0.0], fillcolor: [1.0, 0.784, 0.0], fillalpha: 0.5, minwidth: 300, text: "1/(z^2+1)"}
+											],
+											animation: {autoplay: true},
+											ports: [{
+												id: "CSCanvas",
+												width: 800,
+												height: 400,
+												transform: [ { visibleRect: [-6,-2, 2, 2] } ]
+											}],
+											use: ["CindyGL", "katex"]
+										});
+			</script>
+			
+			<div>
+				On the left, a phase portrait of a complex function is displayed.
+			</div>
+			<div>
+			On the right, one can see the approximation of the function through it's Taylor polynomials at the red base point.
+			</div>
+			<div>
+			The complex function, the base point, the order of the polynomial and the zoom can be modified.
+			</div>
+	       
+		</body>
+	</html>

--- a/examples/cindygl/44_raycasting_aberth_real.html
+++ b/examples/cindygl/44_raycasting_aberth_real.html
@@ -197,31 +197,24 @@
             
             polyvalues = apply(li, F(ray(pos, #)));
             poly = B * polyvalues; //interpolate
-            //poly = 1/(poly_N)*poly;
             dpoly = d(poly);
+          
+            z = apply(1..(N-1), l+#*(u-l)/(N-1)); //take real roots as starting value
             
-            //z = apply(1..(N-1), random()+i*random());
-            z = apply(1..(N-1), re(sqrt(#/N))*exp(i*#*137.508°)); //sunflower spiral in D_1
-            
-            //z = apply(1..(N-1), -(poly_(N-1))/(poly_N*(N-1))+exp(2*pi*i*#/(N-1)));
-            //z = apply(1..(N-1), (2*#/(N-1))-.5);
-            
-            repeat(12,
+            repeat(15,
               forall(1..(N-1), k,
                 su = 0;
                 forall(1..(N-1), j, if(j!=k, su = su+1/(z_k-z_j)));
-                newton = eval(poly, z_k)/eval(dpoly, z_k);
+                newton = F(ray(pos, z_k))/eval(dpoly, z_k);
                 z_k = z_k-newton/(1-newton*su)
               );
             );
             
             forall(
-             reverse(sort(apply(z, if(|im(#)|<0.01, re(#), oo)))), //only take real roots
+             reverse(sort(apply(z, if(|F(ray(pos, #))|<0.001, re(#), oo)))), //only take real roots
              color = updatecolor(pos, #, color); );
             
-        );
-      //  color_1 = color_1+1/exp(|poly_(N)|);
-        color
+        ); color
     );
     </script>
     

--- a/examples/cindygl/45_bokeh.html
+++ b/examples/cindygl/45_bokeh.html
@@ -1,0 +1,53 @@
+
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Webcam in Cindy JS</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+video = camera video();
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+R = A.x*.1;
+N = 100;
+if (image ready(video),
+  colorplot(
+    acc = [0,0,0];
+    total = 0;
+    //idea from https://www.shadertoy.com/view/4d2Xzw and http://blog.marmakoide.org/?p=1
+    repeat(N, i,
+      r = re(sqrt(i/N))*R;
+      phi = i*137.508°;
+      col = imagergb(video, #+r*(cos(phi),sin(phi)));
+      v = (col*col)^5;
+      acc = acc + col*v;
+      total = total + v;
+    );
+    acc/total
+  );
+);
+</script>
+<script type="text/javascript">
+var cdy = CindyJS({
+  ports: [{id: "CSCanvas", transform:[{visibleRect:[0,0,1,1]}]}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[.1,.1]}
+  ],
+  use: ["CindyGL"]
+});
+</script>
+Better turn of the lights.
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="width:1280px; height:720px; border:2px solid black"></div>
+</body>
+
+</html>

--- a/examples/cindygl/45_zeta.html
+++ b/examples/cindygl/45_zeta.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+    <title>Cindy JS</title>
+		<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+		<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+    <link rel="stylesheet" href="../../build/js/CindyJS.css">
+  </head>
+    
+	<body style="font-family:Arial;">
+    
+    <h1>CindyJS: The Riemann Zeta-function</h1>
+
+		<script id="csmousedown" type="text/x-cindyscript">
+		dragging = true;
+		</script>
+		<script id="csmouseup" type="text/x-cindyscript">
+		dragging = false;
+		</script>
+		
+		
+		<script id="csinit" type="text/x-cindyscript">
+			color(z) := ( //what color should be given to a complex number z?
+			  regional(n, grey1, grey2);
+			  n = 24;
+			  z = log(z)/2/pi;
+
+			  zfract = n*z - floor(n*z); //value of n*z in C mod Z[i]
+
+			  grey1 = im(zfract);
+			  grey2 = re(zfract);
+				
+				hue(im(z))*(.6+.4*re(sqrt(grey1*grey2)));
+			);
+
+			delta = 1+i*34;
+			dragging = false;
+    </script>
+		
+		<script id="csdraw" type="text/x-cindyscript">
+		if (dragging,
+				delta = delta - complex(mouse()-oldmouse);
+		);
+		oldmouse = mouse();
+
+		normaldist(x, mu, sigma) := 1/(sigma*sqrt(2*pi))*exp	(-(x-mu)^2/(2*sigma^2));
+		
+		n = 40;
+		
+		e = apply(1..n, k, sum(apply(k..n,j,
+			if(n<30,
+			 combinations(n,j)/(2^n),
+			 normaldist(j,n/2,sqrt(n/4)) //approximation through Binomial distribution + central limit theorem
+		  ) 
+		)));
+		
+		//Gourdon, Xavier, and Pascal Sebah. "Numerical evaluation of the Riemann Zeta-function." Numbers, constants and computation (2003).
+		//alternating series method
+		zeta(s) := 1/(1-2^(1-s))*(
+			 sum(apply(1..n, k,     (-1)^(k-1)/(k^s)         ))
+			+sum(apply(n+1..2*n, k, (-1)^(k-1)*e_(k-n)/(k^s) ))
+		);
+		
+	  //only for re(s)>1:
+		//zeta(s) := sum(apply(1..n, k, 1/(k^s)));
+  
+		colorplot(
+			z = (complex(#)+delta);
+			val = zeta(z);
+			color(val)*if(re(z)>1 % re(z)<0,.8,1)
+		);
+		
+	//	draw((-5,0-im(delta)),(5,0-im(delta)),color->[0,0,0]);
+	//	draw((0-re(delta),-5),(0-re(delta),5),color->[0,0,0]);
+		draw((0.5-re(delta),-5),(0.5-re(delta),5),color->[1,1,1],alpha->.3);
+	//	draw((1-re(delta),-5),(1-re(delta),5),color->[0,0,0]);
+
+		if(dragging, drawtext(mouse(), 
+		 "$\zeta(" + format(delta+complex(mouse()),2) + ") \approx " + format(zeta(delta+complex(mouse())),2) + "$",
+		 color -> [1,1,1],
+		 align -> "mid"
+	 ));
+    </script>
+               
+
+    <div>Drag to navigate</div>
+    <div  id="CSCanvas"></div>
+		
+    <script type="text/javascript">
+        CindyJS({canvasname:"CSCanvas",
+                    scripts: "cs*",
+                    geometry: [],
+                    animation: {autoplay: false},
+                    ports: [{
+                      id: "CSCanvas",
+                      width: 800,
+                      height: 800,
+	                      transform: [ { visibleRect: [-4,-4, 4, 4] } ]
+                    }],
+										use: ["CindyGL", "katex"]
+                  });
+    </script>              
+	</body>
+</html>

--- a/make/build.js
+++ b/make/build.js
@@ -338,8 +338,6 @@ module.exports = function build(settings, task) {
     // Build JavaScript version of CindyGL
     //////////////////////////////////////////////////////////////////////
 
-    var cgl_primitives = "sphere cylinder triangle texq".split(" ");
-
     var cgl_str_res = glob.sync("plugins/cindygl/src/str/*.glsl");
     
     var cgl_mods = [

--- a/plugins/cindygl/src/js/LinearAlgebra.js
+++ b/plugins/cindygl/src/js/LinearAlgebra.js
@@ -197,7 +197,7 @@ function uselist(t) {
     if (isnativeglsl(t)) {
         return (args, modifs, codebuilder) => `${webgltype(t)}(${args.join(',')})`;
     }
-    if (d == 1 && isrvectorspace(t)) return usevec(t.length);
+    if (d == 1 && t.parameters === type.float) return usevec(t.length);
     return (args, modifs, codebuilder) => createstruct(t, codebuilder) || `${webgltype(t)}(${args.join(',')})`;
 }
 

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -297,6 +297,12 @@ webgl["mult"] = args => {
             [type.float, type.float], type.float, useinfix('*')
         ],
         [
+            [type.complex, type.float], type.complex, useinfix('*')
+        ],
+        [
+            [type.float, type.complex], type.complex, useinfix('*')
+        ],
+        [
             [type.complex, type.complex], type.complex, useincludefunction('multc')
         ],
     ])(args);
@@ -384,6 +390,12 @@ webgl["div"] = args => {
     let match = first([
         [
             [type.float, type.float], type.float, useinfix('/')
+        ],
+        [
+            [type.float, type.complex], type.complex, useincludefunction('divfc')
+        ],
+        [
+            [type.complex, type.float], type.complex, useinfix('/')
         ],
         [
             [type.complex, type.complex], type.complex, useincludefunction('divc')

--- a/plugins/cindygl/src/str/divfc.glsl
+++ b/plugins/cindygl/src/str/divfc.glsl
@@ -1,0 +1,3 @@
+vec2 divfc(float a, vec2 b){
+  return a*vec2(b.x,-b.y)/dot(b,b);
+}


### PR DESCRIPTION
This adds more examples for CindyGL and contains minor bugfixes, e.g
-handling of lists of length 1
-avoid redefinitions of loop-variables if loop is contained in another unrolled loop
-accelerate some float-complex operations (* and / without type casting to complex-complex)