### PR TITLE
Add fillrule to polygondrawing

### DIFF
--- a/examples/PolyEvenOdd.html
+++ b/examples/PolyEvenOdd.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Construction.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+rule = "evenodd";
+nonz():=(
+rule = "nonzero";
+);
+eo():=(
+rule = "evenodd";
+);
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+lst = [A,B,C,D,E,A];
+fillpoly(lst, fillrule->rule);
+</script>
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  geometry: [
+    {name: "A", type: "Free", pos: [-3.347517730496454, -4.0, -0.7092198581560284], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "B", type: "Free", pos: [-3.2, -4.0, -4.0], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "C", type: "Free", pos: [4.0, 1.6078431372549018, 0.4901960784313726], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "D", type: "Free", pos: [-0.7407407407407408, -4.0, -0.9259259259259259], color: [1.0, 0.0, 0.0], labeled: true},
+    {name: "E", type: "Free", pos: [4.0, 0.9051094890510948, 0.7299270072992701], color: [1.0, 0.0, 0.0], labeled: true}
+  ],
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 335,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -4.06]}],
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  cinderella: {build: 1898, version: [2, 9, 1898]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+    <div>
+ <button onclick="cdy.evokeCS('eo()')">evenodd</button>
+ <button onclick="cdy.evokeCS('nonz()')">nonzero</button>
+ </div>
+</body>
+</html>

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -789,7 +789,7 @@ evaluator.fillpolygon$1 = function(args, modifs) {
 eval_helper.drawpolygon = function(args, modifs, df, cycle) {
     Render2D.handleModifs(modifs, Render2D.conicModifs);
     Render2D.preDrawCurve();
-    csctx.mozFillRule = 'evenodd';
+
 
     var m = csport.drawingstate.matrix;
 
@@ -842,13 +842,13 @@ eval_helper.drawpolygon = function(args, modifs, df, cycle) {
     if (df === "D") {
         if (Render2D.fillColor) {
             csctx.fillStyle = Render2D.fillColor;
-            csctx.fill();
+            csctx.fill(Render2D.fillrule);
         }
         csctx.stroke();
     }
     if (df === "F") {
         csctx.fillStyle = Render2D.lineColor;
-        csctx.fill();
+        csctx.fill(Render2D.fillrule);
     }
     if (df === "C") {
         csctx.clip();

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -6,7 +6,7 @@ Render2D.handleModifs = function(modifs, handlers) {
         Render2D.unSetDash();
     Render2D.colorraw = null;
     Render2D.fillcolorraw = null;
-    Render2D.fillrule = "evenodd";
+    Render2D.fillrule = "nonzero";
     Render2D.size = null;
     if (Render2D.psize <= 0) Render2D.psize = 0;
     if (Render2D.lsize <= 0) Render2D.lsize = 0;

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -6,6 +6,7 @@ Render2D.handleModifs = function(modifs, handlers) {
         Render2D.unSetDash();
     Render2D.colorraw = null;
     Render2D.fillcolorraw = null;
+    Render2D.fillrule = "evenodd";
     Render2D.size = null;
     if (Render2D.psize <= 0) Render2D.psize = 0;
     if (Render2D.lsize <= 0) Render2D.lsize = 0;
@@ -286,6 +287,10 @@ Render2D.modifHandlers = {
         if (v.ctype === "string" && (v.value === "round" || v.value === "bevel" || v.value === "miter"))
             Render2D.lineJoin = v.value;
     },
+    "fillrule": function(v) {
+        if (v.ctype === "string" && (v.value === "nonzero" || v.value === "evenodd"))
+            Render2D.fillrule = v.value;
+    },
 
     "miterLimit": function(v) {
         if (v.ctype === "number" && v.value.real > 0) {
@@ -325,6 +330,7 @@ Render2D.conicModifs = {
     "color": true,
     "alpha": true,
     "fillcolor": true,
+    "fillrule": true,
     "fillalpha": true,
     "lineCap": true,
     "lineJoin": true,
@@ -357,6 +363,8 @@ Render2D.preDrawCurve = function() {
     csctx.lineWidth = Render2D.lsize;
     csctx.lineCap = Render2D.lineCap;
     csctx.lineJoin = Render2D.lineJoin;
+    csctx.mozFillRule = Render2D.fillrule;
+    csctx.fillrule = Render2D.fillrule;
     csctx.miterLimit = Render2D.miterLimit;
     csctx.strokeStyle = Render2D.lineColor;
 };

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -277,6 +277,7 @@ function drawgeopolygon(el) {
         fillalpha: el.fillalpha,
         size: el.size,
         lineJoin: General.string("miter"),
+        fillrule: General.string(el.fillrule),
     };
     eval_helper.drawpolygon([el.vertices], modifs, "D", true);
 }


### PR DESCRIPTION
This adds a modifier for the canvas fill rule. The second commit changes the default behaviour from evenodd to nonzero which would restore compatibility to Cinderella, but this breaks compatibility to previous releases (at least we had a mozfillrule set to evenodd). Of course one could only cherry pick the first. 

I won't be able to make address changes for the next few days, so feel free to modify my code as you wish.