### PR TITLE
Touch support for Cindy3D

### DIFF
--- a/make/build.js
+++ b/make/build.js
@@ -283,6 +283,7 @@ module.exports = function build(settings, task) {
         "Camera",
         "Appearance",
         "Viewer",
+        "Controls",
         "Lighting",
         "PrimitiveRenderer",
         "Spheres",

--- a/make/commands.js
+++ b/make/commands.js
@@ -150,6 +150,7 @@ exports.closureCompiler = function(jar, opts) {
         }
         if ([
             "output_wrapper_file",
+            "externs",
         ].indexOf(key) !== -1)
             this.input(val);
         if ([

--- a/plugins/cindy3d/src/js/Camera.js
+++ b/plugins/cindy3d/src/js/Camera.js
@@ -221,7 +221,7 @@ Camera.prototype.translateZ = function(dy) {
  * @param {number} dy
  */
 Camera.prototype.rotateZ = function(dy) {
-  let a = Camera.ROTATE_SENSITIVITY*dy;
+  let a = dy;
   let c = Math.cos(a), s = Math.sin(a);
   let m = [
     c, -s, 0, 0,

--- a/plugins/cindy3d/src/js/Controls.js
+++ b/plugins/cindy3d/src/js/Controls.js
@@ -1,0 +1,207 @@
+/**
+ * @param {td.EventManager} addEventListener
+ * @param {HTMLCanvasElement} canvas
+ * @param {Camera} camera
+ * @param {Viewer} viewer
+ * @constructor
+ * @struct
+ */
+function Controls(addEventListener, canvas, camera, viewer) {
+  this.canvas = canvas;
+  this.camera = camera;
+  this.viewer = viewer;
+  this.mx = Number.NaN;
+  this.my = Number.NaN;
+  this.mdown = false;
+  this.touches = new Map();
+  addEventListener(canvas, "mousedown", this.mousedown.bind(this));
+  addEventListener(canvas, "mousemove", this.mousemove.bind(this));
+  addEventListener(canvas, "mouseup", this.mouseup.bind(this));
+  addEventListener(canvas, "mouseleave", this.mouseleave.bind(this));
+  addEventListener(canvas, "wheel", this.wheel.bind(this));
+  addEventListener(canvas, "touchstart", this.touchstart.bind(this));
+  addEventListener(canvas, "touchend", this.touchend.bind(this));
+  addEventListener(canvas, "touchcancel", this.touchcancel.bind(this));
+  addEventListener(canvas, "touchmove", this.touchmove.bind(this));
+}
+
+/** @type {HTMLElement} */
+Controls.prototype.canvas;
+
+/** @type {Camera} */
+Controls.prototype.camera;
+
+/** @type {Viewer} */
+Controls.prototype.viewer;
+
+/** @type {number} */
+Controls.prototype.mx;
+
+/** @type {number} */
+Controls.prototype.my;
+
+/** @type {boolean} */
+Controls.prototype.mdown;
+
+/** @typedef {{x: number, y: number}} */
+Controls.TouchInfo;
+
+/** @type {Map<number, Controls.TouchInfo>} */
+Controls.prototype.touches;
+
+/**
+ * @param {Event} evnt
+ */
+Controls.prototype.mousedown = function(/** MouseEvent */ evnt) {
+  if (evnt.button === 0) {
+    this.mdown = true;
+  }
+  if (evnt.buttons === undefined ? this.mdown : (evnt.buttons & 1)) {
+    this.mx = evnt.clientX;
+    this.my = evnt.clientY;
+  }
+};
+
+/**
+ * @param {Event} evnt
+ */
+Controls.prototype.mousemove = function(/** MouseEvent */ evnt) {
+  if (evnt.buttons === undefined ? this.mdown : (evnt.buttons & 1)) {
+    if (!isNaN(this.mx)) {
+      let dx = evnt.clientX - this.mx, dy = evnt.clientY - this.my;
+      if (evnt.shiftKey)
+        this.camera.rotateXY(dx, dy);
+      else if (evnt.altKey || evnt.ctrlKey || evnt.metaKey)
+        this.camera.translateXY(dx, dy);
+      else
+        this.camera.orbitXY(dx, dy);
+      this.viewer.render();
+    }
+    this.mx = evnt.clientX;
+    this.my = evnt.clientY;
+  }
+};
+
+/**
+ * @param {Event} evnt
+ */
+Controls.prototype.mouseup = function(/** MouseEvent */ evnt) {
+  if (evnt.button === 0) this.mdown = false;
+};
+
+/**
+ * @param {Event} evnt
+ */
+Controls.prototype.mouseleave = function(/** MouseEvent */ evnt) {
+  this.mdown = false;
+  this.mx = this.my = Number.NaN;
+};
+
+/**
+ * @param {Event} evnt
+ */ 
+Controls.prototype.wheel = function(/** WheelEvent */ evnt) {
+  let d = evnt.deltaY;
+  if (d) {
+    if (evnt.shiftKey)
+      this.camera.rotateZ(Camera.ROTATE_SENSITIVITY*d);
+    else if (evnt.altKey || evnt.ctrlKey || evnt.metaKey)
+      this.camera.translateZ(d);
+    else
+      this.camera.zoom(d);
+    this.viewer.render();
+  }
+  evnt.preventDefault();
+};
+
+/**
+ * @param {Event} evnt
+ */ 
+Controls.prototype.touchstart = function(/** TouchEvent */ evnt) {
+  evnt.preventDefault();
+  let /** TouchList */ ts = evnt.changedTouches;
+  for (let i = 0; i < ts.length; ++i) {
+    let /** Touch */ t = ts[i];
+    this.touches.set(t.identifier, { x: t.clientX, y: t.clientY });
+  }
+};
+
+/**
+ * @param {Event} evnt
+ */ 
+Controls.prototype.touchend = function(/** TouchEvent */ evnt) {
+  evnt.preventDefault();
+  let /** TouchList */ ts = evnt.changedTouches;
+  for (let i = 0; i < ts.length; ++i)
+    this.touches.delete(ts[i].identifier);
+};
+
+/**
+ * @param {Event} evnt
+ */ 
+Controls.prototype.touchcancel = function(/** TouchEvent */ evnt) {
+  evnt.preventDefault();
+  let /** TouchList */ ts = evnt.changedTouches;
+  for (let i = 0; i < ts.length; ++i)
+    this.touches.delete(ts[i].identifier);
+};
+
+/**
+ * @param {Event} evnt
+ */ 
+Controls.prototype.touchmove = function(/** TouchEvent */ evnt) {
+  evnt.preventDefault();
+  let /** TouchList */ ts = evnt.targetTouches;
+  if (ts.length === 1) {
+    this.singleDrag(ts[0]);
+  } else if (ts.length === 2) {
+    this.doubleDrag(ts[0], ts[1]);
+  }
+  ts = evnt.changedTouches;
+  for (let i = 0; i < ts.length; ++i) {
+    let /** Touch */ cur = ts[i];
+    let /** Controls.TouchInfo */ prev = this.touches.get(cur.identifier);
+    prev.x = cur.clientX;
+    prev.y = cur.clientY;
+  }
+};
+
+/**
+ * @param {Touch} cur
+ */
+Controls.prototype.singleDrag = function(cur) {
+  let /** Controls.TouchInfo */ prev = this.touches.get(cur.identifier);
+  let dx = cur.clientX - prev.x;
+  let dy = cur.clientY - prev.y;
+  this.camera.orbitXY(dx, dy);
+  this.viewer.render();
+};
+
+/**
+ * @param {Touch} cur1
+ * @param {Touch} cur2
+ */
+Controls.prototype.doubleDrag = function(cur1, cur2) {
+  let /** Controls.TouchInfo */ prev1 = this.touches.get(cur1.identifier);
+  let /** Controls.TouchInfo */ prev2 = this.touches.get(cur2.identifier);
+  let rect = this.canvas.getBoundingClientRect();
+  let ctrX = this.canvas.clientLeft + rect.left + this.camera.width * 0.5;
+  let ctrY = this.canvas.clientTop + rect.top + this.camera.height * 0.5;
+  let cx = (prev1.x + prev2.x + 1) * 0.5;
+  let cy = (prev1.y + prev2.y + 1) * 0.5;
+  this.camera.translateXY(ctrX - cx, ctrY - cy);
+  let dx = prev1.x - prev2.x;
+  let dy = prev1.y - prev2.y;
+  let prevDist = Math.hypot(dx, dy);
+  let prevAngle = Math.atan2(dy, dx);
+  cx = (cur1.clientX + cur2.clientX + 1) * 0.5;
+  cy = (cur1.clientY + cur2.clientY + 1) * 0.5;
+  dx = cur1.clientX - cur2.clientX;
+  dy = cur1.clientY - cur2.clientY;
+  let curDist = Math.hypot(dx, dy);
+  let curAngle = Math.atan2(dy, dx);
+  this.camera.zoom(prevDist - curDist);
+  this.camera.rotateZ(prevAngle - curAngle);
+  this.camera.translateXY(cx - ctrX, cy - ctrY);
+  this.viewer.render();
+};

--- a/plugins/cindy3d/src/js/PrimitiveRenderer.js
+++ b/plugins/cindy3d/src/js/PrimitiveRenderer.js
@@ -205,12 +205,12 @@ PrimitiveRenderer.prototype.recompileShader = function(viewer) {
   if (this.shaderProgram !== null)
     this.shaderProgram.dispose(gl);
   let vs = [
-    "precision mediump float;",
+    "precision highp float;",
     "varying float vShininess;",
     this.vertexShaderCode
   ].join("\n");
   let fs = [
-    "precision mediump float;",
+    "precision highp float;",
     viewer.lightingCode,
     this.fragmentShaderCode
   ].join("\n");

--- a/plugins/cindy3d/src/js/Viewer.js
+++ b/plugins/cindy3d/src/js/Viewer.js
@@ -130,7 +130,7 @@ function Viewer(name, ccOpts, opts, addEventListener) {
       target, name, listener, useCapture) {
       target.addEventListener(name, listener, !!useCapture);
     });
-  this.setupListeners(addEventListener);
+  new Controls(addEventListener, this.canvas, this.camera, this);
 }
 
 /** @const @type {Appearance.Triple} */
@@ -217,59 +217,6 @@ Viewer.prototype.backgroundColor;
 
 /** @type {?number} */
 Viewer.prototype.renderTimeout;
-
-/**
- * @param {td.EventManager} addEventListener
- */
-Viewer.prototype.setupListeners = function(addEventListener) {
-  let canvas = this.canvas, mx = Number.NaN, my = Number.NaN, mdown = false;
-  let camera = this.camera, render = this.scheduleRender.bind(this);
-  addEventListener(canvas, "mousedown", function(/** MouseEvent */ evnt) {
-    if (evnt.button === 0) {
-      mdown = true;
-    }
-    if (evnt.buttons === undefined ? mdown : (evnt.buttons & 1)) {
-      mx = evnt.screenX;
-      my = evnt.screenY;
-    }
-  });
-  addEventListener(canvas, "mousemove", function(/** MouseEvent */ evnt) {
-    if (evnt.buttons === undefined ? mdown : (evnt.buttons & 1)) {
-      if (!isNaN(mx)) {
-        let dx = evnt.screenX - mx, dy = evnt.screenY - my;
-        if (evnt.shiftKey)
-          camera.rotateXY(dx, dy);
-        else if (evnt.altKey || evnt.ctrlKey || evnt.metaKey)
-          camera.translateXY(dx, dy);
-        else
-          camera.orbitXY(dx, dy);
-        render();
-      }
-      mx = evnt.screenX;
-      my = evnt.screenY;
-    }
-  });
-  addEventListener(canvas, "mouseup", function(/** MouseEvent */ evnt) {
-    if (evnt.button === 0) mdown = false;
-  });
-  addEventListener(canvas, "mouseleave", function(/** MouseEvent */ evnt) {
-    mdown = false;
-    mx = my = Number.NaN;
-  });
-  addEventListener(canvas, "wheel", function(/** WheelEvent */ evnt) {
-    let d = evnt.deltaY;
-    if (d) {
-      if (evnt.shiftKey)
-        camera.rotateZ(d);
-      else if (evnt.altKey || evnt.ctrlKey || evnt.metaKey)
-        camera.translateZ(d);
-      else
-        camera.zoom(d);
-      render();
-    }
-    evnt.preventDefault();
-  });
-};
 
 Viewer.prototype.clear = function() {
   this.spheres.clear();

--- a/plugins/cindy3d/src/str/texq-frag.glsl
+++ b/plugins/cindy3d/src/str/texq-frag.glsl
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 uniform sampler2D uTexture;
 varying vec2 vPos;

--- a/plugins/cindy3d/src/str/texq-vert.glsl
+++ b/plugins/cindy3d/src/str/texq-vert.glsl
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 attribute vec4 aPos;
 varying vec2 vPos;


### PR DESCRIPTION
Fixes #39.

This adds touch event support for Cindy3D. It also increases floating-point precision, which improves rendering of many elements on some mobile devices.

@richter-gebert can you have a look how this works for you? The iPads I've been testing this on still don't support EXT_frag_depth, according to http://webglreport.com/, which breaks some examples, in particular all those with the torus knot. But apart from that, most examples look reasonably decent now, and can be interacted with in what I consider an intuitive way.