### PR TITLE
Adjust specular reflectiveness based on shininess

### DIFF
--- a/examples/cindy3d/19_Specular.html
+++ b/examples/cindy3d/19_Specular.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>WebGL testing</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/Cindy3D.js"></script>
+<script id="csinit" type="text/x-cindyscript">use("Cindy3D")</script>
+<script id="csdraw" type="text/x-cindyscript">
+begin3d();
+background3d([0,0,0]);
+pointsize3d(5);
+pointcolor3d([.5,.4,.7]);
+directionallight3d(0, direction->[1,1,-5], frame->"world");
+draw3d([1,1,0], shininess->1);
+draw3d([0,1,0], shininess->5);
+draw3d([-1,1,0], shininess->10);
+draw3d([-1,0,0], shininess->20);
+draw3d([-1,-1,0], shininess->50);
+draw3d([0,-1,0], shininess->100);
+draw3d([1,-1,0], shininess->500);
+draw3d([1,0,0], shininess->0);
+end3d();
+</script>
+<script type="text/javascript">
+CindyJS({canvasname:"CSCanvas",scripts:"cs*"});
+</script>
+</head>
+
+<body>
+  <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
+</body>
+
+</html>

--- a/plugins/cindy3d/src/js/PrimitiveRenderer.js
+++ b/plugins/cindy3d/src/js/PrimitiveRenderer.js
@@ -207,6 +207,7 @@ PrimitiveRenderer.prototype.recompileShader = function(viewer) {
   let vs = [
     "precision mediump float;",
     "varying float vShininess;",
+    "varying float vSpecularReflectiveness;",
     this.vertexShaderCode
   ].join("\n");
   let fs = [

--- a/plugins/cindy3d/src/str/cylinder-vert.glsl
+++ b/plugins/cindy3d/src/str/cylinder-vert.glsl
@@ -49,6 +49,7 @@ void main() {
   // Copy attributes to varyings for use in the fragment shader
   vColor = aColor;
   vShininess = aShininess.x;
+  vSpecularReflectiveness = (1.0 - pow(0.95, vShininess));
   vRadius = aRelativeRadius.w;
 
   // Transform position into screen space

--- a/plugins/cindy3d/src/str/lighting1.glsl
+++ b/plugins/cindy3d/src/str/lighting1.glsl
@@ -3,6 +3,7 @@ uniform mat4 uModelViewMatrix;
 
 varying vec4 vColor;
 varying float vShininess;
+varying float vSpecularReflectiveness;
 
 vec3 gPos;
 vec3 gEye;
@@ -24,7 +25,7 @@ void commonLight(in vec4 lightPos, out vec3 lightDir,
   if (diffuseFactor == 0.0)
     specularFactor = 0.0;
   else
-    specularFactor = pow(specularDot, vShininess);
+    specularFactor = pow(specularDot, vShininess) * vSpecularReflectiveness;
 }
 
 vec4 flipY(in vec4 v) {

--- a/plugins/cindy3d/src/str/sphere-vert.glsl
+++ b/plugins/cindy3d/src/str/sphere-vert.glsl
@@ -30,6 +30,7 @@ void main() {
   // Copy attributes to varyings for use in the fragment shader
   vColor = aColor;
   vShininess = aRelativeShininessRadius.z;
+  vSpecularReflectiveness = (1.0 - pow(0.95, vShininess));
   vRadius = aRelativeShininessRadius.w;
 
   // Cover sphere by quad in front of the real sphere

--- a/plugins/cindy3d/src/str/triangle-vert.glsl
+++ b/plugins/cindy3d/src/str/triangle-vert.glsl
@@ -14,5 +14,6 @@ void main() {
   gl_Position = uProjectionMatrix * vPos;
   vNormal = uModelViewMatrix * vec4(aNormalAndShininess.xyz, 0.0);
   vShininess = aNormalAndShininess.w;
+  vSpecularReflectiveness = (1.0 - pow(0.95, vShininess));
   vColor = aColor;
 }


### PR DESCRIPTION
This prevents dull objects from looking extremely overexposed. Look at the example to see the effect of these changes here:

![Before](https://cloud.githubusercontent.com/assets/190759/22443846/be7c4772-e740-11e6-9639-9837eda19773.png)

![After](https://cloud.githubusercontent.com/assets/190759/22443847/be80eb92-e740-11e6-9f50-e6fe97a04e1d.png)

@richter-gebert do you think we need more flexible manual control, or can we use this automatic coupling between shininess and specular reflectiveness and avoid burdening users with yet another parameter to tweak?