### PR TITLE
Fix max and min for CindyGL + highp int

### DIFF
--- a/examples/cindygl/44_raycasting_aberth_real.html
+++ b/examples/cindygl/44_raycasting_aberth_real.html
@@ -121,7 +121,7 @@
 
 
     F(p) := (
-        fun(p.x / zoom, p.y / zoom, p.z / zoom);
+        zoom^(N-1)*fun(p.x / zoom, p.y / zoom, p.z / zoom);
     );
 
     helpfun(s, x) := log(|F(s*x)|)/log(s*|x|); //is approx. degree+log(leadingcoeff)/log(s*|x|) for large s
@@ -197,6 +197,8 @@
             
             polyvalues = apply(li, F(ray(pos, #)));
             poly = B * polyvalues; //interpolate
+            
+            //poly = 1/(poly_N)*poly;
             dpoly = d(poly);
           
             z = apply(1..(N-1), l+#*(u-l)/(N-1)); //take real roots as starting value
@@ -211,7 +213,7 @@
             );
             
             forall(
-             reverse(sort(apply(z, if(|F(ray(pos, #))|<0.001, re(#), oo)))), //only take real roots
+             reverse(sort(apply(z, if(|F(ray(pos, #))|<0.00001, re(#), oo)))), //only take real roots
              color = updatecolor(pos, #, color); );
             
         ); color

--- a/examples/cindygl/44_raycasting_advanced.html
+++ b/examples/cindygl/44_raycasting_advanced.html
@@ -121,7 +121,7 @@
 
 
     F(p) := (
-        fun(p.x / zoom, p.y / zoom, p.z / zoom);
+        zoom^(N-1)*fun(p.x / zoom, p.y / zoom, p.z / zoom);
     );
 
     helpfun(s, x) := log(|F(s*x)|)/log(s*|x|); //is approx. degree+log(leadingcoeff)/log(s*|x|) for large s

--- a/plugins/cindygl/src/js/LinearAlgebra.js
+++ b/plugins/cindygl/src/js/LinearAlgebra.js
@@ -269,8 +269,8 @@ function usereverse(t) {
 function generatemax(t, modifs, codebuilder) {
     let name = `max${webgltype(t)}`;
     codebuilder.add('functions', name, () => `${webgltype(t.parameters)} ${name}(${webgltype(t)} a){` +
-        `${webgltype(t.parameters)} m;\n` +
-        range(t.length).map(function(i) {
+      `${webgltype(t.parameters)} m = ${accesslist(t, t.length-1)(['a', t.length-1], modifs, codebuilder)};\n` +
+      range(t.length-1).map(function(i) {
             let a = accesslist(t, i)(['a', i], modifs, codebuilder);
             //update m to max
             return `m = max(m,${a});`;
@@ -288,8 +288,8 @@ function usemax(t) {
 function generatemin(t, modifs, codebuilder) {
     let name = `min${webgltype(t)}`;
     codebuilder.add('functions', name, () => `${webgltype(t.parameters)} ${name}(${webgltype(t)} a){` +
-        `${webgltype(t.parameters)} m;\n` +
-        range(t.length).map(function(i) {
+        `${webgltype(t.parameters)} m = ${accesslist(t, t.length-1)(['a', t.length-1], modifs, codebuilder)};\n` +
+        range(t.length-1).map(function(i) {
             let a = accesslist(t, i)(['a', i], modifs, codebuilder);
             //update m to min
             return `m = min(m,${a});`;

--- a/plugins/cindygl/src/js/LinearAlgebra.js
+++ b/plugins/cindygl/src/js/LinearAlgebra.js
@@ -269,8 +269,8 @@ function usereverse(t) {
 function generatemax(t, modifs, codebuilder) {
     let name = `max${webgltype(t)}`;
     codebuilder.add('functions', name, () => `${webgltype(t.parameters)} ${name}(${webgltype(t)} a){` +
-      `${webgltype(t.parameters)} m = ${accesslist(t, t.length-1)(['a', t.length-1], modifs, codebuilder)};\n` +
-      range(t.length-1).map(function(i) {
+        `${webgltype(t.parameters)} m = ${accesslist(t, t.length-1)(['a', t.length-1], modifs, codebuilder)};\n` +
+        range(t.length - 1).map(function(i) {
             let a = accesslist(t, i)(['a', i], modifs, codebuilder);
             //update m to max
             return `m = max(m,${a});`;
@@ -289,7 +289,7 @@ function generatemin(t, modifs, codebuilder) {
     let name = `min${webgltype(t)}`;
     codebuilder.add('functions', name, () => `${webgltype(t.parameters)} ${name}(${webgltype(t)} a){` +
         `${webgltype(t.parameters)} m = ${accesslist(t, t.length-1)(['a', t.length-1], modifs, codebuilder)};\n` +
-        range(t.length-1).map(function(i) {
+        range(t.length - 1).map(function(i) {
             let a = accesslist(t, i)(['a', i], modifs, codebuilder);
             //update m to min
             return `m = min(m,${a});`;

--- a/plugins/cindygl/src/str/standardFragmentHeader.glsl
+++ b/plugins/cindygl/src/str/standardFragmentHeader.glsl
@@ -1,5 +1,6 @@
 #ifdef GL_ES
 precision highp float;
+precision highp int;
 #endif
 
 #define pi 3.141592653589793


### PR DESCRIPTION
Before that, max and min could have returned wrong values because of an uninitialized variable.
Futhermore, highp int is used as default.