### PR TITLE
Cindy3D: Allow supplying textures by object not name, allow NPOT textures

### DIFF
--- a/examples/cindy3d/19_TexTorusCam.html
+++ b/examples/cindy3d/19_TexTorusCam.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>WebGL testing</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/Cindy3D.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+  use("Cindy3D");
+  vid = cameravideo();
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+m = 50;
+n = 20;
+r1 = 1;
+r2 = 0.3;
+begin3d();
+mesh3d(m+1, n+1, flatten(apply(0..m, i, apply(0..n, j, (
+  a = i/m*360°;
+  b = j/n*360°;
+  p = [cos(a), sin(a), 0];
+  q = cos(b)*[0,0,1] + sin(b)*p;
+  r1*p + r2*q
+)))), flatten(apply(0..m, i, apply(0..n, j, (
+  a = i/m*360°;
+  b = j/n*360°;
+  p = [cos(a), sin(a), 0];
+  cos(b)*[0,0,1] + sin(b)*p
+)))), uv->flatten(apply(0..m, i, apply(0..n, j, (
+  a = 2*i/m;
+  b = 2*j/n;
+  2/512*(1,1) + 508/512*(min(a, 2-a), min(b, 2-b))
+)))), normaltype->"perVertex", texture->vid);
+end3d();
+</script>
+<script type="text/javascript">
+CindyJS({canvasname:"CSCanvas",scripts:"cs*",images:{tex1:"tex1.png"}});
+</script>
+</head>
+
+<body>
+  <canvas id="Cindy3D" style="border: none;" width="632" height="452"></canvas>
+  <div id="CSCanvas" style="width:50px; height:50px; border:none"></div>
+</body>
+
+</html>

--- a/plugins/cindy3d/src/js/Ops3D.js
+++ b/plugins/cindy3d/src/js/Ops3D.js
@@ -363,7 +363,7 @@ CindyJS.registerPlugin(1, "Cindy3D", function(api) {
     let topology = "open";
     let colors = null;
     let uv = null;
-    let texture = null;
+    let /** @type {?CindyJS.image} */ texture = null;
     let appearance = handleModifsAppearance(
       currentInstance.surfaceAppearance, modifs, {
         "normaltype": (a => normaltype =
@@ -376,21 +376,16 @@ CindyJS.registerPlugin(1, "Cindy3D", function(api) {
           elt => coerce.toColor(elt))),
         "uv": (a => uv = coerce.toList(a).map(
           elt => coerce.toHomog(elt, [0, 0, 0], 2))),
-        "texture": (a => texture = coerce.toString(a)),
+        "texture": (a => texture = api.getImage(a, /*lazy=*/ true)),
       });
     if (pos.length !== m*n) return nada;
     if (texture !== null && uv != null) {
-      const img = api.getImage(/** @type {string} */(texture));
-      if (!img) {
-        console.log("No such texture image: " + texture);
-        return nada;
-      }
 
       // TODO: EVIL HACK!!!!! Fix version if you use this!
       // This sets the texture for all meshes in the instance,
       // even though the modifier is just on a single mesh primitive.
       // Will cause terribly wrong results if more than one mesh is drawn.
-      currentInstance.triangles.texture = img;
+      currentInstance.triangles.texture = texture;
       currentInstance.triangles.opaque = false;
 
       colors = uv; // Re-use the same object

--- a/plugins/cindy3d/src/js/Triangles.js
+++ b/plugins/cindy3d/src/js/Triangles.js
@@ -156,14 +156,26 @@ Triangles.prototype.texture = null;
 /** @type {?WebGLTexture} */
 Triangles.prototype.textureObj = null;
 
+/** @type {?HTMLCanvasElement} */
+Triangles.prototype.textureScaler = null;
+
 /**
  * @param {Viewer} viewer
  */
 Triangles.prototype.render = function(viewer) {
   const gl = viewer.gl;
   if (this.texture) {
+    if (!this.texture.ready)
+      return;
+    if (this.texture.cdyUpdate)
+      this.texture.cdyUpdate();
     if (this.textureObj === null) {
       this.textureObj = gl.createTexture();
+    }
+    let w = this.texture.width, h = this.texture.height;
+    if (true) {
+      w = nextPowerOfTwo(w);
+      h = nextPowerOfTwo(h);
     }
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.textureObj);
@@ -173,8 +185,22 @@ Triangles.prototype.render = function(viewer) {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER,
                      gl.LINEAR_MIPMAP_LINEAR);
     gl.hint(gl.GENERATE_MIPMAP_HINT, gl.NICEST);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE,
-                  this.texture.img);
+    let /** @type {HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} */ img
+        = this.texture.img;
+    if (w !== this.texture.width || h !== this.texture.height) {
+      if (!this.textureScaler) {
+        this.textureScaler = /** @type {HTMLCanvasElement} */
+          (document.createElement("canvas"));
+        this.textureScaler.width = w;
+        this.textureScaler.height = h;
+      }
+      let ctx = this.textureScaler.getContext("2d");
+      ctx.clearRect(0, 0, w, h);
+      ctx.drawImage(this.texture.img, 0, 0, w, h);
+      img = this.textureScaler;
+    }
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA,
+                  gl.UNSIGNED_BYTE, img);
     gl.generateMipmap(gl.TEXTURE_2D);
     this.renderPrimitives(gl, u => {
       viewer.setUniforms(u);
@@ -189,3 +215,12 @@ Triangles.prototype.render = function(viewer) {
     });
   }
 };
+
+function nextPowerOfTwo(x) {
+  if ((x & (x - 1)) === 0)
+    return x;
+  let y = 1;
+  while (y < x)
+    y *= 2;
+  return y;
+}


### PR DESCRIPTION
Now a texture can be given using any CindyJS-supported image format, not only using a string by name.  There is also support for textures which are not a power of two in size, rescaling them to make them power of two.  These two combine nicely to allow e.g. a live camera video as texture.

See https://github.com/CindyJS/CindyJS/pull/571#pullrequestreview-19546447 for previous discussion about this.

At the moment there is no fast-track approach to use CindyGL output as a texture without going via a HTMLCanvasElement. Such a shortcut would certainly be feasible, but probably should be achieved by making the corresponding property part of the externs specification, to allow for better interoperability with future extensions. Probably best handled in a subsequent PR.