### PR TITLE
Compose transformations

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2589,6 +2589,107 @@ geoOps.TransformPolygon.updatePosition = function(el) {
     }));
 };
 
+geoOps.TrComposeTrTr = {};
+geoOps.TrComposeTrTr.kind = "Tr";
+geoOps.TrComposeTrTr.signature = ["Tr", "Tr"];
+geoOps.TrComposeTrTr.updatePosition = function(el) {
+    var a = csgeo.csnames[el.args[0]];
+    var b = csgeo.csnames[el.args[1]];
+    el.matrix = List.normalizeMax(List.productMM(b.matrix, a.matrix));
+    el.dualMatrix = List.normalizeMax(List.productMM(b.dualMatrix, a.dualMatrix));
+};
+
+geoOps._helper.composeMtMt = function(el, m, n) {
+    var add = CSNumber.add;
+    var sub = CSNumber.sub;
+    var mult = CSNumber.mult;
+
+    function f1(a, b, c, d) { // a*b + c*d
+        return add(mult(a, b), mult(c, d));
+    }
+
+    function f2(a, b, c, d, e, f, g, h) {
+        return add(f1(a, b, c, d), f1(e, f, g, h));
+    }
+
+    function f3(a, b, c, d, e, f, g, h) {
+        return sub(f1(a, b, c, d), f1(e, f, g, h));
+    }
+
+    var addsub = n.anti ? f3 : f2;
+    var subadd = n.anti ? f2 : f3;
+    var v = List.normalizeMax(List.turnIntoCSList([
+        subadd(m.ar, n.ar, m.cr, n.br, m.ai, n.ai, m.ci, n.bi),
+        addsub(m.ar, n.ai, m.cr, n.bi, m.ai, n.ar, m.ci, n.br),
+        subadd(m.br, n.ar, m.dr, n.br, m.bi, n.ai, m.di, n.bi),
+        addsub(m.br, n.ai, m.dr, n.bi, m.bi, n.ar, m.di, n.br),
+        subadd(m.ar, n.cr, m.cr, n.dr, m.ai, n.ci, m.ci, n.di),
+        addsub(m.ar, n.ci, m.cr, n.di, m.ai, n.cr, m.ci, n.dr),
+        subadd(m.br, n.cr, m.dr, n.dr, m.bi, n.ci, m.di, n.di),
+        addsub(m.br, n.ci, m.dr, n.di, m.bi, n.cr, m.di, n.dr)
+    ])).value;
+    el.moebius = {
+        anti: m.anti !== n.anti,
+        ar: v[0],
+        ai: v[1],
+        br: v[2],
+        bi: v[3],
+        cr: v[4],
+        ci: v[5],
+        dr: v[6],
+        di: v[7]
+    };
+    geoOps._helper.moebiusPair(el);
+};
+
+geoOps._helper.euc2moeb = function(el) {
+    var m = el.matrix.value;
+    var d = CSNumber.sub( // determinant of upper left 2x2 block
+        CSNumber.mult(m[0].value[0], m[1].value[1]),
+        CSNumber.mult(m[1].value[0], m[0].value[1]));
+    return {
+        anti: d.value.real < 0, // DANGER!!! This feels non-analytic!
+        ar: m[0].value[0],
+        ai: m[1].value[0],
+        br: m[0].value[2],
+        bi: m[1].value[2],
+        cr: CSNumber.zero,
+        ci: CSNumber.zero,
+        dr: m[2].value[2],
+        di: CSNumber.zero
+    };
+};
+
+geoOps.TrComposeMtMt = {};
+geoOps.TrComposeMtMt.kind = "Mt";
+geoOps.TrComposeMtMt.signature = ["Mt", "Mt"];
+geoOps.TrComposeMtMt.updatePosition = function(el) {
+    geoOps._helper.composeMtMt(
+        el,
+        csgeo.csnames[el.args[0]].moebius,
+        csgeo.csnames[el.args[1]].moebius);
+};
+
+geoOps.TrComposeTrMt = {};
+geoOps.TrComposeTrMt.kind = "Mt";
+geoOps.TrComposeTrMt.signature = ["Tr", "Mt"];
+geoOps.TrComposeTrMt.updatePosition = function(el) {
+    geoOps._helper.composeMtMt(
+        el,
+        geoOps._helper.euc2moeb(csgeo.csnames[el.args[0]]),
+        csgeo.csnames[el.args[1]].moebius);
+};
+
+geoOps.TrComposeMtTr = {};
+geoOps.TrComposeMtTr.kind = "Mt";
+geoOps.TrComposeMtTr.signature = ["Mt", "Tr"];
+geoOps.TrComposeMtTr.updatePosition = function(el) {
+    geoOps._helper.composeMtMt(
+        el,
+        csgeo.csnames[el.args[0]].moebius,
+        geoOps._helper.euc2moeb(csgeo.csnames[el.args[1]]));
+};
+
 geoOps._helper.pointReflection = function(center, point) {
     // If center is at infinity, the result will be center unless point
     // is also at infinity, then the result is the ideal point [0, 0, 0].
@@ -3014,6 +3115,19 @@ geoMacros.Transform = function(el) {
 
 geoMacros.TrReflection = function(el) {
     var op = "TrReflection" + csgeo.csnames[el.args[0]].kind;
+    if (geoOps.hasOwnProperty(op)) {
+        el.type = op;
+        return [el];
+    } else {
+        console.log(op + " not implemented yet");
+        return [];
+    }
+};
+
+geoMacros.TrCompose = function(el) {
+    var op = "TrCompose" + el.args.map(function(name) {
+        return csgeo.csnames[name].kind;
+    }).join("");
     if (geoOps.hasOwnProperty(op)) {
         el.type = op;
         return [el];

--- a/tests/GeoOps_tests.js
+++ b/tests/GeoOps_tests.js
@@ -64,6 +64,37 @@ function testGeo(geometry, verifier, done) {
   CindyJS(data);
 }
 
+function testEqualPoints(geometry, equalities, done) {
+  var initscript = 'use("verify");\n' +
+      equalities.map(function(eq) {
+        return "same(" + eq.replace("=", ", ") + ");\n"
+      }).join("") +
+      "done()";
+  var error = null;
+  function plugin(api) {
+    api.defineFunction("same", 2, function(args, modifs) {
+      if (error) return; // only report first error
+      var el1 = api.evaluate(args[0]).value;
+      var el2 = api.evaluate(args[1]).value;
+      if (!almostEqualVector(el1.homog, el2.homog))
+        error = new Error(
+          el1.name + niceprint(el1.homog) + " != " +
+          el2.name + niceprint(el2.homog));
+    });
+    api.defineFunction("done", 0, function(args, modifs) {
+      done(error);
+    });
+  }
+  plugin.apiVersion = 1;
+  var data = {
+    isNode: true,
+    geometry: geometry,
+    scripts: { init: initscript },
+    plugins: { verify: plugin }
+  };
+  CindyJS(data);
+}
+
 //////////////////////////////////////////////////////////////////////
 // Now come the test cases
 
@@ -164,6 +195,159 @@ describe("IntersectLC helper", function() {
     p2.value[0].value.imag.should.be.approximately(0, 1e-12);
     p2.value[1].value.real.should.be.approximately(-3, 1e-12);
     p2.value[1].value.imag.should.be.approximately(0, 1e-12);
+  });
+});
+
+describe("Möbius Transformations", function() {
+  it("TrMoebius", function(done) {
+    testEqualPoints([
+      {name: "A1", type: "RandomPoint"},
+      {name: "B1", type: "RandomPoint"},
+      {name: "C1", type: "RandomPoint"},
+      {name: "A2", type: "RandomPoint"},
+      {name: "B2", type: "RandomPoint"},
+      {name: "C2", type: "RandomPoint"},
+      {name: "Tr1", type: "TrMoebius", args: ["A1", "A2", "B1", "B2", "C1", "C2"]},
+      {name: "A3", type: "TrMoebiusP", args: ["Tr1", "A1"]},
+      {name: "B3", type: "TrMoebiusP", args: ["Tr1", "B1"]},
+      {name: "C3", type: "TrMoebiusP", args: ["Tr1", "C1"]},
+    ], ["A2=A3", "B2=B3", "C2=C3"], done);
+  });
+  it("TrInverseMoebius", function(done) {
+    testEqualPoints([
+      {name: "A1", type: "RandomPoint"},
+      {name: "B1", type: "RandomPoint"},
+      {name: "C1", type: "RandomPoint"},
+      {name: "A2", type: "RandomPoint"},
+      {name: "B2", type: "RandomPoint"},
+      {name: "C2", type: "RandomPoint"},
+      {name: "Tr1", type: "TrMoebius", args: ["A1", "A2", "B1", "B2", "C1", "C2"]},
+      {name: "Tr2", type: "TrInverseMoebius", args: ["Tr1"]},
+      {name: "A4", type: "TrMoebiusP", args: ["Tr2", "A2"]},
+      {name: "B4", type: "TrMoebiusP", args: ["Tr2", "B2"]},
+      {name: "C4", type: "TrMoebiusP", args: ["Tr2", "C2"]},
+    ], ["A1=A4", "B1=B4", "C1=C4"], done);
+  });
+  it("TrReflectionC", function(done) {
+    testEqualPoints([
+      {name: "M", type: "RandomPoint"},
+      {name: "A", type: "RandomPoint"},
+      {name: "C", type: "CircleMP", args: ["M", "A"]},
+      {name: "Tr", type: "TrReflectionC", args: ["C"]},
+      {name: "P1", type: "RandomPoint"},
+      {name: "P2", type: "TrMoebiusP", args: ["Tr", "P1"]},
+      {name: "P3", type: "TrMoebiusP", args: ["Tr", "P2"]},
+      {name: "g1", type: "Join", args: ["M", "P1"]},
+      {name: "g2", type: "Join", args: ["P1", "P2"]},
+    ], ["P1=P3", "g1=g2"], done);
+  });
+});
+
+describe("TrCompose", function() {
+
+  function directMoebiusTrafo(name) {
+    var P = [0, 1, 2, 3].map(function(i) {
+      return name + "_P" + i;
+    });
+    return [
+      {name: P[0], type: "RandomPoint"},
+      {name: P[1], type: "RandomPoint"},
+      {name: P[2], type: "RandomPoint"},
+      {name: P[3], type: "RandomPoint"},
+      {name: name, type: "TrMoebius", args: [P[0], P[0], P[1], P[1], P[2], P[3]]}
+    ];
+  }
+
+  function reverseMoebiusTrafo(name) {
+    return [
+      {name: name + "_M", type: "RandomPoint"},
+      {name: name + "_P", type: "RandomPoint"},
+      {name: name + "_C", type: "CircleMP", args: [name + "_M", name + "_P"]},
+      {name: name, type: "TrReflectionC", args: [name + "_C"]}
+    ];
+  }
+
+  function directEuclideanTrafo(name) {
+    var P = [0, 1, 2, 3].map(function(i) {
+      return name + "_P" + i;
+    });
+    return [
+      {name: P[0], type: "RandomPoint"},
+      {name: P[1], type: "RandomPoint"},
+      {name: P[2], type: "RandomPoint"},
+      {name: P[3], type: "RandomPoint"},
+      {name: name, type: "TrSimilarity", args: P}
+    ];
+  }
+
+  function reverseEuclideanTrafo(name) {
+    return [
+      {name: name + "_L", type: "RandomLine"},
+      {name: name, type: "TrReflectionL", args: [name + "_L"]}
+    ];
+  }
+
+  function testTrCompose(gen1, gen2, done) {
+    var geometry = gen1("Tr1").concat(gen2("Tr2"), [
+      {name: "Tr3", type: "TrCompose", args: ["Tr1", "Tr2"]},
+      {name: "P1", type: "RandomPoint"},
+      {name: "P2", type: "Transform", args: ["Tr1", "P1"]},
+      {name: "P3", type: "Transform", args: ["Tr2", "P2"]},
+      {name: "P4", type: "Transform", args: ["Tr3", "P1"]},
+    ]);
+    testEqualPoints(geometry, ["P3=P4"], done);
+  }
+
+  it("TrComposeTrTr direct direct", function(done) {
+    testTrCompose(directEuclideanTrafo, directEuclideanTrafo, done);
+  });
+  it("TrComposeTrTr direct reverse", function(done) {
+    testTrCompose(directEuclideanTrafo, reverseEuclideanTrafo, done);
+  });
+  it("TrComposeTrTr reverse direct", function(done) {
+    testTrCompose(reverseEuclideanTrafo, directEuclideanTrafo, done);
+  });
+  it("TrComposeTrTr reverse reverse", function(done) {
+    testTrCompose(reverseEuclideanTrafo, reverseEuclideanTrafo, done);
+  });
+
+  it("TrComposeMtMt direct direct", function(done) {
+    testTrCompose(directMoebiusTrafo, directMoebiusTrafo, done);
+  });
+  it("TrComposeMtMt direct reverse", function(done) {
+    testTrCompose(directMoebiusTrafo, reverseMoebiusTrafo, done);
+  });
+  it("TrComposeMtMt reverse direct", function(done) {
+    testTrCompose(reverseMoebiusTrafo, directMoebiusTrafo, done);
+  });
+  it("TrComposeMtMt reverse reverse", function(done) {
+    testTrCompose(reverseMoebiusTrafo, reverseMoebiusTrafo, done);
+  });
+
+  it("TrComposeTrMt direct direct", function(done) {
+    testTrCompose(directEuclideanTrafo, directMoebiusTrafo, done);
+  });
+  it("TrComposeTrMt direct reverse", function(done) {
+    testTrCompose(directEuclideanTrafo, reverseMoebiusTrafo, done);
+  });
+  it("TrComposeTrMt reverse direct", function(done) {
+    testTrCompose(reverseEuclideanTrafo, directMoebiusTrafo, done);
+  });
+  it("TrComposeTrMt reverse reverse", function(done) {
+    testTrCompose(reverseEuclideanTrafo, reverseMoebiusTrafo, done);
+  });
+
+  it("TrComposeMtTr direct direct", function(done) {
+    testTrCompose(directMoebiusTrafo, directEuclideanTrafo, done);
+  });
+  it("TrComposeMtTr direct reverse", function(done) {
+    testTrCompose(directMoebiusTrafo, reverseEuclideanTrafo, done);
+  });
+  it("TrComposeMtTr reverse direct", function(done) {
+    testTrCompose(reverseMoebiusTrafo, directEuclideanTrafo, done);
+  });
+  it("TrComposeMtTr reverse reverse", function(done) {
+    testTrCompose(reverseMoebiusTrafo, reverseEuclideanTrafo, done);
   });
 });
 


### PR DESCRIPTION
This allows for the composition of transformations.

Instead of a visual example there is a sizable test suite to ensure that transforming a point by the transformations one after the other has the same effect as applying the combined transformation.  The test framework was also extended to verify some basic properties of Möbius transformations.