### PR TITLE
Check only html files for forbidden pattern

### DIFF
--- a/make/build.js
+++ b/make/build.js
@@ -168,7 +168,7 @@ module.exports = function build(settings, task) {
     //////////////////////////////////////////////////////////////////////
 
     task("forbidden", [], function() {
-        this.forbidden("examples/**/*", [
+        this.forbidden("examples/**/*.html", [
             // Correct MIME type is "text/x-cindyscript"
             /<script[^>]*type *= *["'][^"'\/]*["']/g,          // requires /
             /<script[^>]*type *= *["']text\/cindyscript["']/g, // requires x-

--- a/make/build.js
+++ b/make/build.js
@@ -172,8 +172,8 @@ module.exports = function build(settings, task) {
             // Correct MIME type is "text/x-cindyscript"
             /<script[^>]*type *= *["'][^"'\/]*["']/g,          // requires /
             /<script[^>]*type *= *["']text\/cindyscript["']/g, // requires x-
-            /.*firstDrawing.*/g, // excessive copy & paste of old example
-            /.*(cinderella\.de|cindyjs\.org)\/.*\/Cindy.*\.js.*/g, // remote
+            /firstDrawing/g, // excessive copy & paste of old example
+            /(cinderella\.de|cindyjs\.org)\/.*\/Cindy.*\.js/g, // remote
             /<canvas[^>]+id=['"]CSCanvas/g,                    // use <div>
         ]);
         this.forbidden("ref/**/*.md", [


### PR DESCRIPTION
This reduces the execution time of the tests if there are additional files present in the example directory. 