### PR TITLE
add alt for <img> elements in examples

### DIFF
--- a/examples/141_fileDrop.html
+++ b/examples/141_fileDrop.html
@@ -57,8 +57,8 @@ var cdy = CindyJS({
   <p>You can also drag and drop
     <a href="../package.json" draggable="true">this link</a> (on some browsers)
     or these images (on most browsers):<br>
-    <img src="rost.png" draggable="true">
-    <img src="boe.png" draggable="true">
+    <img src="rost.png" draggable="true" alt="rost">
+    <img src="boe.png" draggable="true" alt="boe">
   </p>
 </body>
 


### PR DESCRIPTION
We need this before the next release in order to built the cindyjs-homepage successfully 