### PR TITLE
replace .plain.js with .js

### DIFF
--- a/examples/106_DrawTrace1.html
+++ b/examples/106_DrawTrace1.html
@@ -9,7 +9,7 @@
                 padding: 0;
             }
         </style>
-        <script type="text/javascript" src="../build/js/Cindy.plain.js"></script>
+        <script type="text/javascript" src="../build/js/Cindy.js"></script>
         <script type="text/javascript">
 var cdy = CindyJS({
   scripts: "cs*",

--- a/examples/cmdline.html
+++ b/examples/cmdline.html
@@ -3,7 +3,7 @@
   <head>
     <title>CindyScript command line</title>
     <meta charset="utf-8"/>
-    <script src="../build/js/Cindy.plain.js"></script>
+    <script src="../build/js/Cindy.js"></script>
     <script>
       var cindy = CindyJS({
         canvasname:"Cindy"

--- a/examples/symbolic/01_basic_symbolic_operations.html
+++ b/examples/symbolic/01_basic_symbolic_operations.html
@@ -3,7 +3,7 @@
   <head>
     <title>CindyScript command line</title>
     <meta charset="utf-8"/>
-    <script src="../../build/js/Cindy.plain.js"></script>
+    <script src="../../build/js/Cindy.js"></script>
     <script src="../../build/js/symbolic.js"></script>
     <script id='csinit' type='text/x-cindyscript'>
           f(x) := x*x+1;

--- a/examples/symbolic/02_plots.html
+++ b/examples/symbolic/02_plots.html
@@ -3,7 +3,7 @@
   <head>
     <title>CindyScript command line</title>
     <meta charset="utf-8"/>
-    <script src="../../build/js/Cindy.plain.js"></script>
+    <script src="../../build/js/Cindy.js"></script>
     <script src="../../build/js/symbolic.js"></script>
     <link rel="stylesheet" href="../../build/js/CindyJS.css">
     <script id='csinit' type='text/x-cindyscript'>

--- a/examples/test_create.html
+++ b/examples/test_create.html
@@ -9,7 +9,7 @@
                 padding: 0;
             }
         </style>
-        <script type="text/javascript" src="../build/js/Cindy.plain.js"></script>
+        <script type="text/javascript" src="../build/js/Cindy.js"></script>
         <script type="text/javascript">
             CindyJS({ 
         	scripts: "cs*", 


### PR DESCRIPTION
Examples that use CindyJS.plain.js will not work on the homepage