### PR TITLE
compatibility with Cinderella handling of drawtext modifier

### DIFF
--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -255,7 +255,7 @@ Render2D.modifHandlers = {
                 Render2D.align = 0;
             if (s === "right")
                 Render2D.align = 1;
-            if (s === "mid")
+            if (s === "mid" || s === "center")
                 Render2D.align = 0.5;
         }
     },


### PR DESCRIPTION
In Cinderella it is possible to align text using the align->“center“ modifier. CindyJS so far only handles align->“mid“. This commit adds „center“.