### PR TITLE
Switch to using the trusty environment on Travis, currently in beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - node
   - "0.12"
 script: node make build=release alltests
+dist: trusty
 sudo: false
 addons:
   apt:


### PR DESCRIPTION
See https://docs.travis-ci.com/user/trusty-ci-environment/ for details.
This is meant as an alternative to #605 for getting us with a C++11 enabled GCC 4.8.
According to https://wiki.ubuntu.com/Releases, Precise has seen its end of life on 2017-04-28, so I think moving towards trusty is a reasonable next step, and the Beta appears to work well enough for us.