### PR TITLE
Remove duplicate canvas from examples/cindygl/50_fluid.html

### DIFF
--- a/examples/cindygl/50_fluid.html
+++ b/examples/cindygl/50_fluid.html
@@ -167,7 +167,6 @@
 		<div id="container" style="width:512px; height: 512px">
 	    <div id="CSCanvas" style="width:100%; height:100%"></div>
 	  </div>
-    <div id="CSCanvas"></div>
 		<div>
 			Press <b>space</b> to reset advected image to checkerboard.
 		</div>


### PR DESCRIPTION
This fixes an build issue with the website.

Maybe we should use the check for duplicate ids in examples also for the main CindyJS repository.