### PR TITLE
Automatic use webgl 2.0 in Cindy3D if EXT_frag_depth not available

### DIFF
--- a/plugins/cindy3d/src/js/ShaderProgram.js
+++ b/plugins/cindy3d/src/js/ShaderProgram.js
@@ -25,6 +25,17 @@ GlError.prototype.toString = function() {
  */
 function ShaderProgram(gl, vertexShaderCode, fragmentShaderCode) {
   this.handle = gl.createProgram();
+  if(gl.webgl2) {
+    vertexShaderCode = "#version 300 es\n" +
+      vertexShaderCode.replace(/attribute/g, 'in')
+       .replace(/varying/g, 'out');
+    fragmentShaderCode = "#version 300 es\n" +
+      fragmentShaderCode.replace(/varying/g, 'in')
+       .replace(/gl_FragColor/g, 'FragColor')
+       .replace(/texture2D/g, 'texture')
+       .replace(/precision highp float;/g, "precision highp float;\n#define webgl2 true\nout vec4 FragColor;")
+       .replace(/gl_FragDepthEXT/g, "gl_FragDepth");
+  }
   this.vs = this.createShader(gl, gl.VERTEX_SHADER, vertexShaderCode);
   this.fs = this.createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderCode);
   this.link(gl);

--- a/plugins/cindy3d/src/js/ShaderProgram.js
+++ b/plugins/cindy3d/src/js/ShaderProgram.js
@@ -33,8 +33,7 @@ function ShaderProgram(gl, vertexShaderCode, fragmentShaderCode) {
       fragmentShaderCode.replace(/varying/g, 'in')
        .replace(/gl_FragColor/g, 'FragColor')
        .replace(/texture2D/g, 'texture')
-       .replace(/precision highp float;/g, "precision highp float;\n#define webgl2 true\nout vec4 FragColor;")
-       .replace(/gl_FragDepthEXT/g, "gl_FragDepth");
+       .replace(/precision highp float;/g, "precision highp float;\n#define webgl2 true\nout vec4 FragColor;");
   }
   this.vs = this.createShader(gl, gl.VERTEX_SHADER, vertexShaderCode);
   this.fs = this.createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderCode);

--- a/plugins/cindy3d/src/js/Viewer.js
+++ b/plugins/cindy3d/src/js/Viewer.js
@@ -30,6 +30,28 @@ function Viewer(name, ccOpts, opts, addEventListener) {
       canvas.getContext("experimental-webgl", ccOpts));
   if (!gl)
     throw new GlError("Could not obtain a WebGL context.\nReason: " + errorInfo);
+
+  if (/[?&]frag_depth=0/.test(window.location.search)) {
+    this.glExtFragDepth = null;
+  }
+  else {
+    this.glExtFragDepth = gl.getExtension("EXT_frag_depth");
+    if (!this.glExtFragDepth) {
+      console.log("EXT_frag_depth extension not supported, " +
+                  "will try webgl 2.0.");
+      let gl2 = /** @type {WebGLRenderingContext} */(
+        canvas.getContext("webgl2", ccOpts));
+      if (gl2) {
+        gl = gl2;
+        gl.webgl2 = true;
+        console.log("Loaded Webgl 2.0!");
+      } else {
+        console.log("Webgl 2.0 is not availible, " +
+                    "render in reduced quality.");
+      }
+    }
+  }
+
   canvas.removeEventListener(
     "webglcontextcreationerror",
     onContextCreationError, false);
@@ -40,15 +62,6 @@ function Viewer(name, ccOpts, opts, addEventListener) {
   this.width = canvas.width;
   this.height = canvas.height;
   this.gl = gl;
-  if (/[?&]frag_depth=0/.test(window.location.search)) {
-    this.glExtFragDepth = null;
-  }
-  else {
-    this.glExtFragDepth = gl.getExtension("EXT_frag_depth");
-    if (!this.glExtFragDepth)
-      console.log("EXT_frag_depth extension not supported, " +
-                  "will render with reduced quality.");
-  }
 
   this.ssFactor = 1;
   if (opts && opts.superSample) {

--- a/plugins/cindy3d/src/str/common-frag.glsl
+++ b/plugins/cindy3d/src/str/common-frag.glsl
@@ -29,4 +29,8 @@ void finish(in vec3 pos, in vec3 normal) {
   vec4 projPoint = uProjectionMatrix * vec4(pos, 1);
   gl_FragDepthEXT = (projPoint.z / projPoint.w + 1.0) / 2.0;
 #endif
+#ifdef webgl2
+  vec4 projPoint = uProjectionMatrix * vec4(pos, 1);
+  gl_FragDepthEXT = (projPoint.z / projPoint.w + 1.0) / 2.0;
+#endif
 }

--- a/plugins/cindy3d/src/str/common-frag.glsl
+++ b/plugins/cindy3d/src/str/common-frag.glsl
@@ -31,6 +31,6 @@ void finish(in vec3 pos, in vec3 normal) {
 #endif
 #ifdef webgl2
   vec4 projPoint = uProjectionMatrix * vec4(pos, 1);
-  gl_FragDepthEXT = (projPoint.z / projPoint.w + 1.0) / 2.0;
+  gl_FragDepth = (projPoint.z / projPoint.w + 1.0) / 2.0;
 #endif
 }


### PR DESCRIPTION
With this, WebGL 2.0 is used in Cindy3D if EXT_frag_depth not available. This hopefully should solve the rendering issues on iPads, because it seems that iOS 11 will support WebGL 2.0, which automatically supports frag_depth. However, we could not test it on iPads yet.

At this time, switching to WebGL 2.0 whenever available, seems not good as rendering problems become visible in "examples/cindy3d/01_ThreeSpheres.html" in Firefox and WebGL 2.0.

Thank you, @strobelm for helping with the first prototype :+1: 