### PR TITLE
ignore clearimage on undefined image

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1563,6 +1563,9 @@ evaluator.clearimage$1 = function(args, modifs) {
     }
 
     var image = imageFromValue(name);
+    if(!image)
+      return nada;
+      
     var localcanvas = image.img;
 
     if (typeof(localcanvas) === "undefined" || localcanvas === null) {

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1563,9 +1563,9 @@ evaluator.clearimage$1 = function(args, modifs) {
     }
 
     var image = imageFromValue(name);
-    if(!image)
-      return nada;
-      
+    if (!image)
+        return nada;
+
     var localcanvas = image.img;
 
     if (typeof(localcanvas) === "undefined" || localcanvas === null) {


### PR DESCRIPTION
Without this `examples/88_Vectorfield.html` fails because here clearimage is called on an undefined image. One should not do this intentionally, however, if one does it, it should be ignored instead of crashing CindyJS.