### PR TITLE
added webcam support for Safari 11

### DIFF
--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -466,8 +466,15 @@ evaluator.cameravideo$0 = function(args, modifs) {
     var img = loadImage(video, true);
     console.log("Opening stream.");
     openVideoStream(function success(stream) {
+        /* does not work in Safari 11.0 (beta)
         var url = window.URL.createObjectURL(stream);
         video.src = url;
+        */
+        video.srcObject = stream;
+        video.setAttribute('autoplay', '');
+        video.setAttribute('muted', '');
+        video.setAttribute('playsinline', '');
+        video.play();
         video.addEventListener("loadeddata", csplay);
     }, function failure(err) {
         console.error("Could not get user video:", String(err), err);


### PR DESCRIPTION
Safari 11 did not support
`var url = window.URL.createObjectURL(stream);`. The alternative `video.srcObject = stream;` also works on Firefox and Chromium. Furthermore some lines were added to make Safari accepting to play the stream.