### PR TITLE
Fix lagging video if frames are decoded in chunks

### DIFF
--- a/plugins/cindygl/src/js/CanvasWrapper.js
+++ b/plugins/cindygl/src/js/CanvasWrapper.js
@@ -250,7 +250,7 @@ CanvasWrapper.prototype.reloadIfRequired = function() {
 
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 0);
     this.generation = this.canvas.generation;
-    this.lastframecount = (this.canvas.img.webkitDecodedFrameCount || this.canvas.img.mozDecodedFrames);
+    this.lastframecount = Math.min(this.lastframecount + 1, this.canvas.img.webkitDecodedFrameCount || this.canvas.img.mozDecodedFrames);
 };
 
 CanvasWrapper.prototype.drawTo = function(context, x, y) {


### PR DESCRIPTION
Because of
https://github.com/CindyJS/CindyJS/pull/619 the example `examples/cindygl/34_video.html` that plays a video-file got laggy. The problem was that the video has been decoded in chunks in advance. Therefore also `webkitDecodedFrameCount` was increased in big steps. Now every decoded frame is also rendered.