### PR TITLE
Remove e.preventDefault() for keyboard-events

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -165,19 +165,13 @@ function setuplisteners(canvas, data) {
         addAutoCleaningEventListener(canvas, "keydown", function(e) {
             if (e.keyCode === 9 /* tab */ ) return;
             cs_keydown(e);
-            if (!cscompiled.keytyped) {
-                // this must bubble in order to trigger a keypress event
-                e.preventDefault();
-            }
         });
         addAutoCleaningEventListener(canvas, "keyup", function(e) {
             cs_keyup(e);
-            e.preventDefault();
         });
         addAutoCleaningEventListener(canvas, "keypress", function(e) {
             if (e.keyCode === 9 /* tab */ ) return;
             cs_keytyped(e);
-            e.preventDefault();
         });
     }
 


### PR DESCRIPTION
Right now, when a CindyJS-applet that has a `keydown`/`keyup`/`keydown`-script is focused, then all keyboard events that are addressed to the browser (for example `CTRL+S`, `⌘+]`) are ignored as long TAB is not involved.
Currently, @standupmaths, who uses CindyJS+a clicker for a show, had some problems because he could not switch different applets with `⌘+]` via a clicker.

Do we need this behavior? Why was it introduced? Or should we filter all requests that involve `⌘`?
This pull request forwards all keyboard events to the browser.