### PR TITLE
: Operator

### DIFF
--- a/examples/doublepointop.html
+++ b/examples/doublepointop.html
@@ -12,13 +12,28 @@
 
 </script>
 <script id="csdraw" type="text/x-cindyscript">
+println("=== lists ===");
 lst = [1,2,3];
+lst:"age"=17;
+lst:"list"=lst;
+lst:"pt" = B;
+println(lst:"age");
+println(lst:"list");
+println(lst:"pt");
+println(lst:"age");
+
+println(lst:"undef");
+
+
+println("=== geo ===");
 A:"age"=17;
 A:"list"=lst;
 A:"pt" = B;
 println(A:"age");
 println(A:"list");
 println(A:"pt");
+
+println(A:"undef");
 // Drawing code, executed whenever the canvas gets redrawn.
 
 </script>

--- a/examples/doublepointop.html
+++ b/examples/doublepointop.html
@@ -23,6 +23,7 @@ println(lst:"pt");
 println(lst:"age");
 
 println(lst:"undef");
+println(lst:pii);
 
 
 println("=== geo ===");

--- a/examples/doublepointop.html
+++ b/examples/doublepointop.html
@@ -12,8 +12,13 @@
 
 </script>
 <script id="csdraw" type="text/x-cindyscript">
+lst = [1,2,3];
 A:"age"=17;
+A:"list"=lst;
+A:"pt" = B;
 println(A:"age");
+println(A:"list");
+println(A:"pt");
 // Drawing code, executed whenever the canvas gets redrawn.
 
 </script>
@@ -27,7 +32,8 @@ var cdy = CindyJS({ // See ref/createCindy documentation for details.
     // See GeoBasics.js for possible attributes.
   },
   geometry: [
-    {name:"A", type:"Free", pos:[0,0]}
+    {name:"A", type:"Free", pos:[0,0]},
+    {name:"B", type:"Free", pos:[1,1]},
     // For allowed types, see GeoOps.js.
     // For allowed properties, see csinit in GeoBasics.js.
   ] // End of geometry array.

--- a/examples/doublepointop.html
+++ b/examples/doublepointop.html
@@ -12,6 +12,7 @@
 
 </script>
 <script id="csdraw" type="text/x-cindyscript">
+lst = [1,2,3];
 println("=== lists ===");
 lst = [1,2,3];
 lst:"age"=17;
@@ -24,6 +25,9 @@ println(lst:"age");
 
 println(lst:"undef");
 println(lst:pii);
+
+lst:12.3 = 4.56;
+println(lst:"12.3");
 
 
 println("=== geo ===");

--- a/examples/doublepointop.html
+++ b/examples/doublepointop.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+
+// Initialization code, executed once up front.
+
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+A:"age"=17;
+println(A:"age");
+// Drawing code, executed whenever the canvas gets redrawn.
+
+</script>
+<script type="text/javascript">
+
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
+  ports: [{id: "CSCanvas", width: 500, height: 500}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+    // See GeoBasics.js for possible attributes.
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0]}
+    // For allowed types, see GeoOps.js.
+    // For allowed properties, see csinit in GeoBasics.js.
+  ] // End of geometry array.
+});
+
+// Remove all comments after adjusting this template for your use case.
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+</body>
+
+</html>

--- a/ref/Language.md
+++ b/ref/Language.md
@@ -233,13 +233,10 @@ longes portion of input at that position, with the
 literal, which gets parsed as an operator in its own right instead of
 a number ending in a decimal dot and followed by the operator `.`.
 
-    - only CindyJS
     > x = [];
     > x:12.3 = 4.56;
     > x:"12.3"
-    * Can't use infix expression as lvalue
-    * Operator : is not supported yet.
-    < 4.56 
+    < 4.56
 
 There may be no spaces within operator symbols.
 

--- a/ref/Language.md
+++ b/ref/Language.md
@@ -239,7 +239,7 @@ a number ending in a decimal dot and followed by the operator `.`.
     > x:"12.3"
     * Can't use infix expression as lvalue
     * Operator : is not supported yet.
-    < ___
+    < 4.56 
 
 There may be no spaces within operator symbols.
 

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -320,9 +320,9 @@ Accessor.setField = function(geo, field, value) {
 
 };
 
-Accessor.getuserData = function(geo, key) {
+Accessor.getuserData = function(obj, key) {
     var val;
-    if (geo.userData && geo.userData[key]) val = geo.userData[key];
+    if (obj.userData && obj.userData[key]) val = obj.userData[key];
 
     if (val && val.ctype) {
         return val;
@@ -333,7 +333,7 @@ Accessor.getuserData = function(geo, key) {
     }
 };
 
-Accessor.setuserData = function(geo, key, value) {
-    if (!geo.userData) geo.userData = {};
-    geo.userData[key] = value;
+Accessor.setuserData = function(obj, key, value) {
+    if (!obj.userData) obj.userData = {};
+    obj.userData[key] = value;
 };

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -319,3 +319,21 @@ Accessor.setField = function(geo, field, value) {
 
 
 };
+
+Accessor.getuserData = function(geo, key) {
+    var val;
+    if (geo.userData && geo.userData[key]) val = geo.userData[key];
+
+    if (val && val.ctype) {
+        return val;
+    } else if (typeof val !== "object") {
+        return General.wrap(val);
+    } else {
+        return nada;
+    }
+};
+
+Accessor.setuserData = function(geo, key, value) {
+    if (!geo.userData) geo.userData = {};
+    geo.userData[key] = value;
+};

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -31,6 +31,16 @@ function evaluate(a) {
         }
         return nada;
     }
+    if (a.ctype === 'userdata') {
+        var uobj = evaluate(a.obj);
+        if (uobj.ctype === "geo") {
+            return Accessor.getuserData(uobj.value, a.key);
+        }
+        //        if (obj.ctype === "list") { // TODO implement
+        //           return List.getField(obj, a.key);
+        //        }
+        return nada;
+    }
     return a;
 }
 

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -36,9 +36,9 @@ function evaluate(a) {
         if (uobj.ctype === "geo") {
             return Accessor.getuserData(uobj.value, a.key);
         }
-        //        if (obj.ctype === "list") { // TODO implement
-        //           return List.getField(obj, a.key);
-        //        }
+        if (uobj.ctype === "list") {
+            return Accessor.getuserData(uobj, a.key);
+        }
         return nada;
     }
     return a;

--- a/src/js/libcs/Namespace.js
+++ b/src/js/libcs/Namespace.js
@@ -69,7 +69,7 @@ namespace.undefinedWarning = {};
 
 namespace.getvar = function(name) {
 
-    var stack = this.vars[name];
+    var stack = this.vars[name] || [];
     if (stack.length === 0) console.error("Getting non-existing variable " + name);
     var erg = stack[stack.length - 1];
     if (erg === null) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -454,12 +454,25 @@ eval_helper.assigntake = function(data, what) { //TODO: Bin nicht ganz sicher ob
 eval_helper.assigndot = function(data, what) {
     var where = evaluate(data.obj);
     var field = data.key;
+
     if (where.ctype === 'geo' && field) {
         Accessor.setField(where.value, field, evaluateAndVal(what));
     }
 
     return nada;
+};
 
+eval_helper.assigndoubledot = function(data, what) {
+    var where = evaluate(data.obj);
+    var field = data.key;
+
+    if (where.ctype === 'geo' && field) {
+        Accessor.setuserData(where.value, field, evaluateAndVal(what));
+    } else if (where.ctype !== 'geo') {
+        console.log("User data can only be assigned to geo objects.");
+    }
+
+    return nada;
 };
 
 
@@ -498,6 +511,8 @@ function infix_assign(args, modifs) {
         }
     } else if (args[0].ctype === 'field') {
         eval_helper.assigndot(args[0], v1);
+    } else if (args[0].ctype === 'userdata') {
+        eval_helper.assigndoubledot(args[0], v1);
     } else if (args[0].ctype === 'function' && args[0].oper === 'genList') {
         if (v1.ctype === "list") {
             eval_helper.assignlist(args[0].args, v1.value);

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -468,8 +468,10 @@ eval_helper.assigndoubledot = function(data, what) {
 
     if (where.ctype === 'geo' && field) {
         Accessor.setuserData(where.value, field, evaluateAndVal(what));
-    } else if (where.ctype !== 'geo') {
-        console.log("User data can only be assigned to geo objects.");
+    } else if (where.ctype === 'list' && field) {
+        Accessor.setuserData(where, field, evaluateAndVal(what));
+    } else if (where.ctype !== 'geo' || where.ctype !== 'list') {
+        console.log("User data can only be assigned to geo objects and lists.");
     }
 
     return nada;

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -674,8 +674,13 @@ Parser.prototype.postprocess = function(expr) {
                 expr.obj = expr.args[0];
 
                 // convert key to string 
-                var val = evaluate(expr.args[1]).value;
+                var val = evaluate(expr.args[1]);
+                if (val.ctype === 'number') val = val.value.real;
+                else val = val.value;
+
+                if (typeof(val) === "object") val = undefined;
                 expr.key = typeof(val) === 'undefined' ? undefined : String(val);
+
 
                 delete expr.args;
             }

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -665,6 +665,15 @@ Parser.prototype.postprocess = function(expr) {
                 expr.key = expr.args[1].name;
                 delete expr.args;
             }
+            if (expr.oper === ':') {
+                if (!(expr.args[1] && expr.args[1].ctype === 'string'))
+                    throw ParseError(
+                        'Data keys must be type of string and operate on variables', expr.start, expr.text);
+                expr.ctype = 'userdata';
+                expr.obj = expr.args[0];
+                expr.key = expr.args[1].value;
+                delete expr.args;
+            }
             if (this.infixmap)
                 expr.impl = this.infixmap[expr.oper];
         } else if (expr.ctype === 'variable') {
@@ -722,6 +731,13 @@ Parser.prototype.postprocess = function(expr) {
     if (expr.ctype === 'field') {
         return {
             ctype: 'field',
+            obj: expr.obj,
+            key: String(expr.key),
+        };
+    }
+    if (expr.ctype === 'userdata') {
+        return {
+            ctype: 'userdata',
             obj: expr.obj,
             key: String(expr.key),
         };

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -666,12 +666,17 @@ Parser.prototype.postprocess = function(expr) {
                 delete expr.args;
             }
             if (expr.oper === ':') {
-                if (!(expr.args[1] && expr.args[1].ctype === 'string'))
+                if (!(expr.args[1])) {
                     throw ParseError(
-                        'Data keys must be type of string and operate on variables', expr.start, expr.text);
+                        'Data key undefined', expr.start, expr.text);
+                }
                 expr.ctype = 'userdata';
                 expr.obj = expr.args[0];
-                expr.key = expr.args[1].value;
+
+                // convert key to string 
+                var val = evaluate(expr.args[1]).value;
+                expr.key = typeof(val) === 'undefined' ? undefined : String(val);
+
                 delete expr.args;
             }
             if (this.infixmap)


### PR DESCRIPTION
This adds the ":" to geo ops and lists.

Please have a close look at the change at  ```namespace.getvar```, is there a better way to catch the case where a variable is undefined?