### PR TITLE
Determine last working marked version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2997,9 +2997,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.18.tgz",
+      "integrity": "sha512-49i2QYhfULqaXzNZpxC808PisuCTGT2fgG0zrzdCI9N3rIfAWfW0nggvbXr6zvpynZdOG5+9xNxdzP0kwZnERw==",
       "dev": true
     },
     "meow": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "iphone-inline-video": "2.0.2",
     "js-beautify": "1.6.8",
     "jshint": "^2.8.0",
-    "marked": ">=0.3.5 <=0.3.12",
+    "marked": ">=0.3.18 <=0.3.18",
     "mocha": "^3.1.2",
     "node-sass": "^4.5.3",
     "pako": "^1.0.0",


### PR DESCRIPTION
Recent build problems could be fixed by reverting to marked 0.3.12. Let us determine which is actually the last working version of marked, so that maybe the problems can be fixed in marked upstream.

Please do not merge.