### PR TITLE
update to closure compiler 20180506

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - node
-  - 4
+  - 8
 script: node make build=release alltests
 dist: trusty
 sudo: false

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DOWNLOAD=$(if $(CURL_CMD),$(CURL_CMD),$(if $(WGET_CMD),$(WGET_CMD),$(error curl 
 
 NODE_OS:=$(subst Darwin,darwin,$(subst Linux,linux,$(shell uname -s)))
 NODE_ARCH:=$(subst x86_64,x64,$(subst i386,x86,$(subst i686,x86,$(shell uname -m))))
-NODE_VERSION:=8.4.0
+NODE_VERSION:=8.11.2
 NODE_URLBASE:=http://nodejs.org/dist
 NODE_BASENAME:=node-v$(NODE_VERSION)-$(NODE_OS)-$(NODE_ARCH)
 NODE_TAR:=$(NODE_BASENAME).tar.gz

--- a/make/Settings.js
+++ b/make/Settings.js
@@ -18,7 +18,7 @@ module.exports = function Settings() {
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
-        closure_version: "20160822",
+        closure_version: "20180506",
         verbose: "true",
         logprefix: "true",
         c3d_closure_level: "ADVANCED",

--- a/make/check-node-version.js
+++ b/make/check-node-version.js
@@ -7,8 +7,8 @@ v = v.map(function(s){
   return parseInt(s);
 });
 var a = v[0], b = v[1], c = v[2];
-if (a < 4 || a == 4 && b < 2 || a == 4 && b == 2 && c < 6) {
-  console.error("Node 4.2.6 or later required. Version " +
+if (a < 8 || a == 8 && b < 11 || a == 8 && b == 10 && c < 2) {
+  console.error("Node 8.11.2 or later required. Version " +
                 process.version + " found");
   process.exit(1);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1263,14 +1263,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1285,20 +1283,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1415,8 +1410,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1428,7 +1422,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1443,7 +1436,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1451,14 +1443,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1477,7 +1467,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1558,8 +1547,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1571,7 +1559,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1693,7 +1680,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1263,12 +1263,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1283,17 +1285,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1410,7 +1415,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1422,6 +1428,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1436,6 +1443,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1443,12 +1451,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1467,6 +1477,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1547,7 +1558,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1559,6 +1571,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1680,6 +1693,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/plugins/ComplexCurves/ComplexCurves.externs
+++ b/plugins/ComplexCurves/ComplexCurves.externs
@@ -31,37 +31,37 @@ ComplexCurves.fromEquation;
  */
 ComplexCurves.fromFile;
 
-/** @type {function(bool)} */
+/** @type {function(boolean)} */
 ComplexCurves.prototype.setAutorotate;
 
-/** @type {function(bool)} */
+/** @type {function(boolean)} */
 ComplexCurves.prototype.setClipping;
 
-/** @type {function(bool)} */
+/** @type {function(boolean)} */
 ComplexCurves.prototype.setOrtho;
 
-/** @type {function(bool)} */
+/** @type {function(boolean)} */
 ComplexCurves.prototype.setTransparency;
 
-/** @type {function} */
+/** @type {function()} */
 ComplexCurves.prototype.rotateBack;
 
-/** @type {function} */
+/** @type {function()} */
 ComplexCurves.prototype.rotateBottom;
 
-/** @type {function} */
+/** @type {function()} */
 ComplexCurves.prototype.rotateDefault;
 
-/** @type {function} */
+/** @type {function()} */
 ComplexCurves.prototype.rotateFront;
 
-/** @type {function} */
+/** @type {function()} */
 ComplexCurves.prototype.rotateLeft;
 
-/** @type {function} */
+/** @type {function()} */
 ComplexCurves.prototype.rotateRight;
 
-/** @type {function} */
+/** @type {function()} */
 ComplexCurves.prototype.rotateTop;
 
 /** @type {function(number)} */
@@ -75,5 +75,5 @@ ComplexCurves.prototype.setZoom;
  */
 ComplexCurves.prototype.setBackground;
 
-/** @type {function} */
+/** @type {function()} */
 ComplexCurves.prototype.renderSurface;

--- a/tools/prepare-deploy.js
+++ b/tools/prepare-deploy.js
@@ -116,6 +116,7 @@ function map(name, err, content) {
     map.sourceRoot = "https://raw.githubusercontent.com/CindyJS/CindyJS/" + head + "/";
     map.sources = map.sources.map(function(src) {
         if (/^ \[synthetic:.*\] $/.test(src)) return src;
+        if (/^lib|node_modules/.test(src)) return src;
         return ppath.normalize(ppath.join("build/js", root, src));
     });
     map.sourcesContent = map.sources.map(function(src) {


### PR DESCRIPTION
We haven't updated the closure compiler for quite a while and it also contains improvements for object literals (which we use heavily). See https://github.com/google/closure-compiler/wiki/Releases#september-10-2017-v20170910