### PR TITLE
build ComplexCurves only for `make ComplexCurves` or `make deploy`

### DIFF
--- a/examples/ComplexCurves/README.md
+++ b/examples/ComplexCurves/README.md
@@ -1,0 +1,4 @@
+# Complex Curves
+
+In order to view these examples run `make ComplexCurves` to install the 
+necessary dependencies from [https://github.com/ComplexCurves/ComplexCurves](https://github.com/ComplexCurves/ComplexCurves)

--- a/examples/ComplexCurves/README.md
+++ b/examples/ComplexCurves/README.md
@@ -1,4 +1,4 @@
 # Complex Curves
 
-In order to view these examples run `make ComplexCurves` to install the 
+In order to view these examples, run `make ComplexCurves` to install the 
 necessary dependencies from [https://github.com/ComplexCurves/ComplexCurves](https://github.com/ComplexCurves/ComplexCurves)

--- a/make/build.js
+++ b/make/build.js
@@ -724,7 +724,7 @@ module.exports = function build(settings, task) {
     // Copy things which constitute a release
     //////////////////////////////////////////////////////////////////////
 
-    task("deploy", ["all", "closure"], function() {
+    task("deploy", ["all", "ComplexCurves", "closure"], function() {
         this.delete("build/deploy");
         this.mkdir("build/deploy");
         this.node("tools/prepare-deploy.js", {
@@ -760,7 +760,6 @@ module.exports = function build(settings, task) {
         "xlibs",
         "images",
         "sass",
-        "ComplexCurves",
         "symbolic"
     ].concat(gwt_modules));
 


### PR DESCRIPTION
With this, the ComplexCurves-Plugin is only built when `make ComplexCurves` or `make deploy` is executed, but it will be avoided for a `make`, `make live`, etc.

This reduces the build-complexity for most users.