### PR TITLE
Enhance pseudo-random numbers in CindyGL

### DIFF
--- a/examples/cindygl/54_montecarlo.html
+++ b/examples/cindygl/54_montecarlo.html
@@ -1,0 +1,255 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Cindy JS</title>    
+    <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+    <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+  </head>
+    
+  <body style="margin: 0px;">
+      
+      <script id="csmousedown" type="text/x-cindyscript">
+        sx = mouse().x;
+        sy = mouse().y;
+        dragging = sy < Mdate.y-Cdate.radius-.05 % sx<Mdate.x-Cdate.radius-.05;
+      </script>
+      <script id="csmouseup" type="text/x-cindyscript">
+        dragging = false;
+      </script>
+      
+      <script id="csinit" type="text/x-cindyscript">
+      dx = .05; dy =.0;
+      
+      sx = mouse().x;
+      sy = mouse().y;
+      dragging = false;
+    
+      phi = 2.7;
+      lambda = 0.1;
+      dx = 0; dy =0;
+      lasttime = pi; //12:00
+      createimage("acc", 1024, 768);
+      colorplot("acc",(0,0,0,0));
+      </script>
+      
+      <script id="csdraw" type="text/x-cindyscript">
+      //the following is executed for every rendered frame
+      if (dragging,
+          dx = 3 * (sx - mouse().x); dy = 3 * (sy - mouse().y);,
+          dx = 0; dy = 0;
+      );
+      
+      sx = mouse().x;
+      sy = mouse().y;
+      
+      zoom = 0.4;
+      
+      
+      date = mod(-arctan2(Pdate.xy-Mdate.xy)+pi/2,2*pi);
+      
+      declination = arcsin(-sin(23.43693°)*cos(date+10/365*2*pi));
+      //time = 70°;//3:30pm;
+      time = mod(-arctan2(Ptime.xy-Mtime.xy)+90°,360°)/2;
+      if(|mod(lasttime-time+pi,2*pi)-pi|>|mod(lasttime+pi-time+pi,2*pi)-pi|, time=time+pi);
+      lasttime = time;
+      sun = [cos(declination)*sin(time),
+             sin(declination),
+             -cos(declination)*cos(time)]; //for points on equator
+             
+      
+      latitude = 48.1351°;//munich
+      //latitude = 0;//ecuador
+      
+      sun = [[1, 0, 0],
+            [0,cos(latitude),-sin(latitude)],
+            [0,sin(latitude),cos(latitude)]]*sun;
+      sun = sun/|sun|;
+  
+      if(sun!=lastsun,
+        colorplot("acc",
+          old = imagergba("acc",#);
+          forall(1..3, i,
+            old_i = min(old_i, old.a); //clamp by a
+          );
+          .9*old //fading feels smooth
+        );
+          
+      );
+      if(|(dx,dy)|>1e-4,
+        colorplot("acc",(0,0,0,0));,
+      );
+      lastsun = sun;
+      //the rotation matrix: It is modified either if the user is dragging or time passes
+      phi = phi + dx;
+      lambda = lambda + dy;
+      dx = dy = 0;
+      if(lambda>pi/2, lambda=pi/2);
+      if(lambda<-0.15, lambda=-0.15);
+      mat =  
+      (
+        (1,0,0),
+        (0,0,1),
+        (0,1,0)
+      )*
+      (
+          (cos(phi), 0, -sin(phi)),
+          (0, 1, 0),
+          (sin(phi), 0, cos(phi))
+      )*
+      (
+          (1, 0, 0),
+          (0, cos(lambda), -sin(lambda)),
+          (0, sin(lambda), cos(lambda))
+      );
+      
+      
+      
+      box = [
+        [[-10000,-10000,-100],[10000,10000,-1]],
+        [[-1,-1,-1],[-.4,-.4,.8]],
+        [[-1,.4,-1],[-.4,1,.8]],
+        [[.7,-1,-1],[1,-.7,.8]],
+        [[.7,.7,-1],[1,1,.8]],
+        [[-1.1,-1.1,.8],[1.1,1.1,1]],
+        [[-.8,-.8,.2],[.8,.8,.3]],
+        [[-.8,-.8,-.4],[.8,.8,-.3]],
+        [[-.9,-.9,1], [.9,.9,1.05]],
+        [[-.5,-.5,1],[.5,.5,1.3]],
+        
+        [[-1.2,-1.2,-1.2],[1.5,1.2,-.98]]
+        
+      ];
+      
+      randomunitvector() := (
+        regional(r);
+        r = [randomnormal(), randomnormal(), randomnormal()];
+        r/|r|
+      );
+
+      bestt = 1000;
+      rot(x) := [x_2, x_3, x_1];//x_[2,3,1];
+      hit(a, b, x, v) := (
+        repeat(3, j,
+          t = (if(v.x>0, a.x, b.x)-x.x)/v.x;
+          if(0<t & t<bestt,
+            nx = x+t*v;
+            if(a.y<nx.y & nx.y<b.y & a.z<nx.z & nx.z<b.z, bestt = t; hitdir = j);
+          );
+          a = rot(a); b = rot(b); x = rot(x); v = rot(v);
+        );
+      );
+      
+      skycolor(v) := (
+        grey(max((v*sun),0)^8)
+      );
+      pixelwidth = 2/imagesize("acc")_2;
+      
+      colorplot("acc",
+        acc = imagergba("acc",#);
+        pixel = #;
+        //if(acc.a>.99,acc = acc*0.9);//avoid "overwhite" on 8-bit systems
+        repeat(2,
+          p = pixel+(random(pixelwidth),random(pixelwidth));//antialiasing
+          rd = (sin(.4*p.x), sin(.4*p.y), cos(.4*p.x)*cos(.4*p.y)); //unit length vector of ray direction
+          v = mat*rd;
+          v = v/|v|;
+          x = mat*[0,0,-15*zoom];
+          fact = 6;
+          sky = false;
+          hitnormal = v;
+          color = [0,0,0];
+          repeat(4, nr,
+            if(!sky,
+              bestt = 1e8;
+              hitdir = 0;
+              forall(1..length(box), k,
+                hit(box_k_1, box_k_2, x, v);
+              );
+              if(hitdir==1, hitnormal = [-v.x/|v.x|,0,0]);
+              if(hitdir==2, hitnormal = [0,-v.y/|v.y|,0]);
+              if(hitdir==3, hitnormal = [0,0,-v.z/|v.z|]);
+              
+              r = randomunitvector();
+              
+              if(hitdir == 0,
+                //no hit
+                sky = true;
+                v = v/|v|;
+                if(nr == 1, v = v+r/2;);
+                ,
+                //some hit
+                x = x+bestt*v; 
+                v = if(hitnormal*r>0, r, r - 2*(hitnormal*r)*hitnormal);
+                
+                fact = fact*.9;
+              );
+              //& max(|x_1|,|x_2|)>1
+              if(sun.z<0 & |hitnormal.z+1|<.01, color = color+min(1,max(-sun.z,0))*fact*[1,.8,.7]*.7);
+              //d = max([|x_1|,|x_2|, |x_3|]);
+              
+            );
+          );
+          
+          
+          acc = acc + if(sky,
+            //(max((x*[1,2,1]/2)^4,0),max((x*[-1,1,2]/2)^6,0),max((x*[1,-1,2]/2)^4,0),1),
+            color = color+fact*skycolor(v/|v|);
+            [color_1,color_2,color_3,1], 
+            [0,0,0,1]
+          )/255;
+        );
+        acc
+    );
+      
+      //gamma = 1;
+      colorplot(
+        d = imagergba("acc",#);
+        c = [d.r,d.g,d.b]/d.a;
+        c
+        //[re(c_1^gamma),re(c_2^gamma),re(c_3^gamma)]
+      );
+      fillcircle(Mdate.xy, Cdate.radius, color->[0,0,0], alpha->.4);
+      fillcircle(Mtime.xy, Cdate.radius, color->[0,0,0], alpha->.4);
+      months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+      drawtext(Mdate.xy, months_(floor(mod(date/360°,1)*12)+1), color->[1,1,1], align->"mid");
+      fmt(n,d):=(
+        s=("0000"+n);
+        l=length(s);
+        substring(s,(l-d),l)
+      );
+      drawtext(Mtime.xy, floor(mod(time/360°,1)*24) + ":" + fmt(round(mod(time/360°*24*60,60)),2) , color->[1,1,1], align->"mid");
+      </script>
+
+      <div  id="CSCanvas" style="border:0px"></div>
+      
+      <script type="text/javascript">
+          var cdy = CindyJS({canvasname:"CSCanvas",
+                      scripts: "cs*",
+                      animation: {autoplay: true},
+                      csconsole: false,
+                      use : ["CindyGL"],
+                      geometry: [
+                        { name: "Mdate", type: "Free", pos: [ 0.45,0.5 ], visible:false, pinned: true }, 
+                        { name: "Cdatet", type: "CircleByRadius", radius: 0.15, args: [ "Mdate" ], color:[1,1,1], size:4, pinned: true}, 
+                        { name: "Cdate", type: "CircleByRadius", radius: 0.15, args: [ "Mdate" ], color:[0,0,0], size: 2, pinned: true}, 
+                        
+                        { name: "Pdate", printname: "date", type: "PointOnCircle", pos: [ .8,.5 ], color: [ 1.0, 1.0, 1.0 ], narrow: true, color: [1,1,1], size:8, args:[ "Cdate" ], labeled: false }, 
+
+                        { name: "Mtime", type: "Free", pos: [ 0.8,0.5 ], visible:false, pinned: true }, 
+                        { name: "Ctimet", type: "CircleByRadius", radius: 0.15, args: [ "Mtime" ], color:[1,1,1], size:4, pinned: true}, 
+                        { name: "Ctime", type: "CircleByRadius", radius: 0.15, args: [ "Mtime" ], color:[0,0,0], size:2, pinned: true}, 
+                        { name: "Ptime", printname: "time", type: "PointOnCircle", pos: [ .82,.6231 ], color: [ 1.0, 1.0, 1.0 ], narrow: true, color: [1,1,1], size:8, args:[ "Ctime" ], labeled: false }
+                      ],
+                      ports: [{
+                        id: "CSCanvas",
+                        width: 1024,
+                        height: 768,
+                        transform: [ { visibleRect: [ -1, -0.75, 1, 0.75 ] } ]
+                      }]
+          });
+      </script>
+
+  </body>
+</html>

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -387,6 +387,9 @@ CodeBuilder.prototype.determineUniforms = function(expr) {
 
         let alwaysPixelDependent = [ //Operators that are supposed to be interpreted as pixel dependent;
             'random', //our random function is dependent on pixel!
+            'randomint',
+            'randominteger',
+            'randombool',
             'verbatimglsl' //we dont analyse verbatimglsl functions
         ];
         if (expr['ctype'] === 'function' && alwaysPixelDependent.indexOf(getPlainName(expr['oper'])) != -1) {

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -390,6 +390,7 @@ CodeBuilder.prototype.determineUniforms = function(expr) {
             'randomint',
             'randominteger',
             'randombool',
+            'randomnormal',
             'verbatimglsl' //we dont analyse verbatimglsl functions
         ];
         if (expr['ctype'] === 'function' && alwaysPixelDependent.indexOf(getPlainName(expr['oper'])) != -1) {

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -539,7 +539,7 @@ webgl["randombool"] = first([
 
 webgl["randomnormal"] = first([
     [
-        [], type.float, (a, modifs, cb) => (`(sqrt(-2. * log(${useincludefunction('random')([], modifs, cb)})) * cos(6.283185307179586 * ${useincludefunction('random')([], modifs, cb)}))`)
+        [], type.float, useincludefunction('randomnormal')
     ]
 ]);
 
@@ -761,6 +761,7 @@ requires['arctanc'] = ['logc', 'addc', 'multc', 'subc'];
 requires['arctan2c'] = ['logc', 'divc', 'sqrtc', 'multc'];
 requires['arctan2vec2c'] = ['arctan2c'];
 requires['hue'] = ['hsv2rgb'];
+requires['randomnormal'] = ['random'];
 
 
 Object.freeze(requires);

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -520,6 +520,22 @@ webgl["random"] = first([
 
 ]);
 
+webgl["randomint"] = first([
+    [
+        [type.int], type.int, (a, modifs, cb) => (`int(floor(${useincludefunction('random')([], modifs, cb)}*float(${a[0]})))`)
+    ],
+    [
+        [type.float], type.int, (a, modifs, cb) => (`int(floor(${useincludefunction('random')([], modifs, cb)}*floor(${a[0]})))`)
+    ]
+]);
+
+webgl["randominteger"] = webgl["randomint"];
+
+webgl["randombool"] = first([
+    [
+        [], type.bool, (a, modifs, cb) => (`(${useincludefunction('random')([], modifs, cb)}>.5)`)
+    ]
+]);
 
 webgl['arctan2'] = first([
     [

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -512,10 +512,10 @@ webgl["random"] = first([
         [], type.float, useincludefunction('random')
     ],
     [
-        [type.float], type.float, (a, cb) => (`${useincludefunction('random')([], cb)}*${a[0]}`)
+        [type.float], type.float, (a, modifs, cb) => (`${useincludefunction('random')([], modifs, cb)}*${a[0]}`)
     ],
     [
-        [type.complex], type.complex, (a, cb) => (`vec2(${useincludefunction('random')([], cb)},${useincludefunction('random')([], cb)})*${a[0]}`)
+        [type.complex], type.complex, (a, modifs, cb) => (`vec2(${useincludefunction('random')([], modifs, cb)},${useincludefunction('random')([], modifs, cb)})*${a[0]}`)
     ]
 
 ]);

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -537,6 +537,12 @@ webgl["randombool"] = first([
     ]
 ]);
 
+webgl["randomnormal"] = first([
+    [
+        [], type.float, (a, modifs, cb) => (`(sqrt(-2. * log(${useincludefunction('random')([], modifs, cb)})) * cos(6.283185307179586 * ${useincludefunction('random')([], modifs, cb)}))`)
+    ]
+]);
+
 webgl['arctan2'] = first([
     [
         [type.float, type.float], type.float, args => (`atan(${args[1]}, ${args[0]})`) //reverse order

--- a/plugins/cindygl/src/str/random.glsl
+++ b/plugins/cindygl/src/str/random.glsl
@@ -2,9 +2,9 @@ uniform float rnd_;
 
 float last_rnd = .1231;
 float random() {
-  float a = mod(rnd_*plain_pixel.x*32.23,1.21);
+  float a = fract(sin(dot(plain_pixel ,vec2(12.9898,78.233))) * 43758.5453);
   float b = mod(last_rnd*plain_pixel.y*54.21,1.32);
-  last_rnd = mod(a+b+12232.2213*(1.+rnd_)*dot(plain_pixel,plain_pixel)+a+sin(b)+b*sin(dot(plain_pixel, vec2(232.121+rnd_,2232.11))+last_rnd*121.11)*129.12+rnd_,1.);
+  last_rnd = mod(a+b+a+sin(b)+b*sin(dot(plain_pixel, vec2(232.121+rnd_,2232.11))+last_rnd*121.11)*129.12+rnd_,1.);
   return last_rnd;
   
   //return mod(a+b+rnd_, 1.);

--- a/plugins/cindygl/src/str/randomnormal.glsl
+++ b/plugins/cindygl/src/str/randomnormal.glsl
@@ -1,0 +1,3 @@
+float randomnormal() {
+  return sqrt(-2. * log(random())) * cos(6.283185307179586 * random());
+}


### PR DESCRIPTION
This PR
* fixes one bug when using `random(1024)`
* implements `randomint`, `randombool` and `randomnormal`
* Makes it (hopefully) a bit harder to see artifacts in the "randomly" generated value