### PR TITLE
skip I, J, i, j during create$2, use P0, S0, etc...

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4172,8 +4172,8 @@ evaluator.create$2 = function(args, modifs) {
                 useiffree(String.fromCharCode(97 + i)); //a, b, c...
             }
         }
-        for (i = 1; !ans; i++) {
-            useiffree(kind + i); //P1, P2, ...
+        for (i = 0; !ans; i++) {
+            useiffree(kind + i); //P0, P1, P2, ...
         }
         return ans;
     }

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4163,10 +4163,12 @@ evaluator.create$2 = function(args, modifs) {
         var name, i;
         if (kind === 'P') {
             for (i = 0; i < 26 & !ans; i++) {
+                if (i === 8 || i === 9) continue; //skip I and J
                 useiffree(String.fromCharCode(65 + i)); //A, B, C...
             }
         } else if (kind === 'L' || kind === 'S') {
             for (i = 0; i < 26 & !ans; i++) {
+                if (i === 8 || i === 9) continue; //skip i and j
                 useiffree(String.fromCharCode(97 + i)); //a, b, c...
             }
         }


### PR DESCRIPTION
The original lookup in Cinderella skips I an J as point names (for good reason). That should happen for create$2 as well. Also i and j are skipped for line names.

Furthermore, the names P0, S0, C0 will be used (as in Cinderella).