### PR TITLE
Ecmascript 6

### DIFF
--- a/Administration/jshint.conf
+++ b/Administration/jshint.conf
@@ -7,5 +7,6 @@
   "undef": true,
   "unused": false,
   "maxerr": 5000,
-  "predef": ["console", "numeric", "ClipperLib", "convexhull", "module", "enableInlineVideo", "ImageData"]
+  "predef": ["console", "numeric", "ClipperLib", "convexhull", "module", "enableInlineVideo", "ImageData"],
+  "esversion" : 6
 }

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ js_make: $(NPM_DEP)
 ######################################################################
 
 # Specify build=release on the command line to run closure compiler
-build=debug
+build=release
 
 build/js/Cindy.plain.js: js_make
 	$(JS_MAKE) plain

--- a/make/Settings.js
+++ b/make/Settings.js
@@ -14,7 +14,7 @@ var prevSettingsFile = "build/prev-settings.json";
 module.exports = function Settings() {
 
     var configSettings = {
-        build: "debug",
+        build: "release",
         closure_urlbase: "http://dl.google.com/closure-compiler",
         closure_language_in: "ECMASCRIPT6_STRICT",
         closure_language_out: "ECMASCRIPT5_STRICT",

--- a/make/Settings.js
+++ b/make/Settings.js
@@ -16,7 +16,8 @@ module.exports = function Settings() {
     var configSettings = {
         build: "debug",
         closure_urlbase: "http://dl.google.com/closure-compiler",
-        closure_language: "ECMASCRIPT5_STRICT",
+        closure_language_in: "ECMASCRIPT6_STRICT",
+        closure_language_out: "ECMASCRIPT5_STRICT",
         closure_level: "SIMPLE",
         closure_version: "20180506",
         verbose: "true",

--- a/make/build.js
+++ b/make/build.js
@@ -112,7 +112,8 @@ module.exports = function build(settings, task) {
     task("closure", ["plain", "closure-jar"], function() {
         this.setting("closure_version");
         this.closureCompiler(closure_jar, {
-            language_in: this.setting("closure_language"),
+            language_in: this.setting("closure_language_in"),
+            language_out: this.setting("closure_language_out"),
             compilation_level: this.setting("closure_level"),
             js_output_file: "build/js/Cindy.closure.js",
             js: ["build/js/Cindy.plain.js"],
@@ -188,6 +189,7 @@ module.exports = function build(settings, task) {
     });
 
     task("tests", [
+        "closure",
         "nodetest",
         "unittests",
         "excomp",

--- a/make/sources.js
+++ b/make/sources.js
@@ -40,6 +40,8 @@ exports.liblab = [
 exports.lib = [
     "node_modules/iphone-inline-video/dist/iphone-inline-video.min.js",
     "lib/clipper/clipper.js",
+    "node_modules/es6-shim/es6-shim.min.js",
+    "node_modules/es7-shim/dist/es7-shim.min.js",
 ];
 
 exports.cssrc = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,16 @@
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0"
+      }
+    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
@@ -770,6 +780,16 @@
         }
       }
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -992,6 +1012,53 @@
         "is-arrayish": "0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "es6-shim": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/es6-shim/-/es6-shim-0.35.3.tgz",
+      "integrity": "sha1-m/tzY/7//4emzbbNk+QF7DxLbyY=",
+      "dev": true
+    },
+    "es7-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/es7-shim/-/es7-shim-6.0.0.tgz",
+      "integrity": "sha1-DEMLQLhQWtFVcHIajY3U6wxVMVU=",
+      "dev": true,
+      "requires": {
+        "array-includes": "3.0.3",
+        "object.entries": "1.0.4",
+        "object.getownpropertydescriptors": "2.0.3",
+        "object.values": "1.0.4",
+        "string-at": "1.0.1",
+        "string.prototype.padend": "3.0.0",
+        "string.prototype.padstart": "3.0.0",
+        "string.prototype.trimleft": "2.0.0",
+        "string.prototype.trimright": "2.0.0"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1181,6 +1248,12 @@
       "requires": {
         "for-in": "1.0.2"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1763,6 +1836,12 @@
         "rimraf": "2.6.2"
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -1902,6 +1981,15 @@
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -2169,6 +2257,18 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -2276,6 +2376,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
@@ -2989,11 +3104,39 @@
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "dev": true
+    },
     "object-path": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
       "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
       "dev": true
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
@@ -3003,6 +3146,18 @@
       "requires": {
         "for-own": "0.1.5",
         "is-extendable": "0.1.1"
+      }
+    },
+    "object.values": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "on-finished": {
@@ -3899,6 +4054,17 @@
         "limiter": "1.1.3"
       }
     },
+    "string-at": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string-at/-/string-at-1.0.1.tgz",
+      "integrity": "sha1-c7dVrbqsPheNq+fk19ed5WAD+zc=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3908,6 +4074,48 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "string.prototype.padstart": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
+      "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
+      "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
+      "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "chalk": "^1.1.1",
     "chokidar": "^1.6.0",
     "concat-with-sourcemaps": "^1.0.4",
+    "es6-shim": "^0.35.3",
+    "es7-shim": "^6.0.0",
     "glob": "^7.0.3",
     "http-proxy": "^1.11.2",
     "iphone-inline-video": "2.0.2",


### PR DESCRIPTION
*edit* While we are at it: I added shims for es6 and 7 for compatibility.

Hi,

this PR enables ES6 for CindyJS and updates the closure compiler to a more recent version. 

@kortenkamp pointed out that we should still support Internet Explorer 11. Therefore i changed the compilation process to accept ES6 as input and the closure compiler will transpile the code to ES5. 
To check if transpilation is possible I added closure compiler to the tests.

Code which can't be transpiled e.g.
```
function *f(x) {
  x.someMethod(yield 1);
}
```
will throw errors like
```
closure             ] src/js/Head.js:4: ERROR - This code cannot be converted from ES6. Undecomposable expression: Please rewrite the yield or await as a separate statement.
[closure             ] See https://github.com/google/closure-compiler/wiki/FAQ#i-get-an-undecomposable-expression-error-for-my-yield-or-await-expression-what-do-i-do
[closure             ]   x.someMethod(yield 1);
[closure             ]                ^^^^^^^
[closure             ] 
[closure             ] 1 error(s), 6 warning(s)
```.