### PR TITLE
added missing example for calculating variance

### DIFF
--- a/examples/cindygl/58_webcam_mean_variance.html
+++ b/examples/cindygl/58_webcam_mean_variance.html
@@ -1,0 +1,133 @@
+
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Finding the variance of an image</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+    <link rel="stylesheet" href="../../build/js/CindyJS.css">
+<script id="csinit" type="text/x-cindyscript">
+drawgrid=false;
+width=256;
+height=256;
+video = camera video(resolution -> [1280,16/9]);
+create image("input", width, height);
+create image("output1", width/2, height/2);
+create image("output2", width/4, height/4);
+create image("output3", width/8, height/8);
+create image("output4", width/16, height/16);
+create image("output5", width/32, height/32);
+create image("output6", width/64, height/64);
+create image("output7", width/128, height/128);
+create image("output8", width/256, height/256);
+create image("meanvar1", width/2, height/2);
+create image("meanvar2", width/4, height/4);
+create image("meanvar3", width/8, height/8);
+create image("meanvar4", width/16, height/16);
+create image("meanvar5", width/32, height/32);
+create image("meanvar6", width/64, height/64);
+create image("meanvar7", width/128, height/128);
+create image("meanvar8", width/256, height/256);
+
+create image("var", width, height);
+create image("var2", width, height);
+
+
+bw(x):=(.35*x_1+.45*x_2+.2*x_3);
+
+f(x):=x*2;
+
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+if(drawgrid,
+linecolor((.5,.5,.5));
+repeat(65,start->0,step->.2,draw((#,0),(#,4.8)));
+repeat(25,start->0,step->.2,draw((0,#),(12.8,#)));
+);
+	draw((3.2,1.25),(3.5,1.25),color->(0,0,0),size->3);
+	draw((6.70,1.25),(7.0,1.25),color->(0,0,0),size->3, arrow->true, arrowshape->"full", arrowsides->"==>", arrowsize->1.5, arrowposition->1);
+
+	// get current definition of f and redefine if it changed
+	if(Inputf.text!=lastf & Inputf.text!="",
+		parse("f(x) :=" + Inputf.text);
+		lastf = Inputf.text;
+	);
+
+
+if (image ready(video),
+  colorplot("input", (imagergb(video, #*9/16+(180,0))));
+  colorplot("output1", imagergb("input",#));
+  colorplot("output2", imagergb("output1",#));
+  colorplot("output3", imagergb("output2",#));
+  colorplot("output4", imagergb("output3",#));
+  colorplot("output5", imagergb("output4",#));
+  colorplot("output6", imagergb("output5",#));
+  colorplot("output7", imagergb("output6",#));
+  colorplot("output8", imagergb("output7",#));
+
+  // output8 contains the mean value
+
+  // now compute the variance
+
+  colorplot("var", apply((imagergb("input",#)-imagergb("output7",#)),x,x^2));
+  colorplot("var2", apply((imagergb("input",#)-imagergb("output7",#)),x,x^2)*4);
+  colorplot("meanvar1", imagergb("var",#));
+  colorplot("meanvar2", imagergb("meanvar1",#));
+  colorplot("meanvar3", imagergb("meanvar2",#));
+  colorplot("meanvar4", imagergb("meanvar3",#));
+  colorplot("meanvar5", imagergb("meanvar4",#));
+  colorplot("meanvar6", imagergb("meanvar5",#));
+  colorplot("meanvar7", imagergb("meanvar6",#));
+  colorplot("meanvar8", imagergb("meanvar7",#));
+  mean=imagergb((-.5,-.5),(.5,-.5),"meanvar8",(0,0),interpolate->false);
+);
+
+w=width;
+m1=30;
+m2=10;
+
+cp(L,R,image):=drawimage(L,R,image,interpolate->false);
+
+cp([0,2*w+2*m2], [w,2*w+2*m2], "input");
+cp([(w+m1),2*w+2*m2], [(2*w+m1),2*w+2*m2], "output3");
+cp([(2*w+2*m1),2*w+2*m2], [(3*w+2*m1),2*w+2*m2], "output8");
+
+cp([0,w+m2], [w,w+m2], "var2");
+cp([(w+m1),w+m2], [(2*w+m1),w+m2], "meanvar3");
+cp([(2*w+2*m1),w+m2], [(3*w+2*m1),w+m2], "meanvar8");
+
+//drawtext((0,0),"mean:"+mean + "±" + var);
+//cp([0,0], [w,0], "output8");
+//cp([(w+m1),0], [(2*w+m1),0], "meanvar8");
+//cp([(2*w+2*m1),0], [(3*w+2*m1),0], "var");
+
+
+
+
+</script>
+<script type="text/javascript">
+var cdy = CindyJS({
+  ports: [{id: "CSCanvas", transform:[{visibleRect:[0,0,828,788]}]}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0], visible:false},
+      {name:"B", type:"Free", pos:[255,0], visible:false}
+
+  ],
+  use: ["CindyGL" /*,"katex"*/]
+});
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <h1>Calculating the Variance of an Image</h1>
+  <div id="CSCanvas" style="align:left; width: 828px; height: 788px; border:0;margin: 0;"></div>
+
+</body>
+
+</html>


### PR DESCRIPTION
I forgot to add an example created for CADGME 2018 that calculates the variance of an image. Here it is.