### PR TITLE
Recursively delete elements

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -5059,7 +5059,6 @@ evaluator.load$3 = function(args, modifs) {
 
 evaluator.removeelement$1 = function(args, modifs) {
     var arg = evaluate(args[0]);
-    debugger;
-    if(arg.ctype === "geo") removeElement(arg.value.name);
-    else console.log("argument of removeelement is undefined or not of type <geo>")
+    if (arg.ctype === "geo") removeElement(arg.value.name);
+    else console.log("argument of removeelement is undefined or not of type <geo>");
 };

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -5056,3 +5056,10 @@ evaluator.load$3 = function(args, modifs) {
     }
 
 };
+
+evaluator.removeelement$1 = function(args, modifs) {
+    var arg = evaluate(args[0]);
+    debugger;
+    if(arg.ctype === "geo") removeElement(arg.value.name);
+    else console.log("argument of removeelement is undefined or not of type <geo>")
+};

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -362,71 +362,30 @@ function addElementNoProof(el) {
 
 // TODO Remove dependencies also
 function removeElement(name) {
-    var i, el, debug = false;
+    var i, el, debug = true;
     if (debug) console.log("Remove element " + name);
 
     // TODO Check if name exists
     delete csgeo.csnames[name];
 
-    for (i = 0; i < csgeo.gslp.length; i++) {
-        el = csgeo.gslp[i];
-
-        if (el.name === name) {
-            if (debug) console.log("Removed element from gslp " + name);
-            csgeo.gslp.splice(i, 1);
-        }
-    }
-
-    for (i = 0; i < csgeo.free.length; i++) {
-        el = csgeo.free[i];
-
-        if (el.name === name) {
-            if (debug) console.log("Removed element from free " + name);
-            csgeo.free.splice(i, 1);
-        }
-    }
-
-    for (i = 0; i < csgeo.points.length; i++) {
-        el = csgeo.points[i];
-
-        if (el.name === name) {
-            if (debug) console.log("Removed element from points " + name);
-            csgeo.points.splice(i, 1);
-        }
-    }
-
-    for (i = 0; i < csgeo.lines.length; i++) {
-        el = csgeo.lines[i];
-
-        if (el.name === name) {
-            if (debug) console.log("Removed element from lines " + name);
-            csgeo.lines.splice(i, 1);
-        }
-    }
-
-    for (i = 0; i < csgeo.conics.length; i++) {
-        el = csgeo.conics[i];
-
-        if (el.name === name) {
-            if (debug) console.log("Removed element from conics " + name);
-            csgeo.conics.splice(i, 1);
-        }
-    }
-
-    // remove from sets
-    //
-    // define function with closure which compares the name
-    var nameCmp = function(cmpName) {
+    var nameCmp = function(cmpName, arrn) {
         return function(setel) {
             if (setel.name === cmpName) {
-                if (debug) console.log("Removed element " + name + " from set of " + sname);
+                if (debug) console.log("Removed element " + name + " from " + arrn);
                 return false;
             } else return true;
         };
     };
 
+    // process GeoArrays
+    var geoArrs = ["conics", "free", "gslp", "ifs", "lines", "points", "polygons", "texts"];
+    geoArrs.map(function(arrn) {
+        csgeo[arrn] = csgeo[arrn].filter(nameCmp(name, arrn));
+    });
+
+    // remove from sets of geos -- PointSet (Ps), LineSet (Ls)...
     for (var sname in csgeo.sets) {
-        csgeo.sets[sname] = csgeo.sets[sname].filter(nameCmp(name));
+        csgeo.sets[sname] = csgeo.sets[sname].filter(nameCmp(name, "set of " + sname));
     }
 
     geoDependantsCache = {};

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -405,7 +405,7 @@ function removeElement(name) {
 }
 
 function removeAllElements(nameMap) {
-    var i, el, debug = true;
+    var i, el, debug = false;
     var keys = Object.keys(nameMap);
     if (debug) console.log("Remove elements: " + String(keys));
 

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -402,7 +402,7 @@ function removeElement(name) {
 }
 
 function removeOneElement(name) {
-    var i, el, debug = true;
+    var i, el, debug = false;
     if (debug) console.log("Remove element " + name);
 
     // TODO Check if name exists

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -419,13 +419,16 @@ function removeAllElements(nameMap) {
     };
 
     // update incidences
+    var isFiltered = {}; // track filtered arrays
     keys.forEach(function(name) {
         var allIncis = csgeo.csnames[name].incidences;
         allIncis.forEach(function(iname) {
+            if (isFiltered[iname]) return;
             var incis = csgeo.csnames[iname].incidences;
             csgeo.csnames[iname].incidences = incis.filter(function(n) {
                 return !(nameMap[n]);
             });
+            isFiltered[iname] = true;
         });
     });
 

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -360,8 +360,48 @@ function addElementNoProof(el) {
     return csgeo.csnames[el.name];
 }
 
-// TODO Remove dependencies also
 function removeElement(name) {
+    // build dependency tree
+    var depTree = {};
+    var cskeys = Object.keys(csgeo.csnames);
+    cskeys.forEach(function(name) {
+        var el = csgeo.csnames[name];
+        if (!el.hasOwnProperty("args")) return;
+        var args = el.args;
+
+        args.forEach(function(argn) {
+            if (!depTree.hasOwnProperty(argn)) {
+                depTree[argn] = {};
+            }
+            depTree[argn][name] = true;
+        });
+    });
+
+    // recursively find all dependencies
+    var recFind = function(elname, map) {
+        map[elname] = true;
+        if (!depTree.hasOwnProperty(elname)) return map;
+
+        var deps = Object.keys(depTree[elname]);
+        deps.forEach(function(dn) {
+            if (!map[dn]) {
+                map[dn] = true;
+                return recFind(dn, map);
+            }
+        });
+        return map;
+    };
+
+    // collect all objects to delete
+    var delArr = Object.keys(recFind(name, {}));
+
+    // delete every single object
+    delArr.forEach(function(e) {
+        removeOneElement(e);
+    });
+}
+
+function removeOneElement(name) {
     var i, el, debug = true;
     if (debug) console.log("Remove element " + name);
 

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -387,13 +387,12 @@ function removeElement(name) {
         map[elname] = true;
         if (!depTree.hasOwnProperty(elname)) return map;
 
-        var deps = Object.keys(depTree[elname]);
-        deps.forEach(function(dn) {
+        for (var dn in depTree[elname]) {
             if (!map[dn]) {
-                map[dn] = true;
-                return recFind(dn, map);
+                recFind(dn, map);
             }
-        });
+        }
+
         return map;
     };
 

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -404,13 +404,13 @@ function removeElement(name) {
     delArr.forEach(function(e) {
         removeOneElement(e);
     });
+
 }
 
 function removeOneElement(name) {
     var i, el, debug = false;
     if (debug) console.log("Remove element " + name);
 
-    delete csgeo.csnames[name];
 
     var nameCmp = function(cmpName, arrn) {
         return function(setel) {
@@ -420,6 +420,15 @@ function removeOneElement(name) {
             } else return true;
         };
     };
+
+    // update incidences
+    var allIncis = csgeo.csnames[name].incidences;
+    allIncis.forEach(function(iname) {
+        var incis = csgeo.csnames[iname].incidences;
+        csgeo.csnames[iname].incidences = incis.filter(function(n) {
+            return n !== name;
+        });
+    });
 
     // process GeoArrays
     var geoArrs = ["conics", "free", "gslp", "ifs", "lines", "points", "polygons", "texts"];
@@ -432,6 +441,7 @@ function removeOneElement(name) {
         csgeo.sets[sname] = csgeo.sets[sname].filter(nameCmp(name, "set of " + sname));
     }
 
+    delete csgeo.csnames[name];
     geoDependantsCache = {};
 }
 

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -398,50 +398,54 @@ function removeElement(name) {
     };
 
     // collect all objects to delete
-    var delArr = Object.keys(recFind(name, {}));
+    var delArr = recFind(name, {});
 
-    // delete every single object
-    delArr.forEach(function(e) {
-        removeOneElement(e);
-    });
+    removeAllElements(delArr);
 
 }
 
-function removeOneElement(name) {
-    var i, el, debug = false;
-    if (debug) console.log("Remove element " + name);
+function removeAllElements(nameMap) {
+    var i, el, debug = true;
+    var keys = Object.keys(nameMap);
+    if (debug) console.log("Remove elements: " + String(keys));
 
 
-    var nameCmp = function(cmpName, arrn) {
+    var nameCmp = function(cmpMap, arrn) {
         return function(setel) {
-            if (setel.name === cmpName) {
-                if (debug) console.log("Removed element " + name + " from " + arrn);
+            if (cmpMap[setel.name]) {
+                if (debug) console.log("Removed element " + setel.name + " from " + arrn);
                 return false;
             } else return true;
         };
     };
 
     // update incidences
-    var allIncis = csgeo.csnames[name].incidences;
-    allIncis.forEach(function(iname) {
-        var incis = csgeo.csnames[iname].incidences;
-        csgeo.csnames[iname].incidences = incis.filter(function(n) {
-            return n !== name;
+    keys.forEach(function(name) {
+        var allIncis = csgeo.csnames[name].incidences;
+        allIncis.forEach(function(iname) {
+            var incis = csgeo.csnames[iname].incidences;
+            csgeo.csnames[iname].incidences = incis.filter(function(n) {
+                return !(nameMap[n]);
+            });
         });
     });
 
     // process GeoArrays
     var geoArrs = ["conics", "free", "gslp", "ifs", "lines", "points", "polygons", "texts"];
     geoArrs.map(function(arrn) {
-        csgeo[arrn] = csgeo[arrn].filter(nameCmp(name, arrn));
+        csgeo[arrn] = csgeo[arrn].filter(nameCmp(nameMap, arrn));
     });
 
     // remove from sets of geos -- PointSet (Ps), LineSet (Ls)...
     for (var sname in csgeo.sets) {
-        csgeo.sets[sname] = csgeo.sets[sname].filter(nameCmp(name, "set of " + sname));
+        csgeo.sets[sname] = csgeo.sets[sname].filter(nameCmp(nameMap, "set of " + sname));
     }
 
-    delete csgeo.csnames[name];
+
+    keys.forEach(function(name) {
+        delete csgeo.csnames[name];
+    });
+
     geoDependantsCache = {};
 }
 

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -361,7 +361,7 @@ function addElementNoProof(el) {
 }
 
 function removeElement(name) {
-    if(!csgeo.csnames.hasOwnProperty(name)){
+    if (!csgeo.csnames.hasOwnProperty(name)) {
         console.log("removeElement: name " + name + "does not exist.");
         return;
     }

--- a/src/js/libgeo/GeoBasics.js
+++ b/src/js/libgeo/GeoBasics.js
@@ -361,6 +361,11 @@ function addElementNoProof(el) {
 }
 
 function removeElement(name) {
+    if(!csgeo.csnames.hasOwnProperty(name)){
+        console.log("removeElement: name " + name + "does not exist.");
+        return;
+    }
+
     // build dependency tree
     var depTree = {};
     var cskeys = Object.keys(csgeo.csnames);
@@ -405,7 +410,6 @@ function removeOneElement(name) {
     var i, el, debug = false;
     if (debug) console.log("Remove element " + name);
 
-    // TODO Check if name exists
     delete csgeo.csnames[name];
 
     var nameCmp = function(cmpName, arrn) {


### PR DESCRIPTION
This PR implements the deletion of dependent elements. We have to build a dependency tree since we only track a directed graph in the "wrong" direction with geoel.args.  

This PR also enables to call ```removeelement``` from CindyScript.