### PR TITLE
Only run mouseclick if the courser has not moved too far

### DIFF
--- a/examples/mouseevents.html
+++ b/examples/mouseevents.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Mouse events</title>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+m = [(0,0), (0,0), (0,0)];
+ma = [0,0,0];
+mc = [(0,.9,.2), (0.2,0,1), (0.9,0,.2)];
+mn = ["mousedown", "mouseup", "mouseclick"];
+</script>
+<script id="csmouseclick" type="text/x-cindyscript">
+m_3 = mouse();
+ma_3 = 1;
+</script>
+<script id="csmouseup" type="text/x-cindyscript">
+m_2 = mouse();
+ma_2 = 1;
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+forall(1..3, i,
+	draw(m_i, color->mc_i, alpha->ma_i);
+	drawtext(m_i+(0,i/2-1), mn_i, alpha->ma_i);
+);
+ma = .97*ma;
+</script>
+<script id="csmousedown" type="text/x-cindyscript">
+m_1 = mouse();
+ma_1 = 1;
+</script>
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 350,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -4.66]}],
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  autoplay: true,
+  cinderella: {build: 1901, version: [2, 9, 1901]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -123,6 +123,8 @@ function addAutoCleaningEventListener(target, type, listener, useCapture) {
 function setuplisteners(canvas, data) {
 
     var MO = null;
+    var mousedownevent = null;
+    var hasmoved = false;
     if (typeof MutationObserver !== "undefined")
         MO = MutationObserver;
     if (!MO && typeof WebKitMutationObserver !== "undefined")
@@ -197,6 +199,8 @@ function setuplisteners(canvas, data) {
     }
 
     addAutoCleaningEventListener(canvas, "mousedown", function(e) {
+        mousedownevent = e;
+        hasmoved = false;
         mouse.button = e.which;
         updatePosition(e);
         cs_mousedown();
@@ -217,6 +221,8 @@ function setuplisteners(canvas, data) {
     addAutoCleaningEventListener(canvas, "mousemove", function(e) {
         updatePosition(e);
         if (mouse.down) {
+            if (mousedownevent && (Math.abs(mousedownevent.clientX - e.clientX) > 2 || Math.abs(mousedownevent.clientY - e.clientY) > 2))
+                hasmoved = true;
             cs_mousedrag();
         } else {
             cs_mousemove();
@@ -227,7 +233,8 @@ function setuplisteners(canvas, data) {
 
     addAutoCleaningEventListener(canvas, "click", function(e) {
         updatePosition(e);
-        cs_mouseclick();
+        if (!hasmoved)
+            cs_mouseclick();
         e.preventDefault();
     });
 

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -417,6 +417,8 @@ function setuplisteners(canvas, data) {
 
         updatePosition(e.targetTouches[0]);
         if (mouse.down) {
+            if (mousedownevent && (Math.abs(mousedownevent.clientX - e.targetTouches[0].clientX) > 2 || Math.abs(mousedownevent.clientY - e.targetTouches[0].clientY) > 2))
+                hasmoved = true;
             cs_mousedrag();
         } else {
             cs_mousemove();
@@ -442,6 +444,8 @@ function setuplisteners(canvas, data) {
         updatePosition(e.targetTouches[0]);
         cs_mousedown();
         mouse.down = true;
+        mousedownevent = e.targetTouches[0];
+        hasmoved = false;
         //move = getmover(mouse);
         manage("mousedown");
         e.preventDefault();
@@ -464,6 +468,8 @@ function setuplisteners(canvas, data) {
         cindy_cancelmove();
         cs_mouseup();
         manage("mouseup");
+        if (!hasmoved)
+            cs_mouseclick();
         scheduleUpdate();
         e.preventDefault();
     }


### PR DESCRIPTION
With this PR, mouseclick in CindyJS be handeled as it is in Cinderella: If the mouse is moved some distance while having a button pressed, then the mouseclick-script will not be evoked.

Before that, the mouseclick-event coincided with the mouseup-event in almost every case.