### PR TITLE
Simplify usage of cameravideo

### DIFF
--- a/examples/cindygl/24_webcam2.html
+++ b/examples/cindygl/24_webcam2.html
@@ -1,0 +1,40 @@
+
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Webcam in Cindy JS</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+res = [round(C.x*1500/10), round(C.y*1500/10)];
+colorplot([1,1,1]-imagergb(A, B, cameravideo(resolution->res), #));
+
+drawtext(C, "given resolution: " + res + "
+obtained resolution: " + imagesize(cameravideo(resolution->res)));
+
+//drawimage(A, B, cameravideo(resolution->res));
+</script>
+<script type="text/javascript">
+var cdy = CindyJS({
+  ports: [{id: "CSCanvas", transform:[{visibleRect:[-0.1,15.1,20.1,-0.1]}]}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0]},
+    {name:"B", type:"Free", pos:[20,0]},
+    {name:"C", type:"Free", pos:[10,6], color:[0,1,0]}
+  ],
+  use: ["CindyGL"]
+});
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="width:804px; height:604px; border:2px solid black"></div>
+</body>
+
+</html>

--- a/examples/webcam2.html
+++ b/examples/webcam2.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Webcam in Cindy JS</title>
+<meta charset="UTF-8">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script type="text/javascript" src="../build/js/CindyGL.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+res = [round(C.x*1500/40), round(C.y*1500/40)];
+drawimage (A, B, cameravideo(resolution -> res), interpolate->false);
+
+drawtext(C, imagesize(cameravideo(resolution -> res)));  
+</script>
+<script type="text/javascript">
+var cdy = CindyJS({
+  ports: [{id: "CSCanvas", transform:[{visibleRect:[-0.1,30.1,40.1,-0.1]}]}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0]},
+    {name:"B", type:"Free", pos:[40,0]},
+    {name:"C", type:"Free", pos:[15,20], color:[0,1,0]},
+  ]
+});
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="width:804px; height:604px; border:2px solid black"></div>
+  <p>
+    Note if running from a local machine Chromium/Chrome are preventing camera access due to security concerns.<br>
+    You can work around this by launching
+    <code>./node_modules/.bin/st -l -nc</code>
+    and then visiting
+    <a href="http://127.0.0.1:1337/examples/webcam2.html">http://127.0.0.1:1337/examples/webcam2.html</a>.<br>
+    Alternatively, you can also run Chrome with the <code>--allow-file-access-from-files</code> flag.<br>
+    This shouldn't be necessary if the example runs on a webserver.
+  </p>
+</body>
+
+</html>

--- a/plugins/cindygl/src/js/CanvasWrapper.js
+++ b/plugins/cindygl/src/js/CanvasWrapper.js
@@ -1,23 +1,21 @@
 function generateCanvasWrapperIfRequired(imageobject, api, properties) {
     if (imageobject['canvaswrapper']) {
+        if (imageobject.ready && (imageobject['canvaswrapper'].canvas == dummyimage || (imageobject['canvaswrapper'].sizeX != imageobject.width) || (imageobject['canvaswrapper'].sizeY != imageobject.height))) {
+            delete imageobject['canvaswrapper'];
+            imageobject['canvaswrapper'] = generateCanvasWrapperIfRequired(imageobject, api, properties);
+        }
         if (properties) imageobject['canvaswrapper'].updateReadingProperties(properties);
     } else {
-        imageobject['canvaswrapper'] = new CanvasWrapper(imageobject, properties || {
+        imageobject['canvaswrapper'] = new CanvasWrapper(imageobject.ready ? imageobject : dummyimage, properties || {
             interpolate: true,
             mipmap: false,
             repeat: false
         });
 
         if (!imageobject.ready) {
-            console.error("Image not ready. Creating onload event.");
-            imageobject.whenReady(() => {
-                imageobject.generation = Math.max(imageobject.generation, imageobject['canvaswrapper'].generation + 1);
-            });
+            console.log("Image is not ready yet.");
         }
     }
-    //imageobject['readPixels'] = imageobject['canvaswrapper'].readPixels.bind(imageobject['canvaswrapper']);
-    //if (imageobject['canvaswrapper'] && imageobject['canvaswrapper'].generation > imageobject.generation) imageobject['canvaswrapper'].copyTextureToCanvas();
-
     return imageobject['canvaswrapper'];
 }
 

--- a/plugins/cindygl/src/js/Init.js
+++ b/plugins/cindygl/src/js/Init.js
@@ -11,6 +11,11 @@ var glcanvas;
 /** @type {HTMLCanvasElement} */
 var tmpcanvas;
 
+/** @type {HTMLCanvasElement} */
+var dummycanvas;
+
+var dummyimage;
+
 /** @type {WebGLRenderingContext} */
 var gl;
 
@@ -45,6 +50,27 @@ function initGLIfRequired() {
     tmpcanvas.style.display = "none";
     tmpcanvas.width = tmpcanvas.height = 0;
     document.body.appendChild(tmpcanvas);
+
+    dummycanvas = /** @type {HTMLCanvasElement} */ (document.createElement("canvas"));
+    dummycanvas.id = "dummycanvas";
+    dummycanvas.style.display = "none";
+    dummycanvas.width = dummycanvas.height = 1;
+    document.body.appendChild(dummycanvas);
+    dummyimage = {
+        "ctype": "image",
+        "value": {
+            "img": dummycanvas,
+            "width": 1,
+            "height": 1,
+            "ready": true,
+            "live": false,
+            "generation": 0,
+            "whenReady": function(f) {
+                return;
+            },
+        },
+    };
+
 
     let errorInfo = "Unknown";
 

--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -481,6 +481,7 @@ evaluator.cameravideo$0 = function(args, modifs) {
     }
     if (!openVideoStream) {
         console.warn("getUserMedia call not supported");
+        cameravideo[constraintsstr] = nada;
         return nada;
     }
     var video = document.createElement("video");

--- a/src/js/libcs/OpImageDrawing.js
+++ b/src/js/libcs/OpImageDrawing.js
@@ -363,6 +363,8 @@ evaluator.allimages$0 = function() {
     return List.turnIntoCSList(lst);
 };
 
+
+var cameravideo = {};
 evaluator.cameravideo$0 = function(args, modifs) {
     var maximal = true; //use maximal as default (if no other modifier is given)
     var constraints = {};
@@ -452,6 +454,10 @@ evaluator.cameravideo$0 = function(args, modifs) {
             audio: false
         };
     }
+    var constraintsstr = JSON.stringify(constraints);
+
+    if (cameravideo[constraintsstr])
+        return cameravideo[constraintsstr];
 
     var openVideoStream = null;
 
@@ -479,7 +485,7 @@ evaluator.cameravideo$0 = function(args, modifs) {
     }
     var video = document.createElement("video");
     video.autoplay = true;
-    var img = loadImage(video, true);
+    cameravideo[constraintsstr] = loadImage(video, true);
     console.log("Opening stream.");
     openVideoStream(function success(stream) {
         /* does not work in Safari 11.0 (beta)
@@ -495,7 +501,7 @@ evaluator.cameravideo$0 = function(args, modifs) {
     }, function failure(err) {
         console.error("Could not get user video:", String(err), err);
     });
-    return img;
+    return cameravideo[constraintsstr];
 };
 
 evaluator.playvideo$1 = function(args, modifs) {


### PR DESCRIPTION
With this PR the initialization `video = cameravideo()` and the check `if(imageready(video), ...)` can be avoided.
Instead it is possible, to use `cameravideo()` directly, for instance
`colorplot(imagergb(cameravideo(),z^2));` in the draw-script.
If the video is not initialized yet, then imagergb returns [0,0,0] within CindyGL.