### PR TITLE
Enable basic geometry in CindyGL

### DIFF
--- a/examples/cindygl/60_conchoid.html
+++ b/examples/cindygl/60_conchoid.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        
+        <title>exported from UIExperiments.html</title>
+        <style type="text/css">
+            body {
+                margin: 0px;
+                padding: 0px;
+            }
+            
+            
+            #CSCanvas {
+                width: 100vw; height: 100vh;
+            }
+        </style>
+        <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+        <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+        
+      <script id="csdraw" type="text/x-cindyscript">
+almostequal(a, b) := exp(-30*|a-b|)*[1,0,0,1];
+
+colorplot(
+	c = join(C, p);
+	d = meet(c, a);
+	almostequal(|p-d|, C0.radius)
+);
+      </script>
+    
+        <script type="text/javascript">
+          var cdy = CindyJS({
+  "scripts": "cs*",
+  "angleUnit": "°",
+  "exclusive": "true",
+  "geometry": [
+    {
+      "alpha": 1,
+      "color": [
+        1,
+        0,
+        0
+      ],
+      "labeled": true,
+      "name": "A",
+      "pinned": false,
+      "size": 5,
+      "type": "Free",
+      "pos": [
+        0.9999999999999999,
+        -0.140625,
+        -0.3571875
+      ]
+    },
+    {
+      "alpha": 1,
+      "color": [
+        1,
+        0,
+        0
+      ],
+      "labeled": true,
+      "name": "B",
+      "pinned": false,
+      "size": 5,
+      "type": "Free",
+      "pos": [
+        0.9999999999999999,
+        -0.2732558139534883,
+        -0.6645348837209302
+      ]
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "A",
+        "B"
+      ],
+      "clip": "none",
+      "color": [
+        0,
+        0,
+        1
+      ],
+      "labeled": true,
+      "name": "a",
+      "overhang": 1,
+      "pinned": false,
+      "size": 1,
+      "type": "Join"
+    },
+    {
+      "alpha": 1,
+      "color": [
+        1,
+        0,
+        0
+      ],
+      "labeled": true,
+      "name": "C",
+      "pinned": false,
+      "size": 5,
+      "type": "Free",
+      "pos": [
+        -0.6218244043701462,
+        1,
+        0.9629064104251681
+      ]
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "a"
+      ],
+      "color": [
+        1,
+        0.4875,
+        0.5172
+      ],
+      "labeled": true,
+      "name": "D",
+      "pinned": false,
+      "size": 5,
+      "type": "PointOnLine",
+      "pos": [
+        1,
+        0.3353566218878505,
+        0.7458118847265255
+      ]
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "D"
+      ],
+      "clip": "none",
+      "color": [
+        0,
+        0,
+        1
+      ],
+      "labeled": true,
+      "name": "C0",
+      "overhang": 1,
+      "pinned": false,
+      "radius": 1.4492388066023998,
+      "size": 1,
+      "type": "CircleMr",
+      "pos": {
+        "xx": -0.7458118847265255,
+        "yy": -0.7458118847265255,
+        "zz": 0.07480874433402787,
+        "xy": 0,
+        "xz": 2.0000000000000004,
+        "yz": 0.670713243775701
+      }
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "D",
+        "C"
+      ],
+      "clip": "none",
+      "color": [
+        0,
+        0,
+        1
+      ],
+      "labeled": true,
+      "name": "b",
+      "overhang": 1,
+      "pinned": false,
+      "size": 1,
+      "type": "Join"
+    },
+    {
+      "args": [
+        "b",
+        "C0"
+      ],
+      "labeled": true,
+      "name": "Ps0",
+      "pinned": false,
+      "type": "IntersectLC"
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "Ps0"
+      ],
+      "color": [
+        1.4285714285714286,
+        0.6964285714285714,
+        0.7388571428571429
+      ],
+      "labeled": true,
+      "name": "E",
+      "pinned": false,
+      "size": 5,
+      "type": "SelectP",
+      "pos": [
+        -0.048659607041545413,
+        0.8615240022438281,
+        0.9999999999999999
+      ]
+    }
+  ],
+  "ports": [
+    {
+      "id": "CSCanvas",
+      "transform": [
+        {
+          "visibleRect": [
+            -5,
+            -5,
+            5,
+            5
+          ]
+        }
+      ],
+      "background": "rgb(168,176,192)"
+    }
+  ],
+  "csconsole": false,
+  "use": [
+    "CindyGL"
+  ],
+  "autoplay": true,
+  "behavior": []
+});
+        </script>
+    </head>
+    <body>
+        <div id="CSCanvas"></div>
+    </body>
+    </html>
+  

--- a/examples/cindygl/60_conchoid2.html
+++ b/examples/cindygl/60_conchoid2.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="UTF-8">
+        
+        <title>exported from UIExperiments.html</title>
+        <style type="text/css">
+            body {
+                margin: 0px;
+                padding: 0px;
+            }
+            
+            
+            #CSCanvas {
+                width: 100vw; height: 100vh;
+            }
+        </style>
+        <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+        <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+        
+      <script id="csdraw" type="text/x-cindyscript">
+testfun(p) := (
+  c = join(C, p);
+  d = meet(c, a);
+  |p-d|-C0.radius
+);
+
+width = .02;
+colorplot(
+  c0 = #-(width, width);
+	l = apply([c0, c0+(0,width),c0+(width,0), c0+(width,width)], p, testfun(p));
+  if(min(l)<0 & 0 < max(l),
+    [1,0,0,1],
+    [0,0,0,0]
+  )
+);
+      </script>
+    
+        <script type="text/javascript">
+          var cdy = CindyJS({
+  "scripts": "cs*",
+  "angleUnit": "°",
+  "exclusive": "true",
+  "geometry": [
+    {
+      "alpha": 1,
+      "color": [
+        1,
+        0,
+        0
+      ],
+      "labeled": true,
+      "name": "A",
+      "pinned": false,
+      "size": 5,
+      "type": "Free",
+      "pos": [
+        0.9999999999999999,
+        -0.140625,
+        -0.3571875
+      ]
+    },
+    {
+      "alpha": 1,
+      "color": [
+        1,
+        0,
+        0
+      ],
+      "labeled": true,
+      "name": "B",
+      "pinned": false,
+      "size": 5,
+      "type": "Free",
+      "pos": [
+        0.9999999999999999,
+        -0.2732558139534883,
+        -0.6645348837209302
+      ]
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "A",
+        "B"
+      ],
+      "clip": "none",
+      "color": [
+        0,
+        0,
+        1
+      ],
+      "labeled": true,
+      "name": "a",
+      "overhang": 1,
+      "pinned": false,
+      "size": 1,
+      "type": "Join"
+    },
+    {
+      "alpha": 1,
+      "color": [
+        1,
+        0,
+        0
+      ],
+      "labeled": true,
+      "name": "C",
+      "pinned": false,
+      "size": 5,
+      "type": "Free",
+      "pos": [
+        -0.6218244043701462,
+        1,
+        0.9629064104251681
+      ]
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "a"
+      ],
+      "color": [
+        1,
+        0.4875,
+        0.5172
+      ],
+      "labeled": true,
+      "name": "D",
+      "pinned": false,
+      "size": 5,
+      "type": "PointOnLine",
+      "pos": [
+        1,
+        0.3353566218878505,
+        0.7458118847265255
+      ]
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "D"
+      ],
+      "clip": "none",
+      "color": [
+        0,
+        0,
+        1
+      ],
+      "labeled": true,
+      "name": "C0",
+      "overhang": 1,
+      "pinned": false,
+      "radius": 1.4492388066023998,
+      "size": 1,
+      "type": "CircleMr",
+      "pos": {
+        "xx": -0.7458118847265255,
+        "yy": -0.7458118847265255,
+        "zz": 0.07480874433402787,
+        "xy": 0,
+        "xz": 2.0000000000000004,
+        "yz": 0.670713243775701
+      }
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "D",
+        "C"
+      ],
+      "clip": "none",
+      "color": [
+        0,
+        0,
+        1
+      ],
+      "labeled": true,
+      "name": "b",
+      "overhang": 1,
+      "pinned": false,
+      "size": 1,
+      "type": "Join"
+    },
+    {
+      "args": [
+        "b",
+        "C0"
+      ],
+      "labeled": true,
+      "name": "Ps0",
+      "pinned": false,
+      "type": "IntersectLC"
+    },
+    {
+      "alpha": 1,
+      "args": [
+        "Ps0"
+      ],
+      "color": [
+        1.4285714285714286,
+        0.6964285714285714,
+        0.7388571428571429
+      ],
+      "labeled": true,
+      "name": "E",
+      "pinned": false,
+      "size": 5,
+      "type": "SelectP",
+      "pos": [
+        -0.048659607041545413,
+        0.8615240022438281,
+        0.9999999999999999
+      ]
+    }
+  ],
+  "ports": [
+    {
+      "id": "CSCanvas",
+      "transform": [
+        {
+          "visibleRect": [
+            -5,
+            -5,
+            5,
+            5
+          ]
+        }
+      ],
+      "background": "rgb(168,176,192)"
+    }
+  ],
+  "csconsole": false,
+  "use": [
+    "CindyGL"
+  ],
+  "autoplay": true,
+  "behavior": []
+});
+        </script>
+    </head>
+    <body>
+        <div id="CSCanvas"></div>
+    </body>
+    </html>
+  

--- a/plugins/cindygl/src/js/General.js
+++ b/plugins/cindygl/src/js/General.js
@@ -148,6 +148,8 @@ function guessTypeOfValue(tval) {
         }
     } else if (tval['ctype'] === 'string' || tval['ctype'] === 'image') {
         return type.image;
+    } else if (tval['ctype'] === 'geo' && tval['value']['kind'] === 'L') {
+        return type.line;
     }
     console.error(`Cannot guess type of the following type:`);
     console.log(tval);

--- a/plugins/cindygl/src/js/Renderer.js
+++ b/plugins/cindygl/src/js/Renderer.js
@@ -148,6 +148,9 @@ Renderer.prototype.setUniforms = function() {
                 case type.float:
                     setter([val['value']['real']]);
                     break;
+                case type.line:
+                    setter(val['value']['homog']['value'].map(x => x['value']['real']));
+                    break;
                 default:
                     if (t.type === 'list' && t.parameters === type.float) { //float-list
                         setter(val['value'].map(x => x['value']['real']));

--- a/plugins/cindygl/src/js/TypeHelper.js
+++ b/plugins/cindygl/src/js/TypeHelper.js
@@ -129,7 +129,7 @@ function issubtypeof(a, b) {
     if (a.type === 'constant') return (issubtypeof(guessTypeOfValue(a.value), b));
 
     if (b === type.coordinate2d) return issubtypeof(a, type.complex) || issubtypeof(a, type.vec2) || issubtypeof(a, type.point);
-    if (b === type.point) return issubtypeof(a, type.vec3);
+    if (b === type.point) return issubtypeof(a, type.vec3) || issubtypeof(a, type.vec2);
     if (b === type.line) return issubtypeof(a, type.vec3);
     if (b === type.color) return (issubtypeof(a, type.float) || (a.type === 'list' && (a.length === 3 || a.length === 4) && issubtypeof(a.parameters, type.float)));
 

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -252,6 +252,10 @@ webgl["add"] = args => {
     let match = first(
         glslsupportop.map(t => [
             [t, t], t, useinfix('+')
+        ]).concat([
+            [
+                [type.point, type.point], type.vec2, useincludefunction('addpoints')
+            ]
         ])
     )(args);
     if (match) return match;
@@ -278,6 +282,11 @@ webgl["sub"] = args => {
         .concat(glslsupportop.map(t => [
             [type.voidt, t], t, useinfix('-')
         ]))
+        .concat([
+            [
+                [type.point, type.point], type.vec2, useincludefunction('subpoints')
+            ]
+        ])
     )(args);
     if (match) return match;
 
@@ -762,6 +771,8 @@ requires['arctan2c'] = ['logc', 'divc', 'sqrtc', 'multc'];
 requires['arctan2vec2c'] = ['arctan2c'];
 requires['hue'] = ['hsv2rgb'];
 requires['randomnormal'] = ['random'];
+requires['subpoints'] = ['dehomogenize'];
+requires['addpoints'] = ['dehomogenize'];
 
 
 Object.freeze(requires);

--- a/plugins/cindygl/src/str/addpoints.glsl
+++ b/plugins/cindygl/src/str/addpoints.glsl
@@ -1,0 +1,3 @@
+vec2 addpoints(vec3 a, vec3 b) {
+  return dehomogenize(a) + dehomogenize(b);
+}

--- a/plugins/cindygl/src/str/subpoints.glsl
+++ b/plugins/cindygl/src/str/subpoints.glsl
@@ -1,0 +1,3 @@
+vec2 subpoints(vec3 a, vec3 b) {
+  return dehomogenize(a) - dehomogenize(b);
+}


### PR DESCRIPTION
This PR makes `join` and `meet` usable within `colorplot`. This enables the rendering of loci of certain constructions.