### PR TITLE
 add accessors .x .y and .xy within CindyGL

### DIFF
--- a/examples/cindygl/60_conchoid.html
+++ b/examples/cindygl/60_conchoid.html
@@ -11,7 +11,7 @@
 f(P) := (
   l = join(C, P);
   M = meet(l, a);
-  |P-M|-C0.radius
+  |P.xy-M.xy|-C0.radius
 );
 
 tinyhexagon = apply(1..6, gauss(exp(i*#/6*2*pi)))*.02;

--- a/examples/cindygl/60_wattcurve.html
+++ b/examples/cindygl/60_wattcurve.html
@@ -77,7 +77,7 @@ f(E) := (
   intersect = true;
   Circ = circlepr(E, C2.radius/2);
   intersection = intersectcircir(C1.matrix, Circ);
-  opposite = apply(intersection, homog, P = (homog_1, homog_2)/homog_3; E-(P-E));
+  opposite = apply(intersection, I, E-(I.xy-E));
   (|opposite_1-A|-C0.radius)*(|opposite_2-A|-C0.radius)
 );
 

--- a/examples/cindygl/62_steinerlehmus.html
+++ b/examples/cindygl/62_steinerlehmus.html
@@ -8,26 +8,23 @@
         <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
         
       <script id="csinit" type="text/x-cindyscript">  
-  homog(z) := [re(z), im(z), 1];
-  dehomog(p) := [p_1, p_2]/p_3;
-
   bisectors(A, B, C) := (
     //compute the bisectors at point A
     a = complex(A);
     b = complex(B);
     c = complex(C);
     w = sqrt((c-a)*(b-a));
-    [join(A,homog(a+w)), join(A,homog(a+i*w))]
+    [join(A,gauss(a+w)), join(A,gauss(a+i*w))]
   );
 
 
   f(C) := (
     Alines = bisectors(A, B, C);
-    Apts = apply(Alines, l, dehomog(meet(l, join(B,C))));
+    Apts = apply(Alines, l, meet(l, join(B,C)).xy);
     Alen = apply(Apts, P, |P-A|)/|B-A|;
 
     Blines = bisectors(B, C, A);
-    Bpts = apply(Blines, l, dehomog(meet(l, join(A,C))));
+    Bpts = apply(Blines, l, meet(l, join(A,C)).xy);
     Blen = apply(Bpts, P, |P-B|)/|B-A|;
     //v = (Alen_1-Blen_1)*(Alen_2-Blen_1)*(Alen_1-Blen_2)*(Alen_2-Blen_2);
   );      
@@ -164,8 +161,10 @@ if(|Alen_2-Blen_2|<.1,
     </head>
     <body>
       <h1>Generalizing the Steiner-Lehmus Theorem</h1>
-      Adapted from <a href="http://geogebra.es/color_dinamico/color_dinamico.html">http://geogebra.es/color_dinamico/color_dinamico.html</a>. 
+      <div>Adapted from <a href="http://geogebra.es/color_dinamico/color_dinamico.html">http://geogebra.es/color_dinamico/color_dinamico.html</a>.</div> 
+      <div>The point C is on the curve iff there there are bisectors at A and B having the same length.</div>
         <div id="CSCanvas"></div>
+        <div>See also <a href="62_steinerlehmus2.html">the version</a>, where the bisectors at every point are considered</div>
     </body>
     </html>
   

--- a/examples/cindygl/62_steinerlehmus2.html
+++ b/examples/cindygl/62_steinerlehmus2.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
     <html>
     <head>
@@ -8,119 +9,108 @@
         <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
         
       <script id="csinit" type="text/x-cindyscript">  
-  homog(z) := [re(z), im(z), 1];
-  dehomog(p) := [p_1, p_2]/p_3;
-
-  bisectors(A, B, C) := (
-    //compute the bisectors at point A
-    a = complex(A);
-    b = complex(B);
-    c = complex(C);
-    w = sqrt((c-a)*(b-a));
-    [join(A,homog(a+w)), join(A,homog(a+i*w))]
-  );
+        bisectors(A, B, C) := (
+          //compute the bisectors at point A
+          a = complex(A);
+          b = complex(B);
+          c = complex(C);
+          w = sqrt((c-a)*(b-a));
+          [join(A,gauss(a+w)), join(A,gauss(a+i*w))]
+        );
 
 
-  f(C) := (
-    Alines = bisectors(A, B, C);
-    Apts = apply(Alines, l, dehomog(meet(l, join(B,C))));
-    Alen = apply(Apts, P, |P-A|)/|B-A|;
+        f(C) := (
+          Alines = bisectors(A, B, C);
+          Apts = apply(Alines, l, meet(l, join(B, C)).xy);
+          Alen = apply(Apts, P, |P-A|);
 
-    Blines = bisectors(B, C, A);
-    Bpts = apply(Blines, l, dehomog(meet(l, join(A,C))));
-    Blen = apply(Bpts, P, |P-B|)/|B-A|;
-    
-    Clines = bisectors(C, A, B);
-    Cpts = apply(Clines, l, dehomog(meet(l, join(A,B))));
-    Clen = apply(Cpts, P, |P-C|)/|B-A|;
-  );      
+          Blines = bisectors(B, C, A);
+          Bpts = apply(Blines, l, meet(l, join(A, C)).xy);
+          Blen = apply(Bpts, P, |P-B|);
+          
+          Clines = bisectors(C, A, B);
+          Cpts = apply(Clines, l, meet(l, join(A, B)).xy);
+          Clen = apply(Cpts, P, |P-C|);
+        );      
       </script>
       <script id="csdraw" type="text/x-cindyscript">
-colorplot(
-  f(#);
-  /*
-  exp(-40*min(|(Clen_1-Alen_1)|,|(Clen_1-Blen_1)|))*[1,1,1] +
-  exp(-20*min(|(Clen_1-Alen_2)|,|(Clen_1-Blen_2)|))*[1,1,0] +
-  exp(-20*min(|(Clen_2-Alen_1)|,|(Clen_2-Blen_1)|))*[1,0,1] +
-  exp(-10*min(|(Clen_2-Alen_2)|,|(Clen_2-Blen_2)|))*[1,0,0] +
-  
-  exp(-20*min(|(Alen_1-Blen_1)|,|(Alen_2-Blen_2)|))*[0,1,0] +
-  exp(-15*min(|(Alen_2-Blen_1)|,|(Alen_1-Blen_2)|))*[0,0,1] */
-  terms = [
-    10*|(Alen_1-Blen_1)|,
-    |(Alen_1-Blen_2)|,
-    |(Alen_2-Blen_1)|,
-    |(Alen_2-Blen_2)|,
-    5*|(Blen_1-Clen_1)|,
-    5*|(Blen_1-Clen_2)|,
-    |(Blen_2-Clen_1)|,
-    |(Blen_2-Clen_2)|,
-    5*|(Clen_1-Alen_1)|,
-    |(Clen_1-Alen_2)|,
-    5*|(Clen_2-Alen_1)|,
-    |(Clen_2-Alen_2)|
-  ];
-  m = min(terms);
-  (exp(-15*m));
-);
+        colorplot(
+          f(#); //eval f at pixel coordinate
+          terms = [
+            |(Alen_1/Blen_1)-1|,
+            |(Alen_1/Blen_2)-1|,
+            |(Alen_2/Blen_1)-1|,
+            |(Alen_2/Blen_2)-1|,
+            |(Blen_1/Clen_1)-1|,
+            |(Blen_1/Clen_2)-1|,
+            |(Blen_2/Clen_1)-1|,
+            |(Blen_2/Clen_2)-1|,
+            |(Clen_1/Alen_1)-1|,
+            |(Clen_1/Alen_2)-1|,
+            |(Clen_2/Alen_1)-1|,
+            |(Clen_2/Alen_2)-1|
+          ];
+          m = min(terms);
+          (exp(-15*m));
+        );
 
-f(C);
-draw(join(A, C), color->[1,1,1], alpha->.5);
-draw(join(B, C), color->[1,1,1], alpha->.5);
-draw(join(A, B), color->[1,1,1], alpha->.5);
+        f(C);
+        draw(join(A, C), color->[1,1,1], alpha->.5);
+        draw(join(B, C), color->[1,1,1], alpha->.5);
+        draw(join(A, B), color->[1,1,1], alpha->.5);
 
-draw(A, C);
-draw(B, C);
-draw(A, B);
+        draw(A, C);
+        draw(B, C);
+        draw(A, B);
 
-pt2len(p) := (
-  if(p==A,Alen,
-    if(p==B,Blen,
-      Clen
-    )
-  )
-);
+        pt2len(p) := (
+          if(p==A,Alen,
+             if(p==B,Blen,
+                Clen
+               )
+            )
+        );
 
-pt2pts(p) := (
-  if(p==A,Apts,
-    if(p==B,Bpts,
-      Cpts
-    )
-  )
-);
+        pt2pts(p) := (
+          if(p==A,Apts,
+             if(p==B,Bpts,
+                Cpts
+               )
+            )
+        );
 
-lencpdcnt = 0;
-lencpds = [];
+        lencpdcnt = 0;
+        lencpds = [];
 
-addcpd(cpd) := (
-  added = false;
-  forall(1..length(lencpds), k,
-    if(!added & length(cpd ∩ lencpds_k)>0,
-      lencpds_k = lencpds_k ∪ cpd;
-      added = true;
-    );
-  );
-  if(!added,
-    lencpds = lencpds :> cpd;
-  );
-);
+        addcpd(cpd) := (
+          added = false;
+          forall(1..length(lencpds), k,
+                 if(!added & length(cpd ∩ lencpds_k)>0,
+                    lencpds_k = lencpds_k ∪ cpd;
+                    added = true;
+                   );
+                );
+          if(!added,
+             lencpds = lencpds :> cpd;
+            );
+        );
 
-forall([[1,1],[1,2],[2,1],[2,2]], idx,
-  forall([[A,B],[B,C],[C,A]], pts,
-    if(|pt2len(pts_1)_(idx_1)/pt2len(pts_2)_(idx_2)-1|<.05,
-      addcpd([
-        [pts_1, pt2pts(pts_1)_(idx_1)],
-        [pts_2, pt2pts(pts_2)_(idx_2)]
-      ]);
-    );
-  );
-);
+        forall([[1,1],[1,2],[2,1],[2,2]], idx,
+               forall([[A,B],[B,C],[C,A]], pts,
+                      if(|pt2len(pts_1)_(idx_1)/pt2len(pts_2)_(idx_2)-1|<.05,
+                         addcpd([
+                           [pts_1, pt2pts(pts_1)_(idx_1)],
+                           [pts_2, pt2pts(pts_2)_(idx_2)]
+                         ]);
+                        );
+                     );
+              );
 
-forall(1..length(lencpds), k,
-  forall(lencpds_k, l,
-    draw(l_1, l_2, color->[.5,.5,.5]+hue(k/4), size->6, alpha->.8);
-  );
-);
+        forall(1..length(lencpds), k,
+               forall(lencpds_k, l,
+                      draw(l_1, l_2, color->[.5,.5,.5]+hue(k/4), size->6, alpha->.8);
+                     );
+              );
 </script>
     
         <script type="text/javascript">
@@ -218,6 +208,7 @@ forall(1..length(lencpds), k,
         <div>This is an implementation of the dynamic picture from Losada, R., T. Recio, and J. L. Valcarce. <a href="http://www.geogebra.es/pub/adg2010def1.pdf">"On the automatic discovery of Steiner-Lehmus generalizations."</a> Proceedings of ADG. 2010.</div>
         <div>The point C is on the white curve iff there is a pair of bisectors with the same length.</div>
         <div id="CSCanvas"></div>
+        <div>See also the <a href="62_steinerlehmus.html">simpler version</a>, considering only the bisectors at A and B</div>
     </body>
     </html>
   

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -974,21 +974,20 @@ CodeBuilder.prototype.compile = function(expr, generateTerm) {
             'a': 3
         }[expr['key']];
         let term = false;
+        let objterm = self.compile(expr['obj'], true).term;
         if (index != undefined && objt.type === "list") {
-            term = accesslist(objt, index)([self.compile(expr['obj'], true).term], null, this);
-        }
-        if (issubtypeof(objt, type.point)) {
+            term = accesslist(objt, index)([objterm], null, this);
+        } else if (expr['key']==="xy" && objt.type === "list") {
+            if(objt.length === 2) term = objterm;
+            if(objt.length === 3) term = useincludefunction('dehomogenize')([self.castType(objterm, objt, type.point)], null, this);
+        } else if (objt === type.point) {
             let funs = {
                 'xy': 'dehomogenize',
                 'x': 'dehomogenizex',
                 'y': 'dehomogenizey',
             };
             if (funs[expr['key']])
-                term = useincludefunction(funs[expr['key']])([
-                    self.castType(
-                        self.compile(expr['obj'], true).term,
-                        objt, type.point)
-                ], null, this);
+                term = useincludefunction(funs[expr['key']])([self.castType(objterm, objt, type.point)], null, this);
         }
 
         if (term) {

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -879,7 +879,7 @@ CodeBuilder.prototype.compile = function(expr, generateTerm) {
         let fname = expr['oper'];
 
         if (getPlainName(fname) === 'verbatimglsl') {
-            let glsl = this.api.evaluateAndVal(expr['args'][0]).value;
+            let glsl = this.api.evaluateAndVal(expr['args'][0])['value'];
             return (generateTerm ? {
                 term: glsl,
                 code: ''
@@ -977,9 +977,9 @@ CodeBuilder.prototype.compile = function(expr, generateTerm) {
         let objterm = self.compile(expr['obj'], true).term;
         if (index != undefined && objt.type === "list") {
             term = accesslist(objt, index)([objterm], null, this);
-        } else if (expr['key']==="xy" && objt.type === "list") {
-            if(objt.length === 2) term = objterm;
-            if(objt.length === 3) term = useincludefunction('dehomogenize')([self.castType(objterm, objt, type.point)], null, this);
+        } else if (expr['key'] === "xy" && objt.type === "list") {
+            if (objt.length === 2) term = objterm;
+            if (objt.length === 3) term = useincludefunction('dehomogenize')([self.castType(objterm, objt, type.point)], null, this);
         } else if (objt === type.point) {
             let funs = {
                 'xy': 'dehomogenize',

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -135,7 +135,14 @@ CodeBuilder.prototype.computeType = function(expr) { //expression
         return type.voidt;
     } else if (expr['ctype'] === 'field') {
         let t = generalize(this.getType(expr['obj']));
-        if (t.type === 'list') return t.parameters;
+        if (expr['key'].length == 1) {
+            if (t.type === 'list')
+                return t.parameters;
+            else if (issubtypeof(t, type.point))
+                return type.float;
+        } else if (expr['key'] == 'xy' && issubtypeof(t, type.point))
+            return type.vec2;
+
         if (!t) return false;
     } else if (expr['ctype'] === 'string') {
         return type.image;
@@ -956,6 +963,7 @@ CodeBuilder.prototype.compile = function(expr, generateTerm) {
             code: ''
         });
     } else if (expr['ctype'] === 'field') {
+        let objt = this.getType(expr['obj']);
         let index = {
             'x': 0,
             'y': 1,
@@ -965,8 +973,25 @@ CodeBuilder.prototype.compile = function(expr, generateTerm) {
             'b': 2,
             'a': 3
         }[expr['key']];
-        if (index != undefined) {
-            let term = accesslist(this.getType(expr['obj']), index)([self.compile(expr['obj'], true).term], null, this);
+        let term = false;
+        if (index != undefined && objt.type === "list") {
+            term = accesslist(objt, index)([self.compile(expr['obj'], true).term], null, this);
+        }
+        if (issubtypeof(objt, type.point)) {
+            let funs = {
+                'xy': 'dehomogenize',
+                'x': 'dehomogenizex',
+                'y': 'dehomogenizey',
+            };
+            if (funs[expr['key']])
+                term = useincludefunction(funs[expr['key']])([
+                    self.castType(
+                        self.compile(expr['obj'], true).term,
+                        objt, type.point)
+                ], null, this);
+        }
+
+        if (term) {
             return (generateTerm ? {
                 term: term,
                 code: ''

--- a/plugins/cindygl/src/js/General.js
+++ b/plugins/cindygl/src/js/General.js
@@ -135,6 +135,12 @@ function guessTypeOfValue(tval) {
         }
     } else if (tval['ctype'] === 'list') {
         let l = tval['value'];
+        if (l.length === 3) {
+            if (tval["usage"] === "Point")
+                return type.point;
+            else if (tval["usage"] === "Line")
+                return type.line
+        }
         if (l.length > 0) {
             let ctype = guessTypeOfValue(l[0]);
             for (let i = 1; i < l.length; i++) {

--- a/plugins/cindygl/src/js/Plugin.js
+++ b/plugins/cindygl/src/js/Plugin.js
@@ -136,7 +136,7 @@ CindyJS.registerPlugin(1, "CindyGL", api => {
         if (!a.ok || !b.ok || name.ctype !== 'string') {
             return nada;
         }
-        let imageobject = api.getImage(name.value, true);
+        let imageobject = api.getImage(name['value'], true);
         //let canvaswrapper = generateWriteCanvasWrapperIfRequired(imageobject, api);
         let canvaswrapper = generateCanvasWrapperIfRequired(imageobject, api, false);
         var cw = imageobject.width;
@@ -161,7 +161,7 @@ CindyJS.registerPlugin(1, "CindyGL", api => {
             return nada;
         }
 
-        let imageobject = api.getImage(name.value, true);
+        let imageobject = api.getImage(name['value'], true);
         //let canvaswrapper = generateWriteCanvasWrapperIfRequired(imageobject, api);
         let canvaswrapper = generateCanvasWrapperIfRequired(imageobject, api, false);
         var cw = imageobject.width;

--- a/plugins/cindygl/src/js/Renderer.js
+++ b/plugins/cindygl/src/js/Renderer.js
@@ -148,8 +148,14 @@ Renderer.prototype.setUniforms = function() {
                 case type.float:
                     setter([val['value']['real']]);
                     break;
+                case type.point:
                 case type.line:
-                    setter(val['value']['homog']['value'].map(x => x['value']['real']));
+                    if (val.ctype === 'geo')
+                        setter(val['value']['homog']['value'].map(x => x['value']['real']));
+                    else if (val.ctype === 'list' && val['value'].length === 2)
+                        setter(val['value'].map(x => x['value']['real']).concat([1]));
+                    else if (val.ctype === 'list' && val['value'].length === 3)
+                        setter(val['value'].map(x => x['value']['real']));
                     break;
                 default:
                     if (t.type === 'list' && t.parameters === type.float) { //float-list

--- a/plugins/cindygl/src/js/WebGL.js
+++ b/plugins/cindygl/src/js/WebGL.js
@@ -42,6 +42,9 @@ webgl['gauss'] = first([
 webgl['complex'] = first([
     [
         [type.vec2], type.complex, identity
+    ],
+    [
+        [type.point], type.complex, useincludefunction('dehomogenize')
     ]
 ]);
 

--- a/plugins/cindygl/src/str/dehomogenizex.glsl
+++ b/plugins/cindygl/src/str/dehomogenizex.glsl
@@ -1,0 +1,3 @@
+float dehomogenizex(vec3 z) {
+  return z.x/z.z;
+}

--- a/plugins/cindygl/src/str/dehomogenizey.glsl
+++ b/plugins/cindygl/src/str/dehomogenizey.glsl
@@ -1,0 +1,3 @@
+float dehomogenizey(vec3 z) {
+  return z.y/z.z;
+}


### PR DESCRIPTION
If .x .y or .xy is applied to a point, then the coordinates are dehomogenized before.
Furthermore, the examples have adopted accordingly.