### PR TITLE
TrRotationPNumb

### DIFF
--- a/examples/TrRotationPNumb-150.html
+++ b/examples/TrRotationPNumb-150.html
@@ -45,8 +45,8 @@ createCindy({
 		{ name: "A", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
 		{ name: "B", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 1.0 ], labeled: true }, 
 		{ name: "a", type: "Through", pos: [ 0.0, 1.3333333333333333, 4.0 ], color: [ 1.0, 0.0, 0.0 ], args: [ "B" ], labeled: true }, 
-		{ name: "b", type: "Through", pos: [ 0.43496451734786623, -0.7533806435361785, -4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "B" ], labeled: true }, 
-		{ name: "a0", type: "Angle", color: [ 0.0, 0.0, 1.0 ], args: [ "a", "b", "A" ] }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
+		{ name: "b", type: "Through", pos: [ -0.43496451734786623, 0.7533806435361785, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "B" ], labeled: true }, 
+		{ name: "a0", type: "Angle", color: [ 0.0, 0.0, 1.0 ], args: [ "a", "b", "A" ], angle: -150/180*Math.PI }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
 		//{ name: "Text0", type: "Text", color: [ 0.0, 0.0, 0.0 ], args: [ "a0", "B" ], text: "<)@$\"a\"@$\"b\"= @#\"a0\"" }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
 		{ name: "Tr0", type: "TrRotationPNumb", color: [ 0.0, 0.0, 1.0 ], args: [ "A", "a0" ] }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
 		{ name: "C", type: "Free", pos: [ 4.0, -0.0, 0.3076923076923077 ], color: [ 0.0, 1.0, 0.0 ], labeled: true }, 

--- a/examples/TrRotationPNumb-150.html
+++ b/examples/TrRotationPNumb-150.html
@@ -30,7 +30,7 @@ drawtext((-9,5),"b"+b.homog/scale,color->(0,0,1),size->20);
 drawtext((-9,4),"C"+C.homog/scale,color->(0,1,0),size->20);
 drawtext((-9,3),"C'"+CP.homog/scale,color->(0,1,1),size->20);
 drawtext((-9,2),"C''"+CPP.homog/scale,color->(1,1,0),size->20);
-drawtext((-9,1),"α0.angle="+a0.angle,color->(1,1,0),size->20);
+drawtext((-9,1),"α0="+a0,color->(1,1,0),size->20);
 draw((-9.06,0),(18.14,0),arrow->true,size->2,color->(128/255,128/255,128/255));//x-axis
 draw((0,-13.22),(0,9.34),arrow->true,size->2,color->(128/255,128/255,128/255));//y-axis
 drawcircle(A,sqrt((C-A)*(C-A)),color->(128/255,128/255,128/255));

--- a/examples/TrRotationPNumb-150.html
+++ b/examples/TrRotationPNumb-150.html
@@ -37,7 +37,7 @@ drawcircle(A,sqrt((C-A)*(C-A)),color->(128/255,128/255,128/255));
 </script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
     scripts: "cs*", grid: 1, snap: true, 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 }, 
 	angleUnit: "°", 
@@ -61,6 +61,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/examples/TrRotationPNumb-150.html
+++ b/examples/TrRotationPNumb-150.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>TrRotationPNumb-150.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+scale=1;//1 in CindyJS and 4 in Cinderella
+drawtext((11,6),"mouse"+mouse(),color->(0,0,0),size->20);
+drawtext((-9,8),"A"+A.homog/scale,color->(1,0,0),size->20);
+drawtext((-9,7),"B"+B.homog/scale,color->(1,0,1),size->20);
+drawtext((-9,6),"a"+a.homog/scale,color->(1,0,0),size->20);
+drawtext((-9,5),"b"+b.homog/scale,color->(0,0,1),size->20);
+drawtext((-9,4),"C"+C.homog/scale,color->(0,1,0),size->20);
+drawtext((-9,3),"C'"+CP.homog/scale,color->(0,1,1),size->20);
+drawtext((-9,2),"C''"+CPP.homog/scale,color->(1,1,0),size->20);
+drawtext((-9,1),"α0.angle="+a0.angle,color->(1,1,0),size->20);
+draw((-9.06,0),(18.14,0),arrow->true,size->2,color->(128/255,128/255,128/255));//x-axis
+draw((0,-13.22),(0,9.34),arrow->true,size->2,color->(128/255,128/255,128/255));//y-axis
+drawcircle(A,sqrt((C-A)*(C-A)),color->(128/255,128/255,128/255));
+</script>
+
+    <script type="text/javascript">
+createCindy({ 
+    scripts: "cs*", grid: 1, snap: true, 
+	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 }, 
+	angleUnit: "°", 
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "B", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 1.0 ], labeled: true }, 
+		{ name: "a", type: "Through", pos: [ 0.0, 1.3333333333333333, 4.0 ], color: [ 1.0, 0.0, 0.0 ], args: [ "B" ], labeled: true }, 
+		{ name: "b", type: "Through", pos: [ 0.43496451734786623, -0.7533806435361785, -4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "B" ], labeled: true }, 
+		{ name: "a0", type: "Angle", color: [ 0.0, 0.0, 1.0 ], args: [ "a", "b", "A" ] }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
+		//{ name: "Text0", type: "Text", color: [ 0.0, 0.0, 0.0 ], args: [ "a0", "B" ], text: "<)@$\"a\"@$\"b\"= @#\"a0\"" }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
+		{ name: "Tr0", type: "TrRotationPNumb", color: [ 0.0, 0.0, 1.0 ], args: [ "A", "a0" ] }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
+		{ name: "C", type: "Free", pos: [ 4.0, -0.0, 0.3076923076923077 ], color: [ 0.0, 1.0, 0.0 ], labeled: true }, 
+		{ name: "C0", type: "CircleByRadius", color: [ 0.0, 1.0, 0.0 ], radius: 2.45, args: [ "C" ], printname: "$C_{0}$" }, 
+		{ name: "CP", type: "Transform", pos: [ 4.0, 1.5923781594647068, 0.388567239197061 ], color: [ 0.0, 1.0, 1.0 ], args: [ "Tr0", "C" ], labeled: true, printname: "C'" }, 
+		{ name: "C1", type: "Transform", color: [ 0.0, 1.0, 1.0 ], args: [ "Tr0", "C0" ], printname: "$C_{1}$" }, 
+		{ name: "CPP", type: "Transform", pos: [ -3.750689167349033, -4.0, -0.6355028125852985 ], color: [ 1.0, 1.0, 0.0 ], args: [ "Tr0", "CP" ], labeled: true, printname: "C''" }, 
+		{ name: "C2", type: "Transform", color: [ 1.0, 1.0, 0.0 ], args: [ "Tr0", "C1" ], printname: "$C_{2}$" }], 
+    ports: [ 
+		{ id: "CSCanvas", width: 680, height: 564, transform: [ { visibleRect: [ -9.06, 9.34, 18.14, -13.22 ] } ], background: "rgb(168,176,192)" } ], 
+	cinderella: { build: 1798, version: [ 2, 9, 1798 ] } });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/examples/TrRotationPNumb.html
+++ b/examples/TrRotationPNumb.html
@@ -30,7 +30,7 @@ drawtext((-9,5),"b"+b.homog/scale,color->(0,0,1),size->20);
 drawtext((-9,4),"C"+C.homog/scale,color->(0,1,0),size->20);
 drawtext((-9,3),"C'"+CP.homog/scale,color->(0,1,1),size->20);
 drawtext((-9,2),"C''"+CPP.homog/scale,color->(1,1,0),size->20);
-drawtext((-9,1),"α0.angle="+a0.angle,color->(1,1,0),size->20);
+drawtext((-9,1),"α0="+a0,color->(1,1,0),size->20);
 draw((-9.06,0),(18.14,0),arrow->true,size->2,color->(128/255,128/255,128/255));//x-axis
 draw((0,-13.22),(0,9.34),arrow->true,size->2,color->(128/255,128/255,128/255));//y-axis
 drawcircle(A,sqrt((C-A)*(C-A)),color->(128/255,128/255,128/255));

--- a/examples/TrRotationPNumb.html
+++ b/examples/TrRotationPNumb.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>TrRotationPNumb.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+scale=1;//1 in CindyJS and 4 in Cinderella
+drawtext((11,6),"mouse"+mouse(),color->(0,0,0),size->20);
+drawtext((-9,8),"A"+A.homog/scale,color->(1,0,0),size->20);
+drawtext((-9,7),"B"+B.homog/scale,color->(1,0,1),size->20);
+drawtext((-9,6),"a"+a.homog/scale,color->(1,0,0),size->20);
+drawtext((-9,5),"b"+b.homog/scale,color->(0,0,1),size->20);
+drawtext((-9,4),"C"+C.homog/scale,color->(0,1,0),size->20);
+drawtext((-9,3),"C'"+CP.homog/scale,color->(0,1,1),size->20);
+drawtext((-9,2),"C''"+CPP.homog/scale,color->(1,1,0),size->20);
+drawtext((-9,1),"α0.angle="+a0.angle,color->(1,1,0),size->20);
+draw((-9.06,0),(18.14,0),arrow->true,size->2,color->(128/255,128/255,128/255));//x-axis
+draw((0,-13.22),(0,9.34),arrow->true,size->2,color->(128/255,128/255,128/255));//y-axis
+drawcircle(A,sqrt((C-A)*(C-A)),color->(128/255,128/255,128/255));
+</script>
+
+    <script type="text/javascript">
+createCindy({ 
+    scripts: "cs*", grid: 1, snap: true, 
+	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 }, 
+	angleUnit: "°", 
+	geometry: [ 
+		{ name: "A", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 0.0 ], labeled: true }, 
+		{ name: "B", type: "Free", pos: [ 4.0, -3.0, 1.0 ], color: [ 1.0, 0.0, 1.0 ], labeled: true }, 
+		{ name: "a", type: "Through", pos: [ 0.0, 1.3333333333333333, 4.0 ], color: [ 1.0, 0.0, 0.0 ], args: [ "B" ], labeled: true }, 
+		{ name: "b", type: "Through", pos: [ -0.43496451734786623, 0.7533806435361785, 4.0 ], color: [ 0.0, 0.0, 1.0 ], args: [ "B" ], labeled: true }, 
+		{ name: "a0", type: "Angle", color: [ 0.0, 0.0, 1.0 ], args: [ "a", "b", "A" ] }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
+		//{ name: "Text0", type: "Text", color: [ 0.0, 0.0, 0.0 ], args: [ "a0", "B" ], text: "<)@$\"a\"@$\"b\"= @#\"a0\"" }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
+		{ name: "Tr0", type: "TrRotationPNumb", color: [ 0.0, 0.0, 1.0 ], args: [ "A", "a0" ] }, // "?0" is "α0"; "@alpha 0" U+03B1: Greek Small Letter Alpha
+		{ name: "C", type: "Free", pos: [ 4.0, -0.0, 0.3076923076923077 ], color: [ 0.0, 1.0, 0.0 ], labeled: true }, 
+		{ name: "C0", type: "CircleByRadius", color: [ 0.0, 1.0, 0.0 ], radius: 2.45, args: [ "C" ], printname: "$C_{0}$" }, 
+		{ name: "CP", type: "Transform", pos: [ 4.0, 1.5923781594647068, 0.388567239197061 ], color: [ 0.0, 1.0, 1.0 ], args: [ "Tr0", "C" ], labeled: true, printname: "C'" }, 
+		{ name: "C1", type: "Transform", color: [ 0.0, 1.0, 1.0 ], args: [ "Tr0", "C0" ], printname: "$C_{1}$" }, 
+		{ name: "CPP", type: "Transform", pos: [ -3.750689167349033, -4.0, -0.6355028125852985 ], color: [ 1.0, 1.0, 0.0 ], args: [ "Tr0", "CP" ], labeled: true, printname: "C''" }, 
+		{ name: "C2", type: "Transform", color: [ 1.0, 1.0, 0.0 ], args: [ "Tr0", "C1" ], printname: "$C_{2}$" }], 
+    ports: [ 
+		{ id: "CSCanvas", width: 680, height: 564, transform: [ { visibleRect: [ -9.06, 9.34, 18.14, -13.22 ] } ], background: "rgb(168,176,192)" } ], 
+	cinderella: { build: 1798, version: [ 2, 9, 1798 ] } });
+    </script>
+</head>
+<body>
+    <canvas id="CSCanvas"></canvas>
+</body>
+</html>

--- a/examples/TrRotationPNumb.html
+++ b/examples/TrRotationPNumb.html
@@ -37,7 +37,7 @@ drawcircle(A,sqrt((C-A)*(C-A)),color->(128/255,128/255,128/255));
 </script>
 
     <script type="text/javascript">
-createCindy({ 
+CindyJS({ 
     scripts: "cs*", grid: 1, snap: true, 
 	defaultAppearance: { fontFamily: "sans-serif", lineSize: 1, pointSize: 5.0, dimDependent: 0.7 }, 
 	angleUnit: "°", 
@@ -61,6 +61,6 @@ createCindy({
     </script>
 </head>
 <body>
-    <canvas id="CSCanvas"></canvas>
+    <div id="CSCanvas"></div>
 </body>
 </html>

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -2670,37 +2670,10 @@ geoOps.TrTranslation.updatePosition = function(el) {
     el.dualMatrix = m;
 };
 
-// Given two lines, define a rotation angle from the first line to the second line
-// Does not make use of the pivot point given as the third argument
-geoOps.Angle = {};
-geoOps.Angle.kind = "A";
-geoOps.Angle.signature = ["L", "L", "P"];
-geoOps.Angle.updatePosition = function(el) {
-    var a = csgeo.csnames[el.args[0]].homog.value;
-    var b = csgeo.csnames[el.args[1]].homog.value;
-    /*
-        Given line a as [ax, ay, az] and line b as [bx, by, bz];
-        referring to the angle θ as the rotation from line a to line b, then
-            c, r*cos(θ), is (ax*bx+ay*by);
-            s, r*sin(θ), is (ax*by-ay*bx);
-            r is sqrt(c*c+s*s)
-        then the angle θ is -i*log((c+i*s)/r).
-    */
-    var mult = CSNumber.mult;
-    var add = CSNumber.add;
-    var sub = CSNumber.sub;
-    var c = add(mult(a[0], b[0]), mult(a[1], b[1]));
-    var s = sub(mult(a[0], b[1]), mult(a[1], b[0]));
-    var r = CSNumber.sqrt(add(mult(c, c), mult(s, s)));
-    var cis = add(c, mult(CSNumber.complex(0, 1), s));
-    var th = mult(CSNumber.complex(0, -1), CSNumber.log(CSNumber.div(cis, r)));
-    return el.angle = General.withUsage(th, "Angle");
-};
-
 // Define a rotation transformation given the center of rotation point and an angle
 geoOps.TrRotationPNumb = {};
 geoOps.TrRotationPNumb.kind = "Tr";
-geoOps.TrRotationPNumb.signature = ["P", "A"];
+geoOps.TrRotationPNumb.signature = ["P", "V"];
 geoOps.TrRotationPNumb.updatePosition = function(el) {
     /*
         Given a point p as [x, y, z] and an angle θ, where c is cos(θ)
@@ -2716,7 +2689,7 @@ geoOps.TrRotationPNumb.updatePosition = function(el) {
         z*translate([x/z, y/z, 1])·rotate(θ)·translate([-x/z, -y/z, 1]).
     */
     var p = csgeo.csnames[el.args[0]].homog.value;
-    var th = csgeo.csnames[el.args[1]].angle;
+    var th = csgeo.csnames[el.args[1]].value;
     var mult = CSNumber.mult;
     var add = CSNumber.add;
     var sub = CSNumber.sub;


### PR DESCRIPTION
This PR contains a cherry-pick of those commits in #194 that implement `TrRotationPNumb`.
`TrRotationPNumb` and the examples are mainly @elkins0 implementation. I only adopted his commits to use the version of `Angle` in the current master. This `Angle` is well traced, and therefore, no oriented lines are required.

With this, hopefully, @kiryph tilings using crystallographic operations should work. :-)