### PR TITLE
Inversion formula fixed and the circle center is shown

### DIFF
--- a/examples/cindygl/24_webcam_inversion.html
+++ b/examples/cindygl/24_webcam_inversion.html
@@ -33,7 +33,10 @@ if (image ready(video),
   if(mirror, z = -re(z)+i*im(z));
   if(inv, z = 1.0/(re(z)-i*im(z)), z = z/5.0);
   imagergb(video, z*(10.1+mouse().y))));
-if (circle, fillcircle([0,0],2.23,color->(1,0,0.3),alpha->0.3));
+if (circle,
+  fillcircle([0,0],2.23,color->(1,0,0.3),alpha->0.3);
+  fillcircle([0,0],0.05,color->(1,0,0),alpha->0.8);
+);
 </script>
 
 </head>

--- a/examples/cindygl/24_webcam_inversion.html
+++ b/examples/cindygl/24_webcam_inversion.html
@@ -31,7 +31,7 @@ if (image ready(video),
   colorplot(
   z = complex(#);
   if(mirror, z = -re(z)+i*im(z));
-  if(inv, z = 1.0/z, z = z/5.0);
+  if(inv, z = 1.0/(re(z)-i*im(z)), z = z/5.0);
   imagergb(video, z*(10.1+mouse().y))));
 if (circle, fillcircle([0,0],2.23,color->(1,0,0.3),alpha->0.3));
 </script>


### PR DESCRIPTION
Dear Aaron, thanks for merging my first contributions. I had a nice presentation with CindyJS last week among my students.
In the meantime I learned that I used the wrong formula, because the conjugate of the complex input should be used. Now I fixed that issue. Also, it seems useful to show the center of the circle as well.
Please consider merging these two minor changes as well.
I learned that the file package-lock.json file wanted to be committed as well. I did not commit it. I am unsure if it is a good idea to keep package-lock.json in the repository. I found some arguments pro and con at
* https://stackoverflow.com/questions/44206782/do-i-commit-the-package-lock-json-file-created-by-npm-5
* https://github.com/npm/npm/issues/20603
Anyway, personally I think it would be better to remove it from version control.