### PR TITLE
let List.abs return nada if some nadas are contained in the list

### DIFF
--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -709,7 +709,10 @@ List.abs2 = function(a1) {
 };
 
 List.abs = function(a1) {
-    return CSNumber.sqrt(List.abs2(a1));
+    var anssquared = List.abs2(a1);
+    if (anssquared !== nada)
+        return CSNumber.sqrt(anssquared);
+    return nada;
 };
 
 


### PR DESCRIPTION
This PR fixes some exports from Cinderella where `abs` or `|v1,v2|` has been used on undefined arguments. This should not crash CindyJS!
The implemented behaviour (always return nada if some of the arguments contain some nada) is different from Cinderella, which ignores those entries of `v1` and `v2, which are either nada in `v1` or `v2`, ` when computing `|v1, v2|`.