### PR TITLE
Add delimiter modifier to format

### DIFF
--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -374,6 +374,12 @@ The modifier `delimiter` can be used to set decimal seperator.
     > format(1.23456, 2, delimiter->",")
     < "1,23"
 
+The modifier `truncate` can be used to prevent truncation of the output.
+
+    - only CindyJS: the `truncate` modifier is not available in Cinderella.
+    > format(1, 2, truncate->false)
+    < "1.00"
+
 Requesting more than 20 digits will never have any effect.
 
     > format(1/3, 20) == format(1/3, 40)

--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -368,6 +368,12 @@ If, however, it is a list, and somewhere nested inside that list is a value whic
     > format([2.339, "foo", [5.678, 1 < 2]], 2)
     < ["2.34", "foo", ["5.68", "true"]]
 
+The modifier `delimiter` can be used to set decimal seperator.
+
+    - only CindyJS: the `delimiter` modifier is not available in Cinderella.
+    > format(1.23456, 2, delimiter->",")
+    < "1,23"
+
 Requesting more than 20 digits will never have any effect.
 
     > format(1/3, 20) == format(1/3, 40)

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4327,7 +4327,11 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
             erg1 = erg;
             erg = erg.substring(0, erg.length - 1);
         } while (erg !== "" && erg !== "-" && +erg === +erg1);
-        return "" + erg1;
+        var tmp = "" + erg1;
+        if (modifs.delimiter && modifs.delimiter.ctype === "string") {
+            tmp = tmp.replace(".", modifs.delimiter.value);
+        }
+        return tmp;
     }
 
     function fmt(v) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4328,6 +4328,7 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
             truncate = modif.value;
     }
 
+
     function fmtNumber(n, trunc) {
         var erg = n.toFixed(dec),
             erg1;
@@ -4345,12 +4346,13 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
         return tmp;
     }
 
-    function fmt(v) {
+    function fmt(v, dec) {
         var r, i, erg;
         if (v.ctype === 'number') {
             r = fmtNumber(v.value.real, truncate);
             i = fmtNumber(v.value.imag, truncate);
-            if (v.value.imag === 0.0)
+            // check if we have imag part
+            if (Math.abs(v.value.imag) < Math.pow(10, -dec))
                 erg = r;
             else if (i.substring(0, 1) === "-")
                 erg = r + " - i*" + i.substring(1);
@@ -4374,7 +4376,7 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     }
     if ((v0.ctype === 'number' || v0.ctype === 'list') && v1.ctype === 'number') {
         dec = Math.max(0, Math.min(20, Math.round(v1.value.real)));
-        return fmt(v0);
+        return fmt(v0, dec);
     }
     return nada;
 };

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4320,14 +4320,25 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     var v1 = evaluateAndVal(args[1]);
     var dec;
 
-    function fmtNumber(n) {
+    // check if we want to truncate - do so by default
+    var truncate = true;
+    if (modifs.truncate) {
+        var modif = evaluate(modifs.truncate);
+        if (modif.ctype === "boolean")
+            truncate = modif.value;
+    }
+
+    function fmtNumber(n, trunc) {
         var erg = n.toFixed(dec),
             erg1;
+
         do {
             erg1 = erg;
             erg = erg.substring(0, erg.length - 1);
-        } while (erg !== "" && erg !== "-" && +erg === +erg1);
+        } while (trunc && erg !== "" && erg !== "-" && +erg === +erg1);
+
         var tmp = "" + erg1;
+        // switch delimiter if needed
         if (modifs.delimiter && modifs.delimiter.ctype === "string") {
             tmp = tmp.replace(".", modifs.delimiter.value);
         }
@@ -4337,9 +4348,9 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     function fmt(v) {
         var r, i, erg;
         if (v.ctype === 'number') {
-            r = fmtNumber(v.value.real);
-            i = fmtNumber(v.value.imag);
-            if (i === "0")
+            r = fmtNumber(v.value.real, truncate);
+            i = fmtNumber(v.value.imag, truncate);
+            if (v.value.imag === 0.0)
                 erg = r;
             else if (i.substring(0, 1) === "-")
                 erg = r + " - i*" + i.substring(1);

--- a/tests/Operators_tests.js
+++ b/tests/Operators_tests.js
@@ -1,0 +1,30 @@
+var should = require("chai").should();
+var rewire = require("rewire");
+
+global.navigator = {};
+var CindyJS = require("../build/js/Cindy.plain.js");
+
+var cdy = CindyJS({
+            isNode: true,
+            csconsole: null,
+            geometry: [
+            ],
+        });
+
+function itCmd(command, expected) {
+    it(command, function() {
+        String(cdy.niceprint(cdy.evalcs(command))).should.equal(expected);
+    });
+}
+
+describe("Operators: format", function(){
+    itCmd('format(1.23456, 0)', '1');
+    itCmd('format(1.23456, 1)', '1.2');
+
+    itCmd('format(1.23456, -1)', '1');
+
+    // modifiers
+    itCmd('format(1.23456, 2, delimiter->",")', '1,23');
+    itCmd('format(exp(2*pi*i), 2, delimiter->",", truncate->false)', '1,00');
+    itCmd('format(exp(2*pi*i), 2, delimiter->",", truncate->true)', '1');
+});


### PR DESCRIPTION
This PR adds a modifier to `format` to set the delimiter. This should resolve #715.

For example:
```
    > format(1.23456, 2, delimiter->",")
    < "1,23"
```