### PR TITLE
Point on conic

### DIFF
--- a/examples/157_PointOnConic.html
+++ b/examples/157_PointOnConic.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Point on Conic</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script type="text/javascript">
+
+var cdy = CindyJS({
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 335,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -4.06]}],
+    grid: 1.0
+  }],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+  },
+  geometry: [
+    {name: "A", type: "Free", pos: [3.414634146341464, -4.0, -1.2195121951219514], color: [1.0, 0.0, 0.0], labeled: false},
+    {name: "B", type: "Free", pos: [-3.52, -1.92, 4.0], color: [1.0, 0.0, 0.0], labeled: false},
+    {name: "C", type: "Free", pos: [4.0, -0.7213114754098361, 0.5464480874316939], color: [1.0, 0.0, 0.0], labeled: false},
+    {name: "D", type: "Free", pos: [4.0, 1.2355212355212357, 0.3861003861003861], color: [1.0, 0.0, 0.0], labeled: false},
+    {name: "E", type: "Free", pos: [4.0, 1.2686084142394822, 0.32362459546925565], color: [1.0, 0.0, 0.0], labeled: false},
+    {name: "C0", type: "ConicBy5", color: [0.0, 0.0, 1.0], args: ["A", "B", "C", "D", "E"], printname: "$C_{0}$"},
+    {name: "F", type: "PointOnConic", pos: [4.0, 0.9629575165087866, 0.7169297989808624], color: [1.0, 1.0, 0.0], args: ["C0"], labeled: false}
+  ]
+});
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+</body>
+
+</html>

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -1061,6 +1061,10 @@ List.projectiveDistMinScal = function(a, b) {
 
 };
 
+List.euclideanDist = function(a, b) {
+    return List.abs(List.sub(List.normalizeZ(a), List.normalizeZ(b))).value.real;
+};
+
 function conicMat2Vec(m) {
     var v = m.value;
     var r0 = v[0].value;

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -1061,10 +1061,6 @@ List.projectiveDistMinScal = function(a, b) {
 
 };
 
-List.euclideanDist = function(a, b) {
-    return List.abs(List.sub(List.normalizeZ(a), List.normalizeZ(b))).value.real;
-};
-
 function conicMat2Vec(m) {
     var v = m.value;
     var r0 = v[0].value;

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -547,6 +547,7 @@ geoOps.PointOnConic.updatePosition = function(el, isMover) {
     el.homog = General.withUsage(pos, "Point");
     geoOps.PointOnConic.putFarpoint(el, pos);
 };
+geoOps.PointOnConic.getRandomMove = geoOps._helper.getRandPointMove;
 geoOps.PointOnConic.stateSize = 12;
 
 geoOps.PointOnCircle = {};

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -480,7 +480,7 @@ geoOps.PointOnConic.kind = "P";
 geoOps.PointOnConic.signature = ["C"];
 geoOps.PointOnConic.isMovable = true;
 geoOps.PointOnConic.initialize = function(el) {
-    var pos = List.normalizeZ(geoOps._helper.initializePoint(el));
+    var pos = geoOps._helper.initializePoint(el);
     putStateComplexVector(pos);
     geoOps.PointOnConic.putFarpoint(el, pos);
 };
@@ -495,7 +495,9 @@ geoOps.PointOnConic.putFarpoint = function(el, pos) {
 geoOps.PointOnConic.getParamForInput = function(el, pos, type) {
     var m = csgeo.csnames[(el.args[0])].matrix;
     var farpoint = getStateComplexVector(3);
-    var candidates, res = List.realVector([0, 0, 0]), dist = Infinity, d, i;
+    var candidates, res = List.realVector([0, 0, 0]),
+        dist = Infinity,
+        d, i;
     if (type === "mouse") {
         // Orthogonal projection to conic (Euclidean, non-homogeneous!)
         // We want to solve [fundDual*m*q, q, pos] = 0 for q
@@ -507,7 +509,7 @@ geoOps.PointOnConic.getParamForInput = function(el, pos, type) {
         for (i = 0; i < 4; ++i) {
             if (!List._helper.isAlmostReal(candidates[i]))
                 continue;
-            d = List.euclideanDist(pos, candidates[i]);
+            d = List.projectiveDistMinScal(pos, candidates[i]);
             if (d < dist) {
                 dist = d;
                 res = candidates[i];
@@ -516,16 +518,13 @@ geoOps.PointOnConic.getParamForInput = function(el, pos, type) {
         return res;
     } else if (type === "update" || true) { // Don't have a different implementation yet
         var conic = csgeo.csnames[el.args[0]];
-        var mid = List.normalizeZ(geoOps._helper.CenterOfConic(conic.matrix));
+        var mid = geoOps._helper.CenterOfConic(conic.matrix);
         var direction = List.cross(mid, farpoint);
         candidates = geoOps._helper.IntersectLC(direction, conic.matrix);
         for (i = 0; i < 2; ++i) {
-            candidates[i] = List.normalizeZ(candidates[i]);
-        }
-        for (i = 0; i < 2; ++i) {
             //if (!List._helper.isAlmostReal(candidates[i]))
             //    continue;
-            d = List.euclideanDist(pos, candidates[i]);
+            d = List.projectiveDistMinScal(pos, candidates[i]);
             if (d < dist) {
                 dist = d;
                 res = candidates[i];

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -488,26 +488,9 @@ geoOps.PointOnConic.getParamForInput = function(el, pos, type) {
     if (type === "mouse" || true) { // Don't have a different implementation yet
         // Orthogonal projection to conic (Euclidean, non-homogeneous!)
         // We want to solve [fundDual*m*q, q, pos] = 0 for q
-        var a = m.value[0].value[0];
-        var b = m.value[0].value[1];
-        var c = m.value[0].value[2];
-        var d = m.value[1].value[1];
-        var e = m.value[1].value[2];
-        var f = m.value[2].value[2];
-        var x = pos.value[0];
-        var y = pos.value[1];
-        var z = pos.value[2];
-        var add = CSNumber.add;
-        var sub = CSNumber.sub;
-        var rm = CSNumber.realmult;
-        var mul = CSNumber.mult;
-        var neg = CSNumber.neg;
-        var zero = CSNumber.zero;
-        var n = List.matrix([
-            [neg(mul(b, z)), mul(sub(a, d), z), sub(mul(b, x), mul(a, y))],
-            [zero, mul(b, z), sub(mul(d, x), mul(b, y))],
-            [neg(mul(e, z)), mul(c, z), sub(mul(e, x), mul(c, y))]
-        ]);
+        var n = List.productMM(
+            List.crossOperator(pos),
+            List.productMM(List.fundDual, m));
         n = List.normalizeMax(List.add(List.transpose(n), n));
         var candidates = geoOps._helper.IntersectConicConic(m, n);
         var res = List.realVector([0, 0, 0]);


### PR DESCRIPTION
Due high demand (#700 and some visualizations for mathe-vital.de), we should have a working version of PointOnConic. However, tracing this geometric operation is difficult (also compare with the long mail from @gagern at 04.11.16 in our mailing list).

So I am giving a working implementation as a mixture of 
* project to nearest PointOnConic by @gagern. This implementation will only used if the point itself is moved. His comments on his code:
> This works reasonably well for moving the point with the mouse.  The combination of orthogonal projection and Euclidean distance, discarding complex points of intersection, will lead to a very intuitive placement of the point at the nearest position on the conic.  This completely fails to work if the conic moves from under the point, though, as the point will become complex in this situation.
* and the approach that is used in Cinderella, where the center of the conic is connected with the point on the conic and the farpoint of the direction is traced. This implementation will be used if the conic under the point is moved.

As this is my first implementation of a geometric operation, please review it carefully!