### PR TITLE
Format locale

### DIFF
--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -374,6 +374,12 @@ The modifier `delimiter` can be used to set decimal seperator.
     > format(1.23456, 2, delimiter->",")
     < "1,23"
 
+The modifier `truncate` can be used to prevent truncation of the output.
+
+    - only CindyJS: the `truncate` modifier is not available in Cinderella.
+    > format(1, 2, truncate->false)
+    < "1.00"
+
 Requesting more than 20 digits will never have any effect.
 
     > format(1/3, 20) == format(1/3, 40)

--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -368,6 +368,12 @@ If, however, it is a list, and somewhere nested inside that list is a value whic
     > format([2.339, "foo", [5.678, 1 < 2]], 2)
     < ["2.34", "foo", ["5.68", "true"]]
 
+The modifier `delimiter` can be used to set decimal seperator.
+
+    - only CindyJS: the `delimiter` modifier is not available in Cinderella.
+    > format(1.23456, 2, delimiter->",")
+    < "1,23"
+
 Requesting more than 20 digits will never have any effect.
 
     > format(1/3, 20) == format(1/3, 40)

--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -368,7 +368,10 @@ If, however, it is a list, and somewhere nested inside that list is a value whic
     > format([2.339, "foo", [5.678, 1 < 2]], 2)
     < ["2.34", "foo", ["5.68", "true"]]
 
-The modifier `locale` can be used specify localication. The default is `en-US`, for German use `de-DE`.
+The modifier `locale` can be used specify localisation. The default is `en`, for German use `de`. If instantiation language is set then this will be the default setting.
+
+    > format(1.23456, 2, locale->"de")
+    < "1,23"
 
 The modifier `truncate` can be used to prevent truncation of the output.
 

--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -368,7 +368,7 @@ If, however, it is a list, and somewhere nested inside that list is a value whic
     > format([2.339, "foo", [5.678, 1 < 2]], 2)
     < ["2.34", "foo", ["5.68", "true"]]
 
-The modifier `locale` can be used specify localisation. The default is `en`, for German use `de`. If instantiation language is set then this will be the default setting.
+The modifier `locale` can be used specify localisation. The default is `en`, for German use `de`. If instantiation language is set then this will be the default setting. For possible values look up the `Intl` object of the ECMAScript Internationalization API.
 
     > format(1.23456, 2, locale->"de")
     < "1,23"

--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -370,10 +370,6 @@ If, however, it is a list, and somewhere nested inside that list is a value whic
 
 The modifier `locale` can be used specify localication. The default is `en-US`, for German use `de-DE`.
 
-    - only CindyJS: the `locale` modifier is not available in Cinderella.
-    > format(1.23456, 2, locale->"de-DE")
-    < "1,23"
-
 The modifier `truncate` can be used to prevent truncation of the output.
 
     - only CindyJS: the `truncate` modifier is not available in Cinderella.

--- a/ref/String_Operators.md
+++ b/ref/String_Operators.md
@@ -368,10 +368,10 @@ If, however, it is a list, and somewhere nested inside that list is a value whic
     > format([2.339, "foo", [5.678, 1 < 2]], 2)
     < ["2.34", "foo", ["5.68", "true"]]
 
-The modifier `delimiter` can be used to set decimal seperator.
+The modifier `locale` can be used specify localication. The default is `en-US`, for German use `de-DE`.
 
-    - only CindyJS: the `delimiter` modifier is not available in Cinderella.
-    > format(1.23456, 2, delimiter->",")
+    - only CindyJS: the `locale` modifier is not available in Cinderella.
+    > format(1.23456, 2, locale->"de-DE")
     < "1,23"
 
 The modifier `truncate` can be used to prevent truncation of the output.

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4327,7 +4327,11 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
             erg1 = erg;
             erg = erg.substring(0, erg.length - 1);
         } while (erg !== "" && erg !== "-" && +erg === +erg1);
-        return "" + erg1;
+        var tmp = "" + erg1;
+        if (modifs.delimiter && modifs.delimiter.ctype === "string") {
+            tmp = tmp.replace(".", modifs.delimiter.value);
+        }
+        return tmp;
     }
 
     function fmt(v) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4328,6 +4328,7 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
             truncate = modif.value;
     }
 
+
     function fmtNumber(n, trunc) {
         var erg = n.toFixed(dec),
             erg1;
@@ -4345,12 +4346,13 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
         return tmp;
     }
 
-    function fmt(v) {
+    function fmt(v, dec) {
         var r, i, erg;
         if (v.ctype === 'number') {
             r = fmtNumber(v.value.real, truncate);
             i = fmtNumber(v.value.imag, truncate);
-            if (v.value.imag === 0.0)
+            // check if we have imag part
+            if (Math.abs(v.value.imag) < Math.pow(10, -dec))
                 erg = r;
             else if (i.substring(0, 1) === "-")
                 erg = r + " - i*" + i.substring(1);
@@ -4374,7 +4376,7 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     }
     if ((v0.ctype === 'number' || v0.ctype === 'list') && v1.ctype === 'number') {
         dec = Math.max(0, Math.min(20, Math.round(v1.value.real)));
-        return fmt(v0);
+        return fmt(v0, dec);
     }
     return nada;
 };

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4319,6 +4319,7 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     var v0 = evaluateAndVal(args[0]);
     var v1 = evaluateAndVal(args[1]);
     var dec;
+    var options = {};
 
     // check if we want to truncate - do so by default
     var truncate = true;
@@ -4328,31 +4329,20 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
             truncate = modif.value;
     }
 
+    // default locale to en-US
+    var locale = modifs.locale && modifs.locale.ctype === "string" ? modifs.locale.value : "en-US";
 
-    function fmtNumber(n, trunc) {
-        var erg = n.toFixed(dec),
-            erg1;
-
-        do {
-            erg1 = erg;
-            erg = erg.substring(0, erg.length - 1);
-        } while (trunc && erg !== "" && erg !== "-" && +erg === +erg1);
-
-        var tmp = "" + erg1;
-        // switch delimiter if needed
-        if (modifs.delimiter && modifs.delimiter.ctype === "string") {
-            tmp = tmp.replace(".", modifs.delimiter.value);
-        }
-        return tmp;
+    function fmtNumber(n) {
+        return n.toLocaleString(locale, options);
     }
 
-    function fmt(v, dec) {
+    function fmt(v) {
         var r, i, erg;
         if (v.ctype === 'number') {
-            r = fmtNumber(v.value.real, truncate);
-            i = fmtNumber(v.value.imag, truncate);
+            r = fmtNumber(v.value.real);
+            i = fmtNumber(v.value.imag);
             // check if we have imag part
-            if (Math.abs(v.value.imag) < Math.pow(10, -dec))
+            if (Math.abs(v.value.imag) < Math.pow(10, -options.maximumFractionDigits))
                 erg = r;
             else if (i.substring(0, 1) === "-")
                 erg = r + " - i*" + i.substring(1);
@@ -4376,7 +4366,13 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     }
     if ((v0.ctype === 'number' || v0.ctype === 'list') && v1.ctype === 'number') {
         dec = Math.max(0, Math.min(20, Math.round(v1.value.real)));
-        return fmt(v0, dec);
+        // generate locale options
+        options = {
+            "minimumFractionDigits": truncate ? 0 : dec,
+            "maximumFractionDigits": dec,
+            "useGrouping": false
+        };
+        return fmt(v0, options);
     }
     return nada;
 };

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4320,14 +4320,25 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     var v1 = evaluateAndVal(args[1]);
     var dec;
 
-    function fmtNumber(n) {
+    // check if we want to truncate - do so by default
+    var truncate = true;
+    if (modifs.truncate) {
+        var modif = evaluate(modifs.truncate);
+        if (modif.ctype === "boolean")
+            truncate = modif.value;
+    }
+
+    function fmtNumber(n, trunc) {
         var erg = n.toFixed(dec),
             erg1;
+
         do {
             erg1 = erg;
             erg = erg.substring(0, erg.length - 1);
-        } while (erg !== "" && erg !== "-" && +erg === +erg1);
+        } while (trunc && erg !== "" && erg !== "-" && +erg === +erg1);
+
         var tmp = "" + erg1;
+        // switch delimiter if needed
         if (modifs.delimiter && modifs.delimiter.ctype === "string") {
             tmp = tmp.replace(".", modifs.delimiter.value);
         }
@@ -4337,9 +4348,9 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     function fmt(v) {
         var r, i, erg;
         if (v.ctype === 'number') {
-            r = fmtNumber(v.value.real);
-            i = fmtNumber(v.value.imag);
-            if (i === "0")
+            r = fmtNumber(v.value.real, truncate);
+            i = fmtNumber(v.value.imag, truncate);
+            if (v.value.imag === 0.0)
                 erg = r;
             else if (i.substring(0, 1) === "-")
                 erg = r + " - i*" + i.substring(1);

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4319,7 +4319,6 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     var v0 = evaluateAndVal(args[0]);
     var v1 = evaluateAndVal(args[1]);
     var dec;
-    var options = {};
 
     // check if we want to truncate - do so by default
     var truncate = true;
@@ -4332,15 +4331,11 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     // default locale to en-US
     var locale = modifs.locale && modifs.locale.ctype === "string" ? modifs.locale.value : "en-US";
 
-    function fmtNumber(n) {
-        return n.toLocaleString(locale, options);
-    }
-
-    function fmt(v) {
+    function fmt(v, locale, options) {
         var r, i, erg;
         if (v.ctype === 'number') {
-            r = fmtNumber(v.value.real);
-            i = fmtNumber(v.value.imag);
+            r = (v.value.real).toLocaleString(locale, options);
+            i = (v.value.imag).toLocaleString(locale, options);
             // check if we have imag part
             if (Math.abs(v.value.imag) < Math.pow(10, -options.maximumFractionDigits))
                 erg = r;
@@ -4356,7 +4351,7 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
         if (v.ctype === 'list') {
             return {
                 "ctype": "list",
-                "value": v.value.map(fmt)
+                "value": v.value.map(v => fmt(v, locale, options))
             };
         }
         return {
@@ -4367,12 +4362,12 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     if ((v0.ctype === 'number' || v0.ctype === 'list') && v1.ctype === 'number') {
         dec = Math.max(0, Math.min(20, Math.round(v1.value.real)));
         // generate locale options
-        options = {
+        var options = {
             "minimumFractionDigits": truncate ? 0 : dec,
             "maximumFractionDigits": dec,
             "useGrouping": false
         };
-        return fmt(v0, options);
+        return fmt(v0, locale, options);
     }
     return nada;
 };

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4329,7 +4329,8 @@ evaluator.format$2 = function(args, modifs) { //TODO Angles
     }
 
     // default locale to en-US
-    var locale = modifs.locale && modifs.locale.ctype === "string" ? modifs.locale.value : "en-US";
+    var language = instanceInvocationArguments.language || "en";
+    var locale = modifs.locale && modifs.locale.ctype === "string" ? modifs.locale.value : language;
 
     function fmt(v, locale, options) {
         var r, i, erg;

--- a/tests/Operators_tests.js
+++ b/tests/Operators_tests.js
@@ -29,4 +29,8 @@ describe("Operators: format", function(){
     itCmd('format(exp(2*pi*i), 2, locale->"de", truncate->true)', '1');
     itCmd('format(1234567.89, 1, locale->"de")', '1234567,9');
     itCmd('format(123456.000, 2, truncate->false)', '123456.00');
+
+    // fancy stuff
+    itCmd('format(123456.789, 3, locale->"zh-Hans-CN-u-nu-hanidec")', '一二三四五六.七八九');
+    itCmd('format(123456.789, 3, locale->"ar")', '١٢٣٤٥٦٫٧٨٩');
 });

--- a/tests/Operators_tests.js
+++ b/tests/Operators_tests.js
@@ -1,0 +1,30 @@
+var should = require("chai").should();
+var rewire = require("rewire");
+
+global.navigator = {};
+var CindyJS = require("../build/js/Cindy.plain.js");
+
+var cdy = CindyJS({
+            isNode: true,
+            csconsole: null,
+            geometry: [
+            ],
+        });
+
+function itCmd(command, expected) {
+    it(command, function() {
+        String(cdy.niceprint(cdy.evalcs(command))).should.equal(expected);
+    });
+}
+
+describe("Operators: format", function(){
+    itCmd('format(1.23456, 0)', '1');
+    itCmd('format(1.23456, 1)', '1.2');
+
+    itCmd('format(1.23456, -1)', '1');
+
+    // modifiers
+    itCmd('format(1.23456, 2, delimiter->",")', '1,23');
+    itCmd('format(exp(2*pi*i), 2, delimiter->",", truncate->false)', '1,00');
+    itCmd('format(exp(2*pi*i), 2, delimiter->",", truncate->true)', '1');
+});

--- a/tests/Operators_tests.js
+++ b/tests/Operators_tests.js
@@ -7,8 +7,6 @@ var CindyJS = require("../build/js/Cindy.plain.js");
 var cdy = CindyJS({
             isNode: true,
             csconsole: null,
-            geometry: [
-            ],
         });
 
 function itCmd(command, expected) {
@@ -20,11 +18,15 @@ function itCmd(command, expected) {
 describe("Operators: format", function(){
     itCmd('format(1.23456, 0)', '1');
     itCmd('format(1.23456, 1)', '1.2');
-
+    itCmd('format(1234567.89, 1)', '1234567.9');
     itCmd('format(1.23456, -1)', '1');
 
+    itCmd('format(123456.000, 2)', '123456');
+
     // modifiers
-    itCmd('format(1.23456, 2, delimiter->",")', '1,23');
-    itCmd('format(exp(2*pi*i), 2, delimiter->",", truncate->false)', '1,00');
-    itCmd('format(exp(2*pi*i), 2, delimiter->",", truncate->true)', '1');
+    itCmd('format(1.23456, 2, locale->"de")', '1,23');
+    itCmd('format(exp(2*pi*i), 2, locale->"de", truncate->false)', '1,00');
+    itCmd('format(exp(2*pi*i), 2, locale->"de", truncate->true)', '1');
+    itCmd('format(1234567.89, 1, locale->"de")', '1234567,9');
+    itCmd('format(123456.000, 2, truncate->false)', '123456.00');
 });

--- a/tests/Operators_tests.js
+++ b/tests/Operators_tests.js
@@ -32,5 +32,5 @@ describe("Operators: format", function(){
 
     // fancy stuff
     itCmd('format(123456.789, 3, locale->"zh-Hans-CN-u-nu-hanidec")', '一二三四五六.七八九');
-    itCmd('format(123456.789, 3, locale->"ar")', '١٢٣٤٥٦٫٧٨٩');
+    itCmd('format(123456.789, 3, locale->"ar-EG")', '١٢٣٤٥٦٫٧٨٩');
 });


### PR DESCRIPTION
This is the draft for number localisation. We should have a debate on how the modifier should be called (@kortenkamp , @richter-gebert ?). Currently it's called `locale`.

Some examples:
```
    > number = 123456.789;
    > format(123456.789, 3, locale->"de");
    < 123456,789
    > format(123456.789, 3, locale->"zh-Hans-CN-u-nu-hanidec");
    < '一二三四五六.七八九'
    > format(123456.789, 3, locale->"ar-EG");
    > '١٢٣٤٥٦٫٧٨٩'
```