### PR TITLE
extends drawtext to draw text at any angle

### DIFF
--- a/examples/163_textAtAnyAngle.html
+++ b/examples/163_textAtAnyAngle.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>Cindy JS Example</title>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="../build/js/CindyJS.css">
+
+  <script type="text/javascript" src="../build/js/Cindy.js"></script>
+  <script id="csinit" type="text/x-cindyscript">
+    // Initialization code, executed once up front.
+  </script>
+
+  <script id="csdraw" type="text/x-cindyscript">
+  // Drawing code, executed whenever the canvas gets redrawn.
+
+  eps = 1e-4;
+  f(x) := 10/(0.2*x^2+1)*sin(x);
+  plot(f(#));
+
+  f1(x) := (f(x+eps)-f(x-eps))/(2*eps);
+  // f2(x) := (f1(x+eps)-f1(x-eps))/(2*eps);
+  // plot(f1(#), color->(0.18, 0.69, 0.4));
+  // plot(f2(#), color->(1,0,0));
+
+  N = 4;
+  x = 9*(-N..N)/N;
+
+  forall(x, #,
+    y = f(#);
+    angle = arctan( f1(#) );
+
+    // LaTex (KaTex)
+    drawtext( (#,y), "$("+format(#,2)+","+format(y,2)+")$", size->13, align->"mid", angle->angle);
+
+    // Normal Text
+    // drawtext( (#,y), "("+format(#,2)+","+format(y,2)+")", size->13, align->"mid", angle->angle);
+  );
+
+</script>
+  <script type="text/javascript">
+    var cdy = CindyJS({ // See ref/createCindy documentation for details.
+      ports: [{
+        id: "CSCanvas",
+        // axes:true,
+        grid: 1.0,
+        transform: [{
+          visibleRect: [-10, 10, 10, -10]
+        }],
+        width: 500,
+        height: 500
+      }],
+      scripts: "cs*",
+      language: "en",
+      defaultAppearance: {
+      },
+    });
+
+  </script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+</body>
+
+</html>

--- a/plugins/katex/src/js/katex-plugin.js
+++ b/plugins/katex/src/js/katex-plugin.js
@@ -152,7 +152,7 @@
 
     var firstMessage = true;
 
-    function katexRenderer(ctx, text, x, y, align, fontSize, lineHeight) {
+    function katexRenderer(ctx, text, x, y, align, fontSize, lineHeight, angle=0) {
         var key = fontSize + "," + lineHeight + ":" + text;
         var fontsMissing = false;
         var fontsToLoad = {};
@@ -237,7 +237,11 @@
                     total += row[j].width;
                 var pos = x - align * total;
                 for (j = 0; j < n; ++j) {
-                    row[j].renderAt(pos, y);
+                    ctx.save();
+                    ctx.translate(x, y);
+                    ctx.rotate(-angle);
+                    row[j].renderAt(-align*total, 0);
+                    ctx.restore();
                     if (left > pos) left = pos;
                     if (top > y - row[j].height) top = y - row[j].height;
                     if (bottom < y + row[j].depth) bottom = y + row[j].depth;

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -894,7 +894,7 @@ eval_helper.drawpolygon = function(args, modifs, df, cycle) {
 
 };
 
-function defaultTextRendererCanvas(ctx, text, x, y, align, size, lineHeight) {
+function defaultTextRendererCanvas(ctx, text, x, y, align, size, lineHeight, angle=0) {
     if (text.indexOf("\n") !== -1) {
         var left = Infinity;
         var right = -Infinity;
@@ -916,7 +916,11 @@ function defaultTextRendererCanvas(ctx, text, x, y, align, size, lineHeight) {
         };
     }
     var m = ctx.measureText(text);
-    ctx.fillText(text, x - m.width * align, y);
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(-angle);
+    ctx.fillText(text, - m.width * align, 0);
+    ctx.restore();
     // We can't rely on advanced text metrics due to lack of browser support,
     // so we have to guess sizes, the vertical ones in particular.
     return {
@@ -985,7 +989,7 @@ eval_helper.drawtext = function(args, modifs, callback) {
     } else {
         return textRendererCanvas(
             csctx, txt, xx, yy, Render2D.align,
-            size, size * defaultAppearance.lineHeight);
+            size, size * defaultAppearance.lineHeight, Render2D.angle);
     }
 };
 

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -23,6 +23,7 @@ Render2D.handleModifs = function(modifs, handlers) {
     Render2D.italics = "";
     Render2D.family = "sans-serif";
     Render2D.align = 0;
+    Render2D.angle = 0;
     Render2D.xOffset = 0;
     Render2D.yOffset = 0;
     Render2D.lineCap = "round";
@@ -261,6 +262,13 @@ Render2D.modifHandlers = {
         }
     },
 
+    "angle": function(v) {
+        if (v.ctype === "number") {
+            Render2D.angle = v.value.real;
+        }
+    },
+
+
     "x_offset": function(v) {
         if (v.ctype === "number")
             Render2D.xOffset = v.value.real;
@@ -362,6 +370,7 @@ Render2D.textModifs = {
     "italics": true,
     "family": true,
     "align": true,
+    "angle": true,
     "x_offset": true,
     "y_offset": true,
     "offset": true,


### PR DESCRIPTION
Hi,

CindyJS has been great for some of my PhD tasks but wanted to draw text at an angle, which is missing.

Implemented a primitive version of drawing text at any angle. Three of the tests fail saying "`ctx.translate is not a function`"; they seem to run fine when I manually check in a browser.

Please have a look.

Thanks,
Divahar
