### PR TITLE
JSON support

### DIFF
--- a/examples/json.html
+++ b/examples/json.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Cindy JS Example</title>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="../build/js/CindyJS.css">
+<script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+
+// Initialization code, executed once up front.
+
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+circ = circle(A,1);
+json1 =  
+ {
+    "test" : circ,
+    "undef" : undef,
+    "name":"John",
+    "age":30,
+    "bool": false,
+    "cars": [
+        { "name":"Ford", "models":[ "Fiesta", "Focus", "Mustang" ] },
+        { "name":"BMW", "models":[ "320", "X3", "X5" ] },
+        { "name":"Fiat", "models":[ "500", "Panda" ] }
+    ]
+};
+//json1.name = "Joe";
+//println(json1.name);
+//myvar = "name";
+//json1_myvar = "Bob";
+//println(json1_"blubbbb");
+//println(7 * {});
+//a=json1;
+//println((json1.cars_1).name);
+//println((json1.cars_1).models);
+
+//json2 = {"pt1": A, "pt2": B, "pt3" : C};
+//ptA = json2.pt1;
+//println(ptA.xy);
+//json2.pt1 = B;
+//println((json2.pt1).xy);
+//println("===");
+//println(7 * {1, 2});
+//println(keys(json1));
+//forall([1, 2, 3, 4, 5],#^2));
+//json3 = {"bla": 1, "blubb": 2, "lala": 10, "c" : "string" };
+//println(apply(json3, #^2));
+
+json3 = {"bla": 1, "blubb": 2, "lala": 10 };
+println(keys(json3));
+println(values(json3));
+A:"bla" = 5;
+println(keys(A));
+println(values(A));
+//println(select(json3, isOdd(#)));
+//json33 = forall(json3, println(json3_#));
+//println(json33);
+//cc = forall([1,2,3], println(#));
+//println(cc);
+//a=["this","is","a","list"];
+//forall(a,println(#))
+//forall(json3,iterator->"pair", println([#.key, #.value]));
+//forall(json3,iterator->"value", println(#));
+Jason = {"age":13};
+Jasonica = {"age":15};
+
+Jason.sister = Jasonica;
+Jasonica.brother = Jason;
+
+errc(Jason);
+
+json3 = {"a": 1, "b": 2, "c": 10, "d" : "string" };
+json4=apply(json3, v, k, k=k+1; v=v+2);
+print(json3, JSON->true);
+print(json3, JSON->false);
+print(json3);
+</script>
+<script type="text/javascript">
+
+var cdy = CindyJS({ // See ref/createCindy documentation for details.
+  ports: [{id: "CSCanvas", width: 500, height: 500}],
+  scripts: "cs*",
+  language: "en",
+  defaultAppearance: {
+    // See GeoBasics.js for possible attributes.
+  },
+  geometry: [
+    {name:"A", type:"Free", pos:[0,0]},
+    {name:"B", type:"Free", pos:[1,0]},
+    {name:"C", type:"Free", pos:[1,1]},
+    // For allowed types, see GeoOps.js.
+    // For allowed properties, see csinit in GeoBasics.js.
+  ] // End of geometry array.
+});
+
+// Remove all comments after adjusting this template for your use case.
+
+</script>
+</head>
+
+<body style="font-family:Arial;">
+  <div id="CSCanvas" style="border:2px solid black"></div>
+</body>
+
+</html>

--- a/examples/json.html
+++ b/examples/json.html
@@ -81,6 +81,11 @@ G_1 = 3; //works
 G_2 = 2; //works
 errc(G); //G ===> {1:3, 2:2}
 errc(G_1); //gives __
+println("====");
+forall({"a":2, "b":3}, x, iterator->"pair",
+      x.value=x.value^2;
+      print(x.value)
+);
 </script>
 <script type="text/javascript">
 

--- a/examples/json.html
+++ b/examples/json.html
@@ -76,6 +76,11 @@ json4=apply(json3, v, k, k=k+1; v=v+2);
 print(json3, JSON->true);
 print(json3, JSON->false);
 print(json3);
+G = {};
+G_1 = 3; //works
+G_2 = 2; //works
+errc(G); //G ===> {1:3, 2:2}
+errc(G_1); //gives __
 </script>
 <script type="text/javascript">
 

--- a/examples/json.html
+++ b/examples/json.html
@@ -86,6 +86,11 @@ forall({"a":2, "b":3}, x, iterator->"pair",
       x.value=x.value^2;
       print(x.value)
 );
+
+forall({"a":2, "b":3}, x, iterator->"pair",
+       x.value = x;
+      print(x)
+);
 </script>
 <script type="text/javascript">
 

--- a/make/sources.js
+++ b/make/sources.js
@@ -3,6 +3,7 @@
 exports.libcs = [
     "src/js/libcs/CSNumber.js",
     "src/js/libcs/List.js",
+    "src/js/libcs/Json.js",
     "src/js/libcs/Dict.js",
     "src/js/libcs/General.js",
     "src/js/libcs/Essentials.js",

--- a/ref/Dictionaries.md
+++ b/ref/Dictionaries.md
@@ -25,10 +25,10 @@ The expression `{"key1" : val, ...}` created a basic dictionary.
 ### Printing a dictionary
 
 **Description:**
-As usual the function `print` will output the object. This will generally be not a valid JSON object: therefore one can use the modifier `JSON`. The output then can be used by a JSON parser.
+As usual the function `print` will output the object. This will generally be not a valid JSON object, since CindyJS uses different data types than JavaScript.
 
-    > print({"a" : 1, "b" : false, "c": "mystring"}, JSON->true);
-    * {"a":1,"b":false,"c":"mystring"}
+    > print({"a" : 1, "b" : false, "c": "mystring"});
+    * {a:1, b:false, c:mystring}
 
 **Circular Dictionaries**
 Circular objects are allowed, but a printout will be shortened. The default recursion depth is 1000 but can be adjusted with the modifier `maxDepth`:

--- a/ref/Dictionaries.md
+++ b/ref/Dictionaries.md
@@ -205,6 +205,21 @@ The variable is local to the expression.
 
 ------
 
+
+### Deleting keys from a dictionary:
+
+A key-value pair can be deleted from a dictionary by setting its value to an undefined value.
+
+    > json = {"a":1, "b": 2};
+    > json.a = nada;
+    * Warning: Accessing undefined variable: nada
+    > forall(json, k, println(k));
+    * 2
+    > keys(json)
+    < ["b"]
+
+------
+
 # Deprecated `dict`
 
 This should not be used anymore.

--- a/ref/Dictionaries.md
+++ b/ref/Dictionaries.md
@@ -1,24 +1,213 @@
 # Dictionaries
 
-Dictrionaries are maps from keys to values.
-Like all other data structures in CindyJS, dictionaries are immutable.
-Modifying a dictionary does in fact create a new dictionary.
-Since dictionary keys have to be compared in full for dictionary lookups,
-users are advised against using large data structures as dictionary keys.
-The order of key-value pairs in a dictionary is implementation-defined.
+Dictrionaries are maps from keys to values. We designed the syntax closely to JSON. **Note that entries are are given by reference** (like geometric objects).
 
-**This is an experimental feature in its early stages of development.**
+###  Elementary Dictionary Operations
 
-All of the features described here are subject to changes without notice,
-i.e. may change even without a major version bump.
-If you want to avoid accidents, please inform the CindyJS development team
-of how you are using dictionaries, so that we can try to maintain compatibility
-for your use cases or inform you if things are likely to break soon.
+**Description:**
+Without arguments, this creates an empty dictionary.
 
-At this early stage, a lot of the functionality is only available through
-named functions but should become available through operator symbols, too.
-The named functions will probably remain as an alternative
-for the sake of compatibility and clarity.
+    > {}
+    < {}
+
+------
+
+### Creating a simple dictionary: `{"key" : val, ...}`
+
+**Description:**
+The expression `{"key1" : val, ...}` created a basic dictionary. 
+
+    > {"a" : 1, "b" : 2};
+    < {a:1, b:2}
+
+------
+
+### Printing a dictionary
+
+**Description:**
+As usual the function `print` will output the object. This will generally be not a valid JSON object: therefore one can use the modifier `JSON`. The output then can be used by a JSON parser.
+
+    > print({"a" : 1, "b" : false, "c": "mystring"}, JSON->true);
+    * {"a":1,"b":false,"c":"mystring"}
+
+**Circular Dictionaries**
+Circular objects are allowed, but a printout will be shortened. The default recursion depth is 1000 but can be adjusted with the modifier `maxDepth`:
+
+    > dic={"a" : 1}; dic.b = dic; print(dic, maxDepth->3);
+    * Warning: We visited a key-value pair very often or encountered a very deeply nested dictionary. Dictionary is probably cyclic. Output will be probably incomplete.
+    * {a:1, b:{a:1, b:{a:1, b:{a:..., b:...}}}}
+
+
+------
+
+### Accessing Elements of Lists: `‹dict›.name`
+
+**Description:**
+Basic (static) access is possible via the dot operator. The variable after the dot is **not** evaluated.
+
+    > json = {"a" : 1, "b" : 2};
+    > json.a
+    < 1
+
+------
+### Retrieving all keys and values of a dictionary: `keys(‹dict›)` and `values(‹dict›)`
+
+**Description:**
+To retrieve all keys or values of a dictionary as a list one can use `keys(‹dict›)` and `values(‹dict›)`
+
+
+    > json = {"a" : 1, "b" : 2};
+    > keys(json);
+    < ["a", "b"]
+    > values(json);
+    < [1, 2]
+
+------
+
+### Dynamically accessing Elements of Lists: `‹dict›_‹var›` and `take(‹dict›,‹var›)`
+
+**Description:**
+One can dynamically access the individual elements of a dict either with the infix operator `‹list›_‹var›` or the functional operator `take(‹list›,‹var›)`. The keys (`var`) can be of any printable type.
+
+
+    > json = {"a" : 1, "b" : 2};
+    > json_"a"
+    < 1
+    > take({"a" : 1, "b" : 2}, "b")
+    < 2
+
+------
+
+### Applying an expression: `apply(‹dict›,‹expr›)`
+
+**Description:**
+This operator generates a new list by applying the operation `‹expr›` to all elements of a dict (but not to the keys) and collecting the results.
+As usual, `#` is the run variable, which successively takes the value of each element in the list.
+
+    > apply({"a" : 1, "b" : 2}, #^2);
+    < {a:1, b:4}
+
+------
+
+### Applying an expression: `apply(‹dict›,‹var›,‹expr›)`
+
+**Description:**
+Similar to `apply(‹list›,‹expr›)`, but the run variable is now named `‹var›`.
+The variable is local to the expression.
+
+    > v = 123;
+    > apply({"a" : 1, "b" : 2}, v, v^2);
+    < {a:1, b:4}
+    > v
+    < 123
+
+------
+
+
+### Applying an expression: `apply(‹dict›,‹varVal›, ‹varKey›,‹expr›)`
+
+**Description:**
+Similar to `apply(‹list›,‹var›, ‹expr›)`, but with two running variables: `‹varVal›` for the value and `‹varVal›` for the key.
+The variables are local to the expression.
+
+    > apply({"a" : 1, "b" : 2}, v, k, k+v);
+    < {a:a1, b:b2}
+
+------
+
+### Selecting elements of a list: `select(‹list›,‹boolexpr›)`
+
+**Description:**
+This operator selects all elements of a dict for which a certain condition is satisfied.
+The condition is supposed to be encoded by `‹boolexpr›`.
+This expression is assumed to return a `‹bool›` value.
+As usual, `#` is the run variable, which successively take the value of all elements in the list.
+
+    > select({"a" : 5, "b" : 2}, isodd(#));
+    < {a:5}
+
+------
+
+### Selecting elements of a list: `select(‹list›,‹var›,‹boolexpr›)`
+
+**Description:**
+Similar to `select(‹dict›,‹boolexpr›)`, but the run variable is now named ‹var›.
+The variable is local to the expression.
+
+    > v = 123;
+    > select({"a" : 5, "b" : 2}, v, isodd(v))
+    < {a:5}
+    > v
+    < 123
+
+------
+
+### The forall loop: `forall(‹dict›,‹expr›)`
+
+**Description:**
+This operator is useful for applying an operation to all elements of a dict.
+It takes a `‹dict›` as first argument.
+It produces a loop in which `‹expr›` is evaluated for each **value** of the list.
+For each run, the run variable `#` takes the value of the corresponding list value.
+
+**Example:**
+
+    > a={"a" : 5, "b" : 2};
+    > forall(a,println(#))
+
+This code fragment produces the output
+
+    * 5
+    * 2
+
+**Modifiers** 
+
+forall supports the modifier `iterator` that changes the behavior of the running variable: "value" iterates of the dictionary values (the default), "key" iterates over the dictionary keys and "pair" returns an elementary dictionary element that key and value can be accessed using the ".key" and ".value property".
+
+**Example iterator key:**
+
+    > a={"a" : 5, "b" : 2};
+    > forall(a,println(#), iterator->"key")
+
+This code fragment produces the output
+
+    * a
+    * b
+
+
+**Example iterator pair:**
+
+    > a={"a" : 5, "b" : 2};
+    > forall(a,println([#.key, #.value]), iterator->"pair")
+
+This code fragment produces the output
+
+    * [a, 5]
+    * [b, 2]
+
+------
+
+### The forall loop: `forall(‹dict›,‹var›,‹expr›)`
+
+**Description:**
+Similar to `forall(‹dict›,‹expr›)`, but the run variable is now named `‹var›`.
+The variable is local to the expression.
+
+    > v=994;
+    > k=123;
+    > forall({"a" : 5, "b" : 2},v,println(v))
+    * 5
+    * 2
+    > v
+    < 994
+    > k
+    < 123
+
+------
+
+# Deprecated `dict`
+
+This should not be used anymore.
 
 ## Creating a new: `dict()`
 

--- a/ref/Language.md
+++ b/ref/Language.md
@@ -493,17 +493,21 @@ These always denote a list, even if they contain exactly one expression.
 
 #### Curly braces `{…}`
 
-Curly braces are reserved for future applications.
+Curly braces denote JSON objects. JavaScript Object Notation (JSON) is a text format for the serialization of structured data. Please see RFC 4627 for a detailed documentation. CindyScript (currently) only allows strings as keys, but this might change in the future.
 
     - CindyScript >=3.0
     > 7 * {1 + 2}
-    ! CindyScriptParseError: {…} reserved for future use at 1:4
+    * Error: JSON keys have to be strings.
     > 7 * {1, 2}
-    ! CindyScriptParseError: {…} reserved for future use at 1:4
+    * Error: JSON keys have to be strings.
+    * Error: JSON keys have to be strings.
+    < ___
+    > 7 * {"key" : 1 }
+    < ___
     > 7 * {}
-    ! CindyScriptParseError: {…} reserved for future use at 1:4
+    < ___
     > sin{30°}
-    ! CindyScriptParseError: {…} reserved for future use at 1:3
+    ! CindyScriptParseError: {…} not yet defined for operators. at 1:3
 
 #### Function invocation
 

--- a/ref/js/runtests.js
+++ b/ref/js/runtests.js
@@ -225,6 +225,10 @@ function sanityCheck(val) {
     if (typeof val.value !== "object")
       throw Error("not a dict object");
     break;
+  case "JSON":
+    if (typeof val.value !== "object")
+      throw Error("not a JSON object");
+    break;
   case "undefined":
     break;
   case "geo":

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -341,7 +341,7 @@ Accessor.setField = function(geo, field, value) {
 
 Accessor.getuserData = function(obj, key) {
     var val;
-    if (obj.userData && obj.userData[key]) val = obj.userData[key];
+    if (key.ctype === "string" && obj.userData && obj.userData[key.value]) val = obj.userData[key.value];
 
     if (val && val.ctype) {
         return val;
@@ -353,6 +353,9 @@ Accessor.getuserData = function(obj, key) {
 };
 
 Accessor.setuserData = function(obj, key, value) {
+    if (!(key && key.ctype === "string" && obj && value)) {
+        return;
+    }
     if (!obj.userData) obj.userData = {};
-    obj.userData[key] = value;
+    obj.userData[key.value] = value;
 };

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -63,7 +63,7 @@ function operator_not_implemented(name) {
 // this function is responsible for evaluation an expression tree
 //****************************************************************
 
-function niceprint(a) {
+function niceprint(a, modifs) {
     if (typeof a === 'undefined') {
         return '_??_';
     }
@@ -92,6 +92,17 @@ function niceprint(a) {
 
         }
         return erg + "]";
+    }
+    if (a.ctype === 'JSONAtom') {
+        return Json.Atomniceprint(a);
+    }
+    if (a.ctype === 'JSON') {
+        // try catch to avoid bad situations with cyclic dicts
+        try {
+            return Json.niceprint(a, modifs);
+        } catch (e) {
+            return Json._helper.handlePrintException(e);
+        }
     }
     if (a.ctype === 'dict') {
         return Dict.niceprint(a);

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -94,7 +94,11 @@ function niceprint(a, modifs) {
         return erg + "]";
     }
     if (a.ctype === 'JSON' && a.isJSONAtom) {
-        return Json.Atomniceprint(a);
+        try {
+            return Json.Atomniceprint(a);
+        } catch (e) {
+            return Json._helper.handlePrintException(e);
+        }
     }
     if (a.ctype === 'JSON') {
         // try catch to avoid bad situations with cyclic dicts

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -139,6 +139,7 @@ function niceprint(a, modifs) {
     return "_?_";
 
 }
+niceprint.errorTypes = ['_?_', '_??_', '_???_', '___'];
 
 
 //TODO Eventuell auslagern

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -93,7 +93,7 @@ function niceprint(a, modifs) {
         }
         return erg + "]";
     }
-    if (a.ctype === 'JSONAtom') {
+    if (a.ctype === 'JSON' && a.isJSONAtom) {
         return Json.Atomniceprint(a);
     }
     if (a.ctype === 'JSON') {

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -93,13 +93,6 @@ function niceprint(a, modifs) {
         }
         return erg + "]";
     }
-    if (a.ctype === 'JSON' && a.isJSONAtom) {
-        try {
-            return Json.Atomniceprint(a);
-        } catch (e) {
-            return Json._helper.handlePrintException(e);
-        }
-    }
     if (a.ctype === 'JSON') {
         // try catch to avoid bad situations with cyclic dicts
         try {

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -29,12 +29,23 @@ function evaluate(a) {
         if (obj.ctype === "list") {
             return List.getField(obj, a.key);
         }
+        if (obj.ctype === "JSONAtom") {
+            if (a.key === "key") {
+                return General.string(obj.value.key);
+            }
+            if (a.key === "value") {
+                return obj.value.value;
+            }
+        }
+        if (obj.ctype === "JSON") {
+            return Json.getField(obj, a.key);
+        }
         return nada;
     }
     if (a.ctype === 'userdata') {
         var uobj = evaluate(a.obj);
-        var key = niceprint(evaluate(a.key));
-        if (key === "_?_") key = undefined;
+        var key = General.string(niceprint(evaluate(a.key)));
+        if (key.value === "_?_") key = nada;
 
         if (uobj.ctype === "geo") {
             return Accessor.getuserData(uobj.value, key);

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -29,14 +29,6 @@ function evaluate(a) {
         if (obj.ctype === "list") {
             return List.getField(obj, a.key);
         }
-        if (obj.ctype === "JSON" && obj.isJSONAtom) {
-            if (a.key === "key") {
-                return General.string(obj.value.key);
-            }
-            if (a.key === "value") {
-                return obj.value.value;
-            }
-        }
         if (obj.ctype === "JSON") {
             return Json.getField(obj, a.key);
         }

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -29,7 +29,7 @@ function evaluate(a) {
         if (obj.ctype === "list") {
             return List.getField(obj, a.key);
         }
-        if (obj.ctype === "JSONAtom") {
+        if (obj.ctype === "JSON" && obj.isJSONAtom) {
             if (a.key === "key") {
                 return General.string(obj.value.key);
             }

--- a/src/js/libcs/General.js
+++ b/src/js/libcs/General.js
@@ -287,13 +287,3 @@ General.deeplyEqual = function(a, b) {
         --cnt;
     return cnt === 0;
 };
-
-General.DeepCloneJSON = function(o) {
-    var out, v, key;
-    out = Array.isArray(o) ? [] : {};
-    for (key in o) {
-        v = o[key];
-        out[key] = (typeof v === "object" && v !== null) ? General.DeepCloneJSON(v) : v;
-    }
-    return out;
-};

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -28,7 +28,11 @@ Json.getField = function(obj, key) {
 };
 
 Json.setField = function(where, field, what) {
-    where[field] = what;
+    if (what.ctype === 'undefined' && where[field]) {
+        delete where[field];
+    } else {
+        where[field] = what;
+    }
 };
 
 Json.GenFromUserDataEl = function(el) {

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -65,9 +65,8 @@ Json.GenFromUserDataEl = function(el) {
 Json._helper.GenJSONAtom = function(key, val) {
     return {
         "ctype": "JSON",
-        "isJSONAtom": true,
         "value": {
-            'key': key,
+            'key': General.string(key),
             'value': val
         }
     };

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -100,35 +100,12 @@ Json._helper.niceprint = function(a, modifs, options) {
         return Json.niceprint(a, modifs, options);
     }
 
-    if (options.printValidJSON) {
-        if (a.ctype === "number" && a.value.imag === 0) {
-            return a.value.real;
-        }
-        if ("boolean" === a.ctype) {
-            return a.value;
-        }
-        if (a.ctype === 'list') {
-            var erg = "[";
-            for (var i = 0; i < a.value.length; i++) {
-                erg = erg + Json._helper.niceprint(evaluate(a.value[i]), modifs, options);
-                if (i !== a.value.length - 1) {
-                    erg = erg + ', ';
-                }
-
-            }
-            return erg + "]";
-        }
-
-        return "\"" + String(niceprint(a)) + "\"";
-    }
-
     return niceprint(a);
 };
 
 Json.niceprint = function(el, modifs, options) {
     if (!options) {
         options = {};
-        options.printValidJSON = false;
         options.printedWarning = false;
         // track depth
         options.visitedMap = {};
@@ -138,10 +115,6 @@ Json.niceprint = function(el, modifs, options) {
         options.visitedMap.maxElVisit = 5000;
 
         if (modifs) {
-            if (modifs.JSON) {
-                let jmodif = evaluate(modifs.JSON);
-                if (jmodif.ctype === "boolean") options.printValidJSON = jmodif.value;
-            }
             if (modifs.maxDepth) {
                 let depth = evaluate(modifs.maxDepth);
                 if (depth.ctype === "number") options.visitedMap.maxLevel = depth.value.real;
@@ -167,11 +140,8 @@ Json.niceprint = function(el, modifs, options) {
                     console.log("Warning: We visited a key-value pair very often or encountered a very deeply nested dictionary. Dictionary is probably cyclic. Output will be probably incomplete.");
                     options.printedWarning = true;
                 }
-                if (options.printValidJSON) {
-                    return "\"" + key + "\"" + ":" + '"..."';
-                } else {
-                    return key + ":" + '...';
-                }
+
+                return key + ":" + '...';
             }
             // update only once a recursive call
             if (visitedMap.newLevel) {
@@ -180,22 +150,9 @@ Json.niceprint = function(el, modifs, options) {
                 visitedMap.newLevel = false;
             }
         }
-        if (options.printValidJSON) {
-            return "\"" + key + "\"" + ":" + Json._helper.niceprint(elValKey, modifs, options);
-        } else {
-            return key + ":" + Json._helper.niceprint(elValKey, modifs, options);
-        }
+        return key + ":" + Json._helper.niceprint(elValKey, modifs, options);
     }).join(", ") + "}";
 
-
-    // pretty print 
-    if (options.printValidJSON) {
-        try {
-            jsonString = JSON.stringify(JSON.parse(jsonString), null, 0);
-        } catch (e) {
-            console.log("Could not parse JSON string.");
-        }
-    }
 
     return jsonString;
 };

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -20,16 +20,6 @@ Json._helper.ShallowClone = function(o) {
     return out;
 };
 
-Json._helper.DeepClone = function(o) {
-    var out, v, key;
-    out = Array.isArray(o) ? [] : {};
-    for (key in o) {
-        v = o[key];
-        out[key] = (typeof v === "object" && v !== null) ? Json._helper.DeepClone(v) : v;
-    }
-    return out;
-};
-
 Json.getField = function(obj, key) {
     if (obj.value && obj.value[key]) {
         return obj.value[key];
@@ -133,10 +123,6 @@ Json._helper.niceprint = function(a, modifs, options) {
     }
 
     return niceprint(a);
-};
-
-Json.Atomniceprint = function(el) {
-    return "\{" + el.value.key + ":" + niceprint(el.value.value) + "\}";
 };
 
 Json.niceprint = function(el, modifs, options) {

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -120,7 +120,7 @@ Json._helper.niceprint = function(a, modifs, options) {
         if (a.ctype === 'list') {
             var erg = "[";
             for (var i = 0; i < a.value.length; i++) {
-                erg = erg + Json._helper.niceprint(evaluate(a.value[i]));
+                erg = erg + Json._helper.niceprint(evaluate(a.value[i]), modifs, options);
                 if (i !== a.value.length - 1) {
                     erg = erg + ', ';
                 }

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -65,7 +65,7 @@ Json.GenFromUserDataEl = function(el) {
 Json._helper.GenJSONAtom = function(key, val) {
     return {
         "ctype": "JSON",
-        "isJSONAtom" : true,
+        "isJSONAtom": true,
         "value": {
             'key': key,
             'value': val

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -146,6 +146,7 @@ Json.niceprint = function(el, modifs, options) {
         options.printedWarning = false;
         // track depth
         options.visitedMap = {};
+        options.visitedMap.tracker = new WeakMap();
         options.visitedMap.level = 0;
         options.visitedMap.maxLevel = 1000;
         options.visitedMap.maxElVisit = 5000;
@@ -171,8 +172,8 @@ Json.niceprint = function(el, modifs, options) {
     var jsonString = "{" + keys.map(function(key) {
         // update visitedMap
         let elValKey = el.value[key];
-        if (!visitedMap[elValKey]) {
-            visitedMap[elValKey] = 1;
+        if (!visitedMap.tracker.has(elValKey)) {
+            visitedMap.tracker.set(elValKey, 1);
         } else {
             if (visitedMap[elValKey] > visitedMap.maxElVisit || visitedMap.level > visitedMap.maxLevel) {
                 //console.log([visitedMap[elValKey], visitedMap.level]);
@@ -188,7 +189,7 @@ Json.niceprint = function(el, modifs, options) {
             }
             // update only once a recursive call
             if (visitedMap.newLevel) {
-                visitedMap[elValKey] += 1;
+                visitedMap.tracker.set(elValKey, visitedMap.tracker.get(elValKey) + 1);
                 // update only once each function call
                 visitedMap.newLevel = false;
             }

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -1,0 +1,223 @@
+// CindyScript JSON
+var Json = {};
+Json._helper = {};
+
+
+Json.turnIntoCSJson = function(a) {
+    return {
+        "ctype": "JSON",
+        "value": a
+    };
+};
+
+Json._helper.ShallowClone = function(o) {
+    var out, v, key;
+    out = Array.isArray(o) ? [] : {};
+    for (key in o) {
+        v = o[key];
+        out[key] = v;
+    }
+    return out;
+};
+
+Json._helper.DeepClone = function(o) {
+    var out, v, key;
+    out = Array.isArray(o) ? [] : {};
+    for (key in o) {
+        v = o[key];
+        out[key] = (typeof v === "object" && v !== null) ? Json._helper.DeepClone(v) : v;
+    }
+    return out;
+};
+
+Json.getField = function(obj, key) {
+    if (obj.value && obj.value[key]) {
+        return obj.value[key];
+    }
+    return nada;
+};
+
+Json.setField = function(where, field, what) {
+    where[field] = what;
+};
+
+Json.GenFromUserDataEl = function(el) {
+    // key/obj are reversed due to the semantics of the ":" operator in CindyScript
+    var key = el.obj;
+    var obj = el.key;
+
+    if (!key || key.ctype !== "string") {
+        console.log("Error: JSON keys have to be strings.");
+        return nada;
+    }
+    if (!obj) {
+        console.log("Warning: JSON object not defined.");
+        return {
+            "key": key.value,
+            "val": nada,
+        };
+    } else return {
+        "key": key.value,
+        "val": evaluate(obj)
+    };
+};
+
+Json._helper.GenJSONAtom = function(key, val) {
+    return {
+        "ctype": "JSONAtom",
+        "value": {
+            'key': key,
+            'value': val
+        }
+    };
+};
+
+
+Json._helper.forall = function(li, runVar, fct, modifs) { // JSON
+    // default iterate over values in JSON
+    var iteratorType = "value";
+    var res;
+    if (modifs.iterator !== undefined) {
+        let it = evaluate(modifs.iterator);
+        let iterTypes = ["key", "value", "pair"];
+        if (it.ctype === 'string' && iterTypes.includes(it.value)) {
+            iteratorType = it.value;
+        }
+    }
+    // iterate over key, value or pair
+    if (iteratorType === "value") {
+        for (let k in li) {
+            namespace.setvar(runVar, li[k]);
+            res = evaluate(fct);
+        }
+    } else if (iteratorType === "key") {
+        for (let k in li) {
+            namespace.setvar(runVar, General.string(k));
+            res = evaluate(fct);
+        }
+    } else { // pair
+        for (let k in li) {
+            namespace.setvar(runVar, Json._helper.GenJSONAtom(k, li[k]));
+            res = evaluate(fct);
+        }
+    }
+
+    return res;
+};
+
+Json._helper.niceprint = function(a, modifs, options) {
+    if (a.ctype === "JSON") {
+        return Json.niceprint(a, modifs, options);
+    }
+
+    if (options.printValidJSON) {
+        if (a.ctype === "number" && a.value.imag === 0) {
+            return a.value.real;
+        }
+        if ("boolean" === a.ctype) {
+            return a.value;
+        }
+        if (a.ctype === 'list') {
+            var erg = "[";
+            for (var i = 0; i < a.value.length; i++) {
+                erg = erg + Json._helper.niceprint(evaluate(a.value[i]));
+                if (i !== a.value.length - 1) {
+                    erg = erg + ', ';
+                }
+
+            }
+            return erg + "]";
+        }
+
+        return "\"" + String(niceprint(a)) + "\"";
+    }
+
+    return niceprint(a);
+};
+
+Json.Atomniceprint = function(el) {
+    return "\{" + el.value.key + ":" + niceprint(el.value.value) + "\}";
+};
+
+Json.niceprint = function(el, modifs, options) {
+    if (!options) {
+        options = {};
+        options.printValidJSON = false;
+        options.printedWarning = false;
+        // track depth
+        options.visitedMap = {};
+        options.visitedMap.level = 0;
+        options.visitedMap.maxLevel = 1000;
+        options.visitedMap.maxElVisit = 5000;
+
+        if (modifs) {
+            if (modifs.JSON) {
+                let jmodif = evaluate(modifs.JSON);
+                if (jmodif.ctype === "boolean") options.printValidJSON = jmodif.value;
+            }
+            if (modifs.maxDepth) {
+                let depth = evaluate(modifs.maxDepth);
+                if (depth.ctype === "number") options.visitedMap.maxLevel = depth.value.real;
+            }
+        }
+    }
+
+    var visitedMap = options.visitedMap;
+    // track a new recursive call
+    visitedMap.newLevel = true;
+    visitedMap.level += 1;
+
+    var keys = Object.keys(el.value).sort();
+    var jsonString = "{" + keys.map(function(key) {
+        // update visitedMap
+        let elValKey = el.value[key];
+        if (!visitedMap[elValKey]) {
+            visitedMap[elValKey] = 1;
+        } else {
+            if (visitedMap[elValKey] > visitedMap.maxElVisit || visitedMap.level > visitedMap.maxLevel) {
+                //console.log([visitedMap[elValKey], visitedMap.level]);
+                if (!options.printedWarning) {
+                    console.log("Warning: We visited a key-value pair very often or encountered a very deeply nested dictionary. Dictionary is probably cyclic. Output will be probably incomplete.");
+                    options.printedWarning = true;
+                }
+                if (options.printValidJSON) {
+                    return "\"" + key + "\"" + ":" + '"..."';
+                } else {
+                    return key + ":" + '...';
+                }
+            }
+            // update only once a recursive call
+            if (visitedMap.newLevel) {
+                visitedMap[elValKey] += 1;
+                // update only once each function call
+                visitedMap.newLevel = false;
+            }
+        }
+        if (options.printValidJSON) {
+            return "\"" + key + "\"" + ":" + Json._helper.niceprint(elValKey, modifs, options);
+        } else {
+            return key + ":" + Json._helper.niceprint(elValKey, modifs, options);
+        }
+    }).join(", ") + "}";
+
+
+    // pretty print 
+    // to be valid JSON we need to replace single with double quotes
+    if (options.printValidJSON) {
+        jsonString = jsonString.replace(/'/g, '"');
+        jsonString = JSON.stringify(JSON.parse(jsonString), null, 0);
+    }
+
+    return jsonString;
+};
+
+Json._helper.handlePrintException = function(e) {
+    if (e instanceof RangeError) {
+        console.log("Warning: Dictionary string could not be generated! Probably large cyclic Dictionary!");
+    } else if (e instanceof SyntaxError) {
+        console.log("Warning: Dictionary string could not be parsed!");
+    } else {
+        console.log("Warning: Dictionary printing failed!");
+    }
+
+};

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -203,10 +203,12 @@ Json.niceprint = function(el, modifs, options) {
 
 
     // pretty print 
-    // to be valid JSON we need to replace single with double quotes
     if (options.printValidJSON) {
-        jsonString = jsonString.replace(/'/g, '"');
-        jsonString = JSON.stringify(JSON.parse(jsonString), null, 0);
+        try {
+            jsonString = JSON.stringify(JSON.parse(jsonString), null, 0);
+        } catch (e) {
+            console.log("Could not parse JSON string.");
+        }
     }
 
     return jsonString;

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -64,7 +64,8 @@ Json.GenFromUserDataEl = function(el) {
 
 Json._helper.GenJSONAtom = function(key, val) {
     return {
-        "ctype": "JSONAtom",
+        "ctype": "JSON",
+        "isJSONAtom" : true,
         "value": {
             'key': key,
             'value': val

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -531,8 +531,8 @@ eval_helper.assigntake = function(data, what) { //TODO: Bin nicht ganz sicher ob
         }
     }
     if (where.ctype === 'JSON') {
-        var key = niceprint(ind);
-        if (key !== niceprint(nada)) {
+        const key = niceprint(ind);
+        if (!niceprint.errorTypes.includes(key)) {
             rhs = Json._helper.ShallowClone(where);
             rhs.value[key] = evaluate(what);
         }
@@ -2631,8 +2631,12 @@ function infix_take(args, modifs) {
             printStackTrace("WARNING: Index out of range!");
             return nada;
         }
-    } else if (v0.ctype === "JSON" && v1.ctype === "string") {
-        var val = v0.value[v1.value];
+    } else if (v0.ctype === "JSON") {
+        let np = niceprint(v1);
+        if (niceprint.errorTypes.includes(np)) {
+            return nada;
+        }
+        let val = v0.value[np];
         if (val !== undefined && val.ctype) return val;
         return nada;
     }

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -43,12 +43,12 @@ evaluator.errc$1 = function(args, modifs) { //OK
 };
 
 evaluator.print$1 = function(args, modifs) {
-    csconsole.out(niceprint(evaluate(args[0])), true);
+    csconsole.out(niceprint(evaluate(args[0]), modifs), true);
     return nada;
 };
 
 evaluator.println$1 = function(args, modifs) {
-    csconsole.out(niceprint(evaluate(args[0])));
+    csconsole.out(niceprint(evaluate(args[0], modifs)));
     return nada;
 };
 
@@ -193,38 +193,77 @@ evaluator.while$2 = function(args, modifs) { //OK
 };
 
 
-evaluator.apply$2 = function(args, modifs) { //OK
+evaluator.apply$2 = function(args, modifs) {
     return evaluator.apply$3([args[0], null, args[1]], modifs);
 };
 
-evaluator.apply$3 = function(args, modifs) { //OK
+evaluator.apply$3 = function(args, modifs) {
+    return evaluator.apply$4([args[0], args[1], null, args[2]], modifs);
+};
 
+evaluator.apply$4 = function(args, modifs) {
     var v1 = evaluateAndVal(args[0]);
-    if (v1.ctype !== 'list') {
+
+    if (!(v1.ctype === 'list' || v1.ctype === "JSON")) {
         return nada;
     }
 
-    var lauf = '#';
+    var valueVar = '#';
     if (args[1] !== null) {
         if (args[1].ctype === 'variable') {
-            lauf = args[1].name;
+            valueVar = args[1].name;
+        }
+    }
+
+    var keyVar;
+    if (args[2] !== null) {
+        if (args[2].ctype === 'variable') {
+            keyVar = args[2].name;
+            namespace.newvar(keyVar);
         }
     }
 
     var li = v1.value;
-    var erg = [];
-    namespace.newvar(lauf);
-    for (var i = 0; i < li.length; i++) {
-        namespace.setvar(lauf, li[i]);
-        erg[i] = evaluate(args[2]);
+    var erg = v1.ctype === "list" ? [] : {};
+
+    namespace.newvar(valueVar);
+
+    if (keyVar !== undefined) {
+        if (v1.ctype === "list") {
+            for (let i = 0; i < li.length; i++) {
+                namespace.setvar(keyVar, CSNumber.real(i + 1));
+                namespace.setvar(valueVar, li[i]);
+                erg[i] = evaluate(args[3]);
+            }
+        } else { // JSON
+            var res;
+            for (let k in li) {
+                namespace.setvar(keyVar, General.string(k));
+                namespace.setvar(valueVar, li[k]);
+                erg[k] = evaluate(args[3]);
+            }
+        }
+        namespace.removevar(keyVar);
+    } else { // no key var
+        if (v1.ctype === "list") {
+            erg = [];
+            for (let i = 0; i < li.length; i++) {
+                namespace.setvar(valueVar, li[i]);
+                erg[i] = evaluate(args[3]);
+            }
+        } else { // JSON
+            for (let k in li) {
+                // iterate over values 
+                namespace.setvar(valueVar, li[k]);
+                erg[k] = evaluate(args[3]);
+            }
+        }
     }
-    namespace.removevar(lauf);
 
-    return {
-        'ctype': 'list',
-        'value': erg
-    };
 
+    namespace.removevar(valueVar);
+
+    return (v1.ctype === "list") ? List.turnIntoCSList(erg) : Json.turnIntoCSJson(erg);
 };
 
 evaluator.forall$2 = function(args, modifs) { //OK
@@ -232,32 +271,35 @@ evaluator.forall$2 = function(args, modifs) { //OK
 };
 
 evaluator.forall$3 = function(args, modifs) { //OK
-
     var v1 = evaluateAndVal(args[0]);
-    if (v1.ctype !== 'list') {
+
+    if (!(v1.ctype === 'list' || v1.ctype === "JSON")) {
         return nada;
     }
 
-    var lauf = '#';
+    var runVar = '#';
     if (args[1] !== null) {
         if (args[1].ctype === 'variable') {
-            lauf = args[1].name;
+            runVar = args[1].name;
         }
     }
 
     var li = v1.value;
-    var erg = [];
-    namespace.newvar(lauf);
+    namespace.newvar(runVar);
+
     var res;
-    for (var i = 0; i < li.length; i++) {
-        namespace.setvar(lauf, li[i]);
-        res = evaluate(args[2]);
-        erg[i] = res;
+    if (v1.ctype === "list") {
+        for (let i = 0; i < li.length; i++) {
+            namespace.setvar(runVar, li[i]);
+            res = evaluate(args[2]);
+        }
+    } else { // JSON
+        res = Json._helper.forall(li, runVar, args[2], modifs);
     }
-    namespace.removevar(lauf);
+
+    namespace.removevar(runVar);
 
     return res;
-
 };
 
 evaluator.select$2 = function(args, modifs) { //OK
@@ -265,9 +307,8 @@ evaluator.select$2 = function(args, modifs) { //OK
 };
 
 evaluator.select$3 = function(args, modifs) { //OK
-
     var v1 = evaluateAndVal(args[0]);
-    if (v1.ctype !== 'list') {
+    if (!(v1.ctype === 'list' || v1.ctype === "JSON")) {
         return nada;
     }
 
@@ -279,26 +320,49 @@ evaluator.select$3 = function(args, modifs) { //OK
     }
 
     var li = v1.value;
-    var erg = [];
+    var erg, ret, res;
     namespace.newvar(lauf);
-    var ct = 0;
-    for (var i = 0; i < li.length; i++) {
-        namespace.setvar(lauf, li[i]);
-        var res = evaluate(args[2]);
-        if (res.ctype === 'boolean') {
-            if (res.value === true) {
-                erg[ct] = li[i];
-                ct++;
+
+    if (v1.ctype === "list") {
+        erg = [];
+        var ct = 0;
+        for (var i = 0; i < li.length; i++) {
+            namespace.setvar(lauf, li[i]);
+            res = evaluate(args[2]);
+            if (res.ctype === 'boolean') {
+                if (res.value === true) {
+                    erg[ct] = li[i];
+                    ct++;
+                }
             }
         }
+
+        ret = {
+            'ctype': 'list',
+            'value': erg
+        };
+
+    } else { // JSON
+        erg = {};
+        for (var k in li) {
+            namespace.setvar(lauf, li[k]);
+            res = evaluate(args[2]);
+            if (res.ctype === 'boolean') {
+                if (res.value === true) {
+                    erg[k] = li[k];
+                }
+            }
+        }
+
+        ret = {
+            'ctype': 'JSON',
+            'value': erg
+        };
     }
+
     namespace.removevar(lauf);
 
-    return {
-        'ctype': 'list',
-        'value': erg
-    };
-
+    return ret;
 };
 
 
@@ -421,6 +485,22 @@ evaluator.genList = function(args, modifs) { //VARIADIC!
     return List.turnIntoCSList(args.map(evaluate));
 };
 
+evaluator.genJSON = function(args, modifs) {
+    var res = {};
+    for (var i = 0; i < args.length; i++) {
+        var atom = Json.GenFromUserDataEl(args[i]);
+        // discard values that have no key
+        if (!atom.key) {
+            continue;
+        }
+        res[atom.key] = atom.val;
+    }
+
+    return {
+        'ctype': 'JSON',
+        'value': res
+    };
+};
 
 eval_helper.assigntake = function(data, what) { //TODO: Bin nicht ganz sicher obs das so tut
     var lhs = data.args[0];
@@ -428,6 +508,7 @@ eval_helper.assigntake = function(data, what) { //TODO: Bin nicht ganz sicher ob
     var ind = evaluateAndVal(data.args[1]);
     var rhs = nada;
 
+    // TODO fix ind must be number
     if (where.ctype === 'list' || where.ctype === 'string') {
         var ind1 = Math.floor(ind.value.real);
         if (ind1 < 0) {
@@ -440,13 +521,20 @@ eval_helper.assigntake = function(data, what) { //TODO: Bin nicht ganz sicher ob
                 rhs = List.turnIntoCSList(lst);
                 // update colon op
                 if (where.userData) rhs.userData = where.userData;
-            } else {
+            } else { // string
                 var str = where.value;
                 str = str.substring(0, ind1 - 1) +
                     niceprint(evaluate(what)) +
                     str.substring(ind1, str.length);
                 rhs = General.string(str);
             }
+        }
+    }
+    if (where.ctype === 'JSON') {
+        var key = niceprint(ind);
+        if (key !== niceprint(nada)) {
+            rhs = Json._helper.ShallowClone(where);
+            rhs.value[key] = evaluate(what);
         }
     }
     infix_assign([lhs, rhs]);
@@ -457,8 +545,11 @@ eval_helper.assigndot = function(data, what) {
     var where = evaluate(data.obj);
     var field = data.key;
 
-    if (where.ctype === 'geo' && field) {
+    if (where.ctype === 'geo' && typeof(field) === "string") {
         Accessor.setField(where.value, field, evaluateAndVal(what));
+    }
+    if (where.ctype === 'JSON' && typeof(field) === "string") {
+        Json.setField(where.value, field, evaluateAndVal(what));
     }
 
     return nada;
@@ -468,8 +559,8 @@ eval_helper.assigncolon = function(data, what) {
     var lhs = data.obj;
     var where = evaluate(lhs);
 
-    var key = niceprint(evaluate(data.key));
-    if (key === "_?_") key = undefined;
+    var key = General.string(niceprint(evaluate(data.key)));
+    if (key.value === "_?_") key = nada;
 
     if (where.ctype === 'geo' && key) {
         Accessor.setuserData(where.value, key, evaluateAndVal(what));
@@ -485,11 +576,11 @@ eval_helper.assigncolon = function(data, what) {
             rhs.userData = tmpObj;
         }
 
-        rhs.userData[key] = evaluateAndVal(what);
+        rhs.userData[key.value] = evaluateAndVal(what);
 
         infix_assign([lhs, rhs]);
     } else {
-        if (!key) console.log("Key is undefined");
+        if (!(key && key.ctype === "string")) console.log("Key is undefined");
         else console.log("User data can only be assigned to geo objects and lists.");
     }
 
@@ -500,14 +591,44 @@ eval_helper.assigncolon = function(data, what) {
 evaluator.keys$1 = function(args, modifs) {
     var obj = evaluate(args[0]);
     var ctype = obj.ctype;
-    if (ctype === "geo" || ctype === "list") {
+    if (ctype === "geo" || ctype === "list" || ctype === "JSON") {
         var keys = [];
 
-        var data = ctype === "geo" ? obj.value.userData : obj.userData;
+        var data;
+        if (ctype === "geo") {
+            data = obj.value.userData;
+        } else if (ctype === "list") {
+            data = obj.userData;
+        } else { // JSON
+            data = obj.value;
+        }
         if (data) {
-            keys = Object.keys(data).map(General.string);
+            keys = Object.keys(data).map(General.string).sort();
         }
         return List.turnIntoCSList(keys);
+    }
+
+    return nada;
+};
+
+evaluator.values$1 = function(args, modifs) {
+    var obj = evaluate(args[0]);
+    let ctype = obj.ctype;
+    if (ctype === "list") return obj;
+
+    if (ctype === "geo" || ctype === "JSON") {
+        let values = [];
+
+        let data;
+        if (ctype === "geo") {
+            data = obj.value.userData;
+        } else { // JSON
+            data = obj.value;
+        }
+        if (data) {
+            values = Object.keys(data).sort().map(key => data[key]);
+        }
+        return List.turnIntoCSList(values);
     }
 
     return nada;
@@ -2490,10 +2611,10 @@ evaluator.mincostmatching$1 = function(args, modifs) {
 function infix_take(args, modifs) {
     var v0 = evaluate(args[0]);
     var v1 = evaluateAndVal(args[1]);
-    if (v0.ctype !== 'string') {
+    if (v0.ctype !== 'string' && v0.ctype !== "JSON") {
         v0 = List.asList(v0);
     }
-    if (v1.ctype === 'number') {
+    if (v0.ctype !== "JSON" && v1.ctype === 'number') {
         var ind = Math.floor(v1.value.real);
         if (ind < 0) {
             ind = v0.value.length + ind + 1;
@@ -2510,6 +2631,10 @@ function infix_take(args, modifs) {
             printStackTrace("WARNING: Index out of range!");
             return nada;
         }
+    } else if (v0.ctype === "JSON" && v1.ctype === "string") {
+        var val = v0.value[v1.value];
+        if (val !== undefined && val.ctype) return val;
+        return nada;
     }
     if (v1.ctype === 'list') { // This is recursive, different from Cinderella
         var li = [];

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -545,7 +545,12 @@ function parseRec(tokens, closing) {
                                 ' arguments', tok.start);
                         }
                     } else if (pair === '{}') {
-                        throw ParseError('{…} reserved for future use', tok.start);
+                        seq.push({
+                            ctype: 'function',
+                            oper: 'genJSON',
+                            args: lst,
+                            modifs: {},
+                        });
                     } else if (pair !== '[]' && lst.length === 1) {
                         seq.push({
                             ctype: 'paren',
@@ -566,7 +571,7 @@ function parseRec(tokens, closing) {
                     }
                 } else { // operator position, so it's a function call
                     if (pair === '{}')
-                        throw ParseError('{…} reserved for future use', tok.start);
+                        throw ParseError('{…} not yet defined for operators.', tok.start);
                     var fname = seq[seq.length - 1];
                     if (fname.ctype !== 'variable')
                         throw ParseError(
@@ -668,7 +673,7 @@ Parser.prototype.postprocess = function(expr) {
             if (expr.oper === ':') {
                 if (!(expr.args[1])) {
                     throw ParseError(
-                        'Data key undefined', expr.start, expr.text);
+                        'UserData/JSON: Key or Value undefined', expr.start, expr.text);
                 }
                 expr.ctype = 'userdata';
                 expr.obj = expr.args[0];

--- a/tests/ColonOp_tests.js
+++ b/tests/ColonOp_tests.js
@@ -1,3 +1,4 @@
+"use strict";
 var should = require("chai").should();
 var rewire = require("rewire");
 
@@ -52,6 +53,7 @@ describe("ColonOp: Lists", function(){
     // keys
     itCmd('keys(a)', '[bla]');
     itCmd('keys(b)', '[]');
+    itCmd('keys(lst)', '[1, age, list, pt, 12.3, 1 + i*1, [1, 2, 3]]');
 });
 
 

--- a/tests/JSON_tests.js
+++ b/tests/JSON_tests.js
@@ -95,6 +95,8 @@ describe("JSON operations", function(){
 
     itCmd('li=[];forall({"a":2, "b":3}, x, iterator->"pair",x.value=x.value^2;li=li++x.value;);li', '[4, 9]');
 
+    itCmd('li=[];forall({"a":2,"b":3},x,iterator->"pair",x.key=x.key;li=li++[x]);','[{key:a, value:2}, {key:b, value:3}]')
+
 
     // 4ary apply
     itCmd('apply(json3, v, k, v+k)', '{a:1a, b:2b, c:10c, d:stringd}');

--- a/tests/JSON_tests.js
+++ b/tests/JSON_tests.js
@@ -1,0 +1,106 @@
+"use strict";
+var should = require("chai").should();
+var rewire = require("rewire");
+
+global.navigator = {};
+var CindyJS = require("../build/js/Cindy.plain.js");
+
+var cdy = CindyJS({
+            isNode: true,
+            csconsole: null,
+            geometry: [
+                {name:"A", type:"Free", pos:[0,0]},
+                {name:"B", type:"Free", pos:[1,1]},
+                {name:"C", type:"Free", pos:[1,2]},
+            ],
+        });
+
+function itCmd(command, expected) {
+    it(command, function() {
+        String(cdy.niceprint(cdy.evalcs(command))).should.equal(expected);
+    });
+}
+
+function getJSONStr() {
+return "{\"age\":30, \"bool\":false, \"cars\":[{\n \"models\": [\n  \"Fiesta\",\n  \"Focus\",\n  \"Mustang\"\n ],\n \"name\": \"Ford\"\n}, {\n \"models\": [\n  \"320\",\n  \"X3\",\n  \"X5\"\n ],\n \"name\": \"BMW\"\n}, {\n \"models\": [\n  \"500\",\n  \"Panda\"\n ],\n \"name\": \"Fiat\"\n}], \"name\":\"Joe\"}"
+}
+
+function getJSONprettyStr() {
+    return '{age:30, bool:false, cars:[{models:[Fiesta, Focus, Mustang], name:Ford}, {models:[320, X3, X5], name:BMW}, {models:[500, Panda], name:Fiat}], name:Joe, test:circle, undef:___}';
+}
+
+describe("JSON basic getter / setter", function(){
+    before(function(){
+        cdy.evalcs('circ = circle(A,1);');
+        cdy.evalcs('json = ' + getJSONStr());
+        cdy.evalcs('json.test = circ;');
+        cdy.evalcs('json.undef = undef;');
+        }
+    );
+
+    itCmd('json.name', 'Joe');
+    itCmd('json.bool', 'false');
+    itCmd('json.undef', '___');
+    itCmd('json.age', '30');
+    itCmd('((json.cars)_1).models_2', 'Focus');
+    itCmd('json.test', 'circle');
+
+    // pretty print
+    itCmd('json', getJSONprettyStr());
+
+    // keys
+    itCmd('keys(json)', '[age, bool, cars, name, test, undef]');
+
+    // values  
+    itCmd('values({"a" : 5, "b" : 2})', '[5, 2]');
+
+    // dynamic access
+    itCmd('myvar = "name"; json_myvar = "Bob"; json.name', 'Bob');
+    itCmd('json_undef', '___');
+    itCmd('json1 = {"1":2}; json_1', '___');
+
+    // copy by reference
+    itCmd('json1 = {"a":1}; json2=json1; json2.a=2; json1.a', '2');
+    itCmd('json1 = {"a":1}; json2=json1; myvar = "a"; json2_myvar=2; json1.a', '2');
+});
+
+describe("JSON geo objects", function(){
+    before(function(){
+        cdy.evalcs('geojson = {"pt1": A, "pt2": B, "pt3" : C};');
+        }
+    );
+
+    itCmd('(geojson.pt1).xy', '[0, 0]');
+    itCmd('geojson.pt1 = C; (geojson.pt1).xy', '[1, 2]');
+});
+
+describe("JSON operations", function(){
+    before(function(){
+        cdy.evalcs('json3 = {"a": 1, "b": 2, "c": 10, "d" : "string" };');
+        }
+    );
+
+    itCmd('apply(json3, #^2)', '{a:1, b:4, c:100, d:___}');
+    itCmd('select(json3, isOdd(#))', '{a:1}');
+
+    itCmd('li = []; forall(json3,v, li = li++[[v.key, v.value]], iterator->"pair"); li', '[[a, 1], [b, 2], [c, 10], [d, string]]');
+
+    itCmd('li = []; forall(json3,v, li = li++[v], iterator->"key"); li', '[a, b, c, d]');
+
+    itCmd('v=123;apply(json3,v, v^2); v', '123');
+
+
+    // 4ary apply
+    itCmd('apply(json3, v, k, v+k)', '{a:1a, b:2b, c:10c, d:stringd}');
+    // check that keys are by value and not by reference
+    itCmd('apply(json3, v, k, k=k+1; v=v+2);', '{a:3, b:4, c:12, d:string2}');
+
+    function cycleString(){
+        return '{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:13, sister:{age:15, brother:{age:..., sister:...}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}'
+    }
+    // cycles 
+    itCmd('Jason = {"age":13};Jasonica = {"age":15};Jason.sister = Jasonica; Jasonica.brother = Jason; Jason;', cycleString());
+
+});
+
+

--- a/tests/JSON_tests.js
+++ b/tests/JSON_tests.js
@@ -93,6 +93,8 @@ describe("JSON operations", function(){
 
     itCmd('v=123;apply(json3,v, v^2); v', '123');
 
+    itCmd('li=[];forall({"a":2, "b":3}, x, iterator->"pair",x.value=x.value^2;li=li++x.value;);li', '[4, 9]');
+
 
     // 4ary apply
     itCmd('apply(json3, v, k, v+k)', '{a:1a, b:2b, c:10c, d:stringd}');

--- a/tests/JSON_tests.js
+++ b/tests/JSON_tests.js
@@ -57,7 +57,8 @@ describe("JSON basic getter / setter", function(){
     // dynamic access
     itCmd('myvar = "name"; json_myvar = "Bob"; json.name', 'Bob');
     itCmd('json_undef', '___');
-    itCmd('json1 = {"1":2}; json_1', '___');
+    itCmd('json1 = {"1":2}; json1_1', '2');
+    itCmd('json1 = {"1":2}; json1_"1"', '2');
 
     // copy by reference
     itCmd('json1 = {"a":1}; json2=json1; json2.a=2; json1.a', '2');

--- a/tests/JSON_tests.js
+++ b/tests/JSON_tests.js
@@ -108,5 +108,8 @@ describe("JSON operations", function(){
     }
     // cycles 
     itCmd('Jason = {"age":13};Jasonica = {"age":15};Jason.sister = Jasonica; Jasonica.brother = Jason; Jason;', cycleString());
+    
+    //deleting keys from a dictionary
+    itCmd('json = {"a":1, "b": 2}; json.a = nada; keys(json)','[b]');
 
 });

--- a/tests/Parser_tests.js
+++ b/tests/Parser_tests.js
@@ -111,7 +111,6 @@ describe('CindyScript parser error reporting', function() {
     badCase('1 + || * 2', "Don't support |…| with 0 arguments at 1:4");
     badCase('|x,y,z|', "Don't support |…| with 3 arguments at 1:0");
     badCase('1 + 2)', 'Closing bracket never opened. at 1:5: ‘)’');
-    badCase('{1,2}', '{…} reserved for future use at 1:0');
     badCase('17()', 'Function name must be an identifier at 1:0');
     badCase('f(7->8)', 'Modifier name must be an identifier at 1:3');
     badCase('f(x.y->8)', 'Modifier name must be an identifier at 1:5');


### PR DESCRIPTION
This PR adds JSON support to CindyScript. 
For example:
```
circ = circle(A,1);
json1 =  
 {
    "test" : circ,
    "undef" : undef,
    "name":"John",
    "age":30,
    "bool": false,
    "cars": [
        { "name":"Ford", "models":[ "Fiesta", "Focus", "Mustang" ] },
        { "name":"BMW", "models":[ "320", "X3", "X5" ] },
        { "name":"Fiat", "models":[ "500", "Panda" ] }
    ]
};
```
yields the following results:
```
json1.name --> "Joe", json.test --> "Circle"
``` 

The setters work analogously.

Geometric objects (as values) are also supported. Keys are of type string only. I could add geo objects (using niceprint) if desired.