### PR TITLE
Add ability to script multitouch events

### DIFF
--- a/examples/multitouch.html
+++ b/examples/multitouch.html
@@ -22,7 +22,7 @@ drawtext((0,0), multiidlist());
 
 al = 1;
 forall(events, e,
-  dim = if(e_3=="down" % e_3=="up", .7, 1);
+  dim = if(e_3=="down" % e_3=="up", drawtext(e_1, e_3 + " of " + e_2, alpha->al);.7, 1);
   draw(e_1, color->hue(e_2/sqrt(20))*dim, alpha->al);
   al = al*.95;
 );

--- a/examples/multitouch.html
+++ b/examples/multitouch.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Multitouch scripting</title>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+events = [];
+
+addevent(pos, id, kind) := (
+  events = [pos, id, kind] <: events;
+  if(length(events)>=200,
+    events = events_(1..200);
+  );
+);
+</script>
+
+
+<script id="csdraw" type="text/x-cindyscript">
+drawtext((0,0), multiidlist());
+
+al = 1;
+forall(events, e,
+  dim = if(e_3=="down" % e_3=="up", .7, 1);
+  draw(e_1, color->hue(e_2/sqrt(20))*dim, alpha->al);
+  al = al*.95;
+);
+
+</script>
+<script id="csmultidown" type="text/x-cindyscript">
+addevent(mouse(id->multiid()), multiid(), "down");
+</script>
+
+<script id="csmultidrag" type="text/x-cindyscript">
+addevent(mouse(id->multiid()), multiid(), "draw");
+</script>
+
+<script id="csmultiup" type="text/x-cindyscript">
+addevent(mouse(id->multiid()), multiid(), "up");
+</script>
+
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 350,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -4.66]}],
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  autoplay: true,
+  cinderella: {build: 1901, version: [2, 9, 1901]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/examples/multitouchtrafo.html
+++ b/examples/multitouchtrafo.html
@@ -6,7 +6,7 @@
     <title>Multitouch scripting</title>
     <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script id="csinit" type="text/x-cindyscript">
-O = [(0,0,1),(1,0,1),(0,1,1),(2,2,1)];
+O = [(0,0,1),(2,0,1),(0,2,1),(1,1,1),(2,2,1)] ++ apply(1..50, gauss(exp(2*pi*i*#/50)).homog);
 T = [[1,0,0],[0,1,0],[0,0,1]];
 
 down = dict();
@@ -68,7 +68,7 @@ updateT();
 <script id="csmultiup" type="text/x-cindyscript">
 updateT();
 </script>
-Multitouch gestures can be used to define a transformation.
+Multitouch gestures can be used to define a transformation, i.e. one finger for translations, two fingers for similarities, three fingers for affine transformations and four fingers for projective transformations.
     <script type="text/javascript">
 var cdy = CindyJS({
   scripts: "cs*",
@@ -82,9 +82,9 @@ var cdy = CindyJS({
   angleUnit: "°",
   ports: [{
     id: "CSCanvas",
-    width: 680,
-    height: 350,
-    transform: [{visibleRect: [-9.06, 9.34, 18.14, -4.66]}],
+    width: 800,
+    height: 600,
+    transform: [{visibleRect: [-8,-6,8,6]}],
     background: "rgb(168,176,192)"
   }],
   csconsole: false,

--- a/examples/multitouchtrafo.html
+++ b/examples/multitouchtrafo.html
@@ -12,16 +12,20 @@ T = [[1,0,0],[0,1,0],[0,0,1]];
 down = dict();
 cur = dict();
 
+usedfingers = [];
 updateT() := (
   cur = put(cur, multiid(), mouse(id->multiid()));
   
   start = [];
   end = [];
-  forall(multiidlist(), id,
+  
+  usedfingers = usedfingers ++ (multiidlist() -- usedfingers);//enlarge set of usedfingers
+  errc(usedfingers);
+  forall(usedfingers, id,
     start = start :> get(down, id);
     end = end :> get(cur, id);
   );
-  n = length(multiidlist());
+  n = length(usedfingers);
   T = [[1,0,0],[0,1,0],[0,0,1]];
   if(n == 1,
     T = map(start_1, end_1);
@@ -52,8 +56,9 @@ forall(1..length(start), k,
 );
 </script>
 <script id="csmultidown" type="text/x-cindyscript">
+usedfingers = [];
 down = put(down, multiid(), mouse(id->multiid()));
-
+updateT();
 </script>
 
 <script id="csmultidrag" type="text/x-cindyscript">

--- a/examples/multitouchtrafo.html
+++ b/examples/multitouchtrafo.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Multitouch scripting</title>
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+O = [(0,0,1),(1,0,1),(0,1,1),(2,2,1)];
+T = [[1,0,0],[0,1,0],[0,0,1]];
+
+down = dict();
+cur = dict();
+
+updateT() := (
+  cur = put(cur, multiid(), mouse(id->multiid()));
+  
+  start = [];
+  end = [];
+  forall(multiidlist(), id,
+    start = start :> get(down, id);
+    end = end :> get(cur, id);
+  );
+  n = length(multiidlist());
+  T = [[1,0,0],[0,1,0],[0,0,1]];
+  if(n == 1,
+    T = map(start_1, end_1);
+  );
+  if(n == 2,
+    T = map(start_1, start_2, end_1, end_2);
+  );
+  if(n == 3,
+    T = map(start_1, start_2, start_3, end_1, end_2, end_3);
+  );
+  if(n >= 4,
+    T = map(start_1, start_2, start_3, start_4, end_1, end_2, end_3, end_4);
+  );
+);
+</script>
+
+
+<script id="csdraw" type="text/x-cindyscript">
+drawtext((0,0), multiidlist());
+
+forall(O, o,
+  draw(o, color->[0.5,0.5,0.5]);
+  draw(T*o, color->[0,0,0]);
+);
+
+forall(1..length(start), k,
+  draw(start_k, end_k, arrow->true);
+);
+</script>
+<script id="csmultidown" type="text/x-cindyscript">
+down = put(down, multiid(), mouse(id->multiid()));
+
+</script>
+
+<script id="csmultidrag" type="text/x-cindyscript">
+updateT();
+</script>
+
+<script id="csmultiup" type="text/x-cindyscript">
+updateT();
+</script>
+Multitouch gestures can be used to define a transformation.
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 350,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -4.66]}],
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  autoplay: true,
+  cinderella: {build: 1901, version: [2, 9, 1901]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/ref/User_Input.md
+++ b/ref/User_Input.md
@@ -10,9 +10,12 @@ If one wants to react to the corresponding event data, there are several operato
 #### Mouse position: `mouse()`
 
 **Description:**
-Returns a vector that represents the current position of the mouse if the mouse is pressed.
-The vector is given in homogeneous coordinates (this allows also for access of infinite objects).
-If one needs the two-dimensional Euclidean coordinates of the mouse position one can access them via `mouse().xy`.
+Returns a vector that represents the current position of the mouse or of a single contact on a touch-capable device.
+The vector is given in two-dimensional Euclidean coordinates.
+
+The modifier `id` can be used to access the position of a particular multi-touch-event. Hence, `mouse(id->multiid())` returns the position of the current touch. See also the section on [Single and multi-touch](#single-and-multi-touch)
+
+------
 
 ------
 
@@ -44,6 +47,33 @@ Codes for 'shift', 'crtl' and 'alt' are usually 16, 17, 18.
 **Description:**
 This operator returns a list of the codes of all pressed keys.
 An interesting application of the keydown list id given in the chapter on MIDI functions, where you find an example [keyboard piano](MIDI_Functions.md#a-keyboard-piano).
+
+------
+
+------
+
+### Single and multi-touch
+
+Single-touch events are accessible [as it was a mouse](#mouse$0). On multi-touch devices, only contacts that were initialized as unique single touches are handled as the mouse with the corresponding `mousedown`, possible multiple `mousedrag` and `mouseup`-events. Subsequent contacts are ignored as corresponding mouse-events. This guarantees that the mouse-events always appear in this order.
+
+CindyJS can also handle inputs from touch-based devices through scripting. The modification of geometric objects, if not manually scripted, is currently not implemented in a multi-touch way.
+
+Any contact with the surface gives rise to a sequence of a single *multidown*-event, possible multiple *multidown*-events, and a final *multiup*-event. Possibly with multiple fingers involved, there is no guarantee on the order of all fired events anymore. However, every particular contact is associated with an id that is unique during the contact. This id can be accessed through `multiid()`. The mouse with a pressed button also triggers the sequence of these multi-events and will always have the id 0.
+The `multidown`-script is invoked after a finger got down (or the mouse got pressed). `multidrag` is invoked when a finger on the screen (or the mouse with a pressed button) moves and `multiup` is invoked if a finger (or the mouse button) is released. The scripts are invoked in this sequence for a particular touch with fixed id.
+ 
+#### Getting the current multi-id: `multiid()`
+
+This function returns the unique id of the current touch. For the mouse and during the executions from scripts different from the `multidown`, `multidrag` and `multiup` it will be `0`.
+For any contact with the screen, the id is initialized to the unique smallest positive integer that is not used for any other touch at the moment. The id will remain constant and until the corresponding finger is released. `multiid()` returns the id of the current contact.
+
+------
+
+#### Obtain a list of all  active touch events: `multiidlist()`
+
+`multiidlist()` returns the list of the ids of all active touch events. If the (physical) mouse is down, then `0` is contained in the list.
+
+The positions of the touches can be read through [mouse()](#mouse$0) with the modifier `id`.
+ 
 
 ------
 

--- a/ref/createCindy.md
+++ b/ref/createCindy.md
@@ -71,11 +71,15 @@ At the moment the following events are defined:
 * `init` is invoked immediately after startup
 * `move` when some element got moved
 * `draw` for drawing the scene
-* `mousedown` invoked after a mouse button got pressed
-* `mousedrag` invoked when the mouse is moved
+* `mousedown` invoked after a mouse button (or a single finger) got pressed
+* `mousemove` invoked when the mouse (or a single finger) is moved
+* `mousedrag` invoked when the mouse (or a single finger) is moved and the mouse button is pressed
 * `mouseup` invoked if the mouse button is released
 * `keydown` invoked when a key is pressed, see the `keylistener` parameter
 * `tick` to perform a timed animation
+* `multidown` invoked after a finger got down (or the mouse got pressed). More details are discussed in the reference on [multi-touch events](User_Input.html#single-and-multi-touch)
+* `multidrag` invoked when the mouse (with pressed button) or a finger on the screen moves
+* `multiup` invoked if the mouse button or a finger is released
 
 ### keylistener
 

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -4,7 +4,7 @@ var move;
 var cskey = "";
 var cskeycode = 0;
 
-var multiid = -1;
+var multiid = 0;
 var multipos = {};
 var multiiddict = {};
 
@@ -219,10 +219,8 @@ function setuplisteners(canvas, data) {
         hasmoved = false;
         mouse.button = e.which;
         updatePosition(e);
-        multiid = 0;
-        multipos[0] = csmouse;
+        cs_multidown(0);
         cs_mousedown();
-        cs_multidown();
         manage("mousedown");
         mouse.down = true;
         e.preventDefault();
@@ -231,9 +229,8 @@ function setuplisteners(canvas, data) {
     addAutoCleaningEventListener(canvas, "mouseup", function(e) {
         mouse.down = false;
         cindy_cancelmove();
-        multiid = 0;
         cs_mouseup();
-        cs_multiup();
+        cs_multiup(0);
         manage("mouseup");
         delete multipos[0];
         scheduleUpdate();
@@ -246,10 +243,8 @@ function setuplisteners(canvas, data) {
             if (mousedownevent && (Math.abs(mousedownevent.clientX - e.clientX) > 2 || Math.abs(mousedownevent.clientY - e.clientY) > 2))
                 hasmoved = true;
             cs_mousedrag();
-            if (multipos[0]) { //the mouse indeed is down
-                multiid = 0;
-                multipos[0] = csmouse;
-                cs_multidrag();
+            if (multipos[0]) { //the physical mouse (not a finger acting as mouse) indeed is down
+                cs_multidrag(0);
             }
         } else {
             cs_mousemove();
@@ -453,7 +448,7 @@ function setuplisteners(canvas, data) {
         updateMultiPositions(e);
         for (let i = 0; i < e.changedTouches.length; i++) {
             multiid = getmultiid(e.changedTouches[i].identifier);
-            cs_multidrag();
+            cs_multidrag(multiid);
         }
 
         var activeTouchIDList = e.changedTouches;
@@ -486,8 +481,7 @@ function setuplisteners(canvas, data) {
     function touchDown(e) {
         updateMultiPositions(e);
         for (let i = 0; i < e.changedTouches.length; i++) {
-            multiid = getmultiid(e.changedTouches[i].identifier);
-            cs_multidown();
+            cs_multidown(getmultiid(e.changedTouches[i].identifier));
         }
 
         if (activeTouchID !== -1) {
@@ -517,9 +511,8 @@ function setuplisteners(canvas, data) {
         updateMultiPositions(e);
         for (let i = 0; i < e.changedTouches.length; i++) {
             multiid = getmultiid(e.changedTouches[i].identifier);
-            cs_multiup();
+            cs_multiup(multiid);
             delete multiiddict[e.changedTouches[i].identifier];
-            delete multipos[multiid];
         }
 
         var gotit = false;
@@ -779,16 +772,25 @@ function cs_mousedrag(e) {
     evaluate(cscompiled.mousedrag);
 }
 
-function cs_multidown(e) {
+function cs_multidown(id) {
+    multiid = id;
+    if (id == 0)
+        multipos[0] = csmouse;
     evaluate(cscompiled.multidown);
+    multiid = 0;
 }
 
-function cs_multiup(e) {
+function cs_multiup(id) {
+    multiid = id;
     evaluate(cscompiled.multiup);
+    delete multipos[id];
+    multiid = 0;
 }
 
-function cs_multidrag(e) {
+function cs_multidrag(id) {
+    multiid = id;
     evaluate(cscompiled.multidrag);
+    multiid = 0;
 }
 
 function cs_mousemove(e) {

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -160,6 +160,7 @@ function setuplisteners(canvas, data) {
             var pos = csport.to(x, y);
             multipos[id] = [pos[0], pos[1]];
         }
+        scheduleUpdate();
     }
 
     function updatePosition(event) {

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -774,7 +774,7 @@ function cs_mousedrag(e) {
 
 function cs_multidown(id) {
     multiid = id;
-    if (id == 0)
+    if (id === 0)
         multipos[0] = csmouse;
     evaluate(cscompiled.multidown);
     multiid = 0;

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -154,7 +154,7 @@ function setuplisteners(canvas, data) {
         for (let i = 0; i < event.changedTouches.length; i++) {
             let touch = event.changedTouches[i];
             let id = getmultiid(touch.identifier);
-            if (!initialize & !multipos[id])
+            if (!initialize && !multipos[id])
                 continue;
             var rect = canvas.getBoundingClientRect();
             var x = touch.clientX - rect.left - canvas.clientLeft + 0.5;

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -150,10 +150,12 @@ function setuplisteners(canvas, data) {
         addAutoCleaningEventListener(canvas, "DOMNodeRemoved", shutdown);
     }
 
-    function updateMultiPositions(event) {
+    function updateMultiPositions(event, initialize) {
         for (let i = 0; i < event.changedTouches.length; i++) {
             let touch = event.changedTouches[i];
             let id = getmultiid(touch.identifier);
+            if (!initialize & !multipos[id])
+                continue;
             var rect = canvas.getBoundingClientRect();
             var x = touch.clientX - rect.left - canvas.clientLeft + 0.5;
             var y = touch.clientY - rect.top - canvas.clientTop + 0.5;
@@ -445,7 +447,7 @@ function setuplisteners(canvas, data) {
 
 
     function touchMove(e) {
-        updateMultiPositions(e);
+        updateMultiPositions(e, false);
         for (let i = 0; i < e.changedTouches.length; i++) {
             multiid = getmultiid(e.changedTouches[i].identifier);
             cs_multidrag(multiid);
@@ -479,7 +481,7 @@ function setuplisteners(canvas, data) {
     var activeTouchID = -1;
 
     function touchDown(e) {
-        updateMultiPositions(e);
+        updateMultiPositions(e, true);
         for (let i = 0; i < e.changedTouches.length; i++) {
             cs_multidown(getmultiid(e.changedTouches[i].identifier));
         }
@@ -508,7 +510,7 @@ function setuplisteners(canvas, data) {
 
     function touchUp(e) {
         var activeTouchIDList = e.changedTouches;
-        updateMultiPositions(e);
+        updateMultiPositions(e, false);
         for (let i = 0; i < e.changedTouches.length; i++) {
             multiid = getmultiid(e.changedTouches[i].identifier);
             cs_multiup(multiid);

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -289,6 +289,7 @@ function createCindyNow() {
     var scripts = ["move",
         "keydown", "keyup", "keytyped", "keytype",
         "mousedown", "mouseup", "mousedrag", "mousemove", "mouseclick",
+        "multidown", "multiup", "multidrag",
         "init", "tick", "draw",
         "simulationstep", "simulationstart", "simulationstop", "ondrop"
     ];

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3090,9 +3090,17 @@ evaluator.keycode$0 = function(args, modifs) { //OK
 
 
 evaluator.mouse$0 = function(args, modifs) { //OK
-    var x = csmouse[0];
-    var y = csmouse[1];
-    return List.realVector([x, y]);
+    if (modifs.id) {
+        let k = evaluate(modifs.id);
+        if (k.ctype === 'number') {
+            let id = k.value.real;
+            if (multipos[id])
+                return List.realVector(multipos[id]);
+        }
+        return nada;
+    } else {
+        return List.realVector(csmouse);
+    }
 };
 
 evaluator.mover$0 = function(args, modifs) { //OK
@@ -3102,6 +3110,18 @@ evaluator.mover$0 = function(args, modifs) { //OK
             value: move.mover
         };
     return nada;
+};
+
+evaluator.multiid$0 = function(args, modifs) {
+    return CSNumber.real(multiid);
+};
+
+evaluator.multiidlist$0 = function(args, modifs) {
+    let l = [];
+    for (let id in multipos) {
+        l.push(id);
+    }
+    return List.realVector(l);
 };
 
 


### PR DESCRIPTION
Due to an exhibition, we need to be able to handle multitouch input events. This PR adds the scripts `multidown`, `multiup` and `multidrag`. Furthermore with

- `multiid()` the id of the current touch event is obtained
- `multiidlist()` a list of all active touch event ids is obtained
- `mouse(id->number)` the position of the touch with the given id can be obtained.

![image](https://user-images.githubusercontent.com/15124152/52284313-74874000-2964-11e9-9122-002c657f89e7.png)

This PR does not introduce `mtregional` or `mtlocal`. Furthermore, no multitouch interaction with geometry is enabled, because this might be complicated due to tracing.

It would be good that we could agree on the names of the functions/scripts soon so that it can be merged without losing the possibility to implement a broader multi-touch support later. Closer to the javascript like convention would be to have `multi` replaced with `touch` and `drag` replaced with `move`.