### PR TITLE
CindyGL: Fix bug that happend for colorplot + browser induced downsca…

### DIFF
--- a/plugins/cindygl/src/js/Plugin.js
+++ b/plugins/cindygl/src/js/Plugin.js
@@ -66,7 +66,7 @@ CindyJS.registerPlugin(1, "CindyGL", api => {
 
         csctx.save();
         csctx.setTransform(1, 0, 0, 1, 0, 0);
-        csctx.drawImage(glcanvas, 0, 0, iw, ih);
+        csctx.drawImage(glcanvas, 0, 0, iw, ih, 0, 0, iw, ih);
         csctx.restore();
 
         return nada;


### PR DESCRIPTION
…ling

If `examples/cindygl/03_complexplot.html` was open and the user zoomed out, then some render issues became visible due to missing `csctx.drawImage` arguments.