### PR TITLE
make virtualresolution consistent with visibleRect behavior

### DIFF
--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -92,10 +92,7 @@ function updateCanvasDimensions() {
 
     vscale = 1;
     if (virtualwidth || virtualheight) {
-        if (virtualwidth)
-            vscale = virtualwidth / canvas.width;
-        if (virtualheight)
-            vscale = Math.max(vscale, virtualheight / canvas.height);
+        vscale = Math.max(virtualwidth ? virtualwidth / canvas.width : 0, virtualheight ? virtualheight / canvas.height : 0);
 
         csw = vscale * canvas.clientWidth;
         csh = vscale * canvas.clientHeight;

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -94,8 +94,9 @@ function updateCanvasDimensions() {
     if (virtualwidth || virtualheight) {
         if (virtualwidth)
             vscale = virtualwidth / canvas.width;
-        else if (virtualheight)
-            vscale = virtualheight / canvas.height;
+        if (virtualheight)
+            vscale = Math.max(vscale, virtualheight / canvas.height);
+
         csw = vscale * canvas.clientWidth;
         csh = vscale * canvas.clientHeight;
     }


### PR DESCRIPTION
This makes it easy to upscale widgets to fill the screen: simply replace `width` and `height` with `virtualwidth` and `virtualheight` and use `fill: "window"`.