### PR TITLE
Make conics and IFS compatible to virtualwidth/virtualheight

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1564,9 +1564,9 @@ evaluator.repaint$0 = function(args, modifs) {
 
 evaluator.screenbounds$0 = function(args, modifs) {
     var pt1 = General.withUsage(List.realVector(csport.to(0, 0)), "Point");
-    var pt2 = General.withUsage(List.realVector(csport.to(csw / vscale, 0)), "Point");
-    var pt3 = General.withUsage(List.realVector(csport.to(csw / vscale, csh / vscale)), "Point");
-    var pt4 = General.withUsage(List.realVector(csport.to(0, csh / vscale)), "Point");
+    var pt2 = General.withUsage(List.realVector(csport.to(canvas.clientWidth, 0)), "Point");
+    var pt3 = General.withUsage(List.realVector(csport.to(canvas.clientWidth, canvas.clientHeight)), "Point");
+    var pt4 = General.withUsage(List.realVector(csport.to(0, canvas.clientHeight)), "Point");
     return (List.turnIntoCSList([pt1, pt2, pt3, pt4]));
 };
 

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -3462,8 +3462,8 @@ geoOps.IFS.updateParameters = function() {
     var msg = {
         cmd: "init",
         generation: ifs.params.generation,
-        width: csw * supersampling,
-        height: csh * supersampling
+        width: Math.round(csw * supersampling),
+        height: Math.round(csh * supersampling)
     };
     msg.systems = csgeo.ifs.map(function(el) {
         var sum = 0;

--- a/src/js/libgeo/GeoState.js
+++ b/src/js/libgeo/GeoState.js
@@ -64,7 +64,7 @@ csport.reset = function() {
     csport.drawingstate.matrix.sdet = csport.drawingstate.initialmatrix.sdet;
 };
 
-// Convert homogeneous user coordinates to Euclidean pixel coordinates
+// Convert homogeneous user coordinates to Euclidean (CSS) pixel coordinates. Scaling due virtualwidth/virtualheight is taking in consideration. Usable for inputs
 csport.from = function(x, y, z) {
     var xx = x / z;
     var yy = y / z;
@@ -74,7 +74,7 @@ csport.from = function(x, y, z) {
     return [xxx / vscale, yyy / vscale];
 };
 
-// Convert Euclidean pixel coordinates to homogeneous user coordinates
+// Convert Euclidean (CSS) pixel coordinates to homogeneous user coordinates. Scaling due virtualwidth/virtualheight is taking in consideration. Usable for inputs
 csport.to = function(px, py) {
     var m = csport.drawingstate.matrix;
     var xx = px * vscale - m.tx;
@@ -84,7 +84,7 @@ csport.to = function(px, py) {
     return [x, y, 1];
 };
 
-// Homogeneous matrix representation of csport.to (without vscale)
+// Homogeneous matrix representation of csport.to (without vscale). Suitable for transformations from the canvas-coordinate space.
 csport.toMat = function() {
     var m = csport.drawingstate.matrix;
     return List.realMatrix([

--- a/src/js/libgeo/GeoState.js
+++ b/src/js/libgeo/GeoState.js
@@ -84,12 +84,12 @@ csport.to = function(px, py) {
     return [x, y, 1];
 };
 
-// Homogeneous matrix representation of csport.to
+// Homogeneous matrix representation of csport.to (without vscale)
 csport.toMat = function() {
     var m = csport.drawingstate.matrix;
     return List.realMatrix([
-        [vscale * m.d, -vscale * m.b, -m.tx * m.d - m.ty * m.b],
-        [vscale * m.c, -vscale * m.a, -m.tx * m.c - m.ty * m.a],
+        [m.d, -m.b, -m.tx * m.d - m.ty * m.b],
+        [m.c, -m.a, -m.tx * m.c - m.ty * m.a],
         [0, 0, m.det]
     ]);
 };


### PR DESCRIPTION
With this PR also conics and IFSs (both are using `csport.toMat`) are rendered correctly in combination with virtualwidth/virtualheight