### PR TITLE
Enhance opSound 2

### DIFF
--- a/src/js/libcs/OpSound.js
+++ b/src/js/libcs/OpSound.js
@@ -112,18 +112,35 @@ var OpSound = {
         }
     },
 
+    registerInput: function(audioNode) {
+        if (!audioNode.cnt)
+            audioNode.cnt = 1;
+        else
+            audioNode.cnt++;
+    },
+
+    deregisterInput: function(audioNode) {
+        if (audioNode.cnt)
+            audioNode.cnt--;
+    },
+
+    hasRegisteredInput: function(audioNode) {
+        return (audioNode.cnt && audioNode.cnt !== 0);
+    },
+
     playOscillator: function(oscNode, masterGain, gain, attack, duration, release) {
         let audioCtx = this.getAudioContext();
         let gainNode = audioCtx.createGain();
         gainNode.gain.value = 0;
-        gainNode.connect(masterGain);
-        oscNode.connect(gainNode);
+        oscNode.connect(gainNode).connect(masterGain);
+        OpSound.registerInput(masterGain);
         oscNode.start(0);
         oscNode.isplaying = true;
         oscNode.onended = function() {
             this.isplaying = false;
             gainNode.disconnect();
-            if (masterGain.numberOfInputs === 0) {
+            OpSound.deregisterInput(masterGain);
+            if (!OpSound.hasRegisteredInput(masterGain)) {
                 masterGain.disconnect();
                 if (masterGain.panNode) {
                     masterGain.panNode.disconnect();

--- a/src/js/libcs/OpSound.js
+++ b/src/js/libcs/OpSound.js
@@ -240,6 +240,10 @@ class OscillatorLine {
                 console.warn("Ignore phaseshift because the given length does not match with the length of harmonics");
         }
         this.precompute &= this.partials.every(p => Math.abs(p - 1) < 1e-8);
+
+        if (this.damp > 0) {
+            this.duration = Math.min(this.duration, 6 / this.damp); //exp(-6)<0.003, thus unhearable
+        }
     }
 
     panit() {
@@ -259,13 +263,9 @@ class OscillatorLine {
         this.masterGain.gain.cancelScheduledValues(this.audioCtx.currentTime);
         this.masterGain.gain.setValueAtTime(this.masterGain.gain.value, this.audioCtx.currentTime);
         if (this.damp > 0) {
-            this.masterGain.gain.setTargetAtTime(0, this.audioCtx.currentTime + this.release + this.attack, (1 / this.damp));
-            for (let i = 0; i < this.oscNodes[i].length; i++) {
-                //this.oscNodes[i].oscNode.stop(this.audioCtx.currentTime + (6 / this.damp));
-                OpSound.triggerStop(this.oscNodes[i].oscNode, 6 / this.damp);
-            }
+            this.masterGain.gain.setTargetAtTime(0, this.audioCtx.currentTime + this.attack, (1 / this.damp));
         } else if (this.damp < 0) {
-            this.masterGain.gain.setTargetAtTime(1, this.audioCtx.currentTime + this.release + this.attack, (-this.damp));
+            this.masterGain.gain.setTargetAtTime(1, this.audioCtx.currentTime + this.attack, (-this.damp));
         }
     }
 

--- a/src/js/libcs/OpSound.js
+++ b/src/js/libcs/OpSound.js
@@ -344,7 +344,7 @@ class OscillatorLine {
 
         this.panit();
         if (newLine || (restart && this.damp !== 0)) {
-            if (restart) {
+            if (restart && !newLine) {
                 this.stopOscillators();
             }
             this.masterGain.gain.value = this.amp;

--- a/src/js/libcs/OpSound.js
+++ b/src/js/libcs/OpSound.js
@@ -383,6 +383,7 @@ class OscillatorLine {
             this.generateNewMasterGain(this.amp);
             this.startOscillators();
         } else {
+            if (!this.masterGain) this.generateNewMasterGain(this.amp);
             this.updateFrequencyAndGain();
         }
         this.panit();

--- a/src/js/libcs/OpSound.js
+++ b/src/js/libcs/OpSound.js
@@ -333,9 +333,6 @@ class OscillatorLine {
     }
 
     generateNewMasterGain(amp) {
-        if (this.masterGain && this.masterGain.numberOfInputs == 0) {
-            this.masterGain.disconnect();
-        }
         //replace masterGain with a new one (the old one is still needed for smooth fading)
         this.masterGain = this.audioCtx.createGain();
         this.masterGain.connect(this.audioCtx.destination);

--- a/src/js/libcs/OpSound.js
+++ b/src/js/libcs/OpSound.js
@@ -101,9 +101,6 @@ var OpSound = {
         for (let id in this.lines) {
             if (this.lines[id].lineType === 'sin') {
                 if (this.lines[id].oscNodes.every(oscGainPair => !oscGainPair.oscNode.isplaying)) {
-                    this.lines[id].masterGain.disconnect();
-                    if (this.lines[id].panNode)
-                        this.lines[id].panNode.disconnect();
                     delete this.lines[id];
                 } else {
                     for (let i = 0; i < this.lines[id].oscNodes.length; i++) {
@@ -128,6 +125,9 @@ var OpSound = {
             gainNode.disconnect();
             if (masterGain.numberOfInputs === 0) {
                 masterGain.disconnect();
+                if (masterGain.panNode) {
+                    masterGain.panNode.disconnect();
+                }
             }
             OpSound.cleanup();
         };
@@ -244,15 +244,15 @@ class OscillatorLine {
 
     panit() {
         //insert pannode in between if necessary
-        if (this.pan !== 0 & !this.panNode) {
+        if (this.pan !== 0 && !this.masterGain.panNode) {
             this.masterGain.disconnect(this.audioCtx.destination);
-            this.panNode = this.audioCtx.createStereoPanner();
-            this.masterGain.connect(this.panNode);
-            this.panNode.connect(this.audioCtx.destination);
+            this.masterGain.panNode = this.audioCtx.createStereoPanner();
+            this.masterGain.connect(this.masterGain.panNode);
+            this.masterGain.panNode.connect(this.audioCtx.destination);
         }
         //update pan value
-        if (this.panNode)
-            this.panNode.pan.value = this.pan;
+        if (this.masterGain.panNode)
+            this.masterGain.panNode.pan.value = this.pan;
     }
 
     dampit() {


### PR DESCRIPTION
This PR enhances the cleaning of OpSound if panNodes are involved and furthermore a workaround to overwrite calls of oscNode.stop() for Safari has been introduced.