### PR TITLE
enhance compatibility OpSound

### DIFF
--- a/src/js/libcs/OpSound.js
+++ b/src/js/libcs/OpSound.js
@@ -132,7 +132,8 @@ var OpSound = {
         let audioCtx = this.getAudioContext();
         let gainNode = audioCtx.createGain();
         gainNode.gain.value = 0;
-        oscNode.connect(gainNode).connect(masterGain);
+        oscNode.connect(gainNode);
+        gainNode.connect(masterGain);
         OpSound.registerInput(masterGain);
         oscNode.start(0);
         oscNode.isplaying = true;


### PR DESCRIPTION
With this, OpSound works again on Safari on iOS.