### PR TITLE
TypeScript support

### DIFF
--- a/make/build.js
+++ b/make/build.js
@@ -5,6 +5,7 @@ var glob = require("glob");
 var path = require("path");
 var Q = require("q");
 var qfs = require("q-io/fs");
+var tsc = require("typescript-compiler");
 
 var getversion = require("./getversion");
 var src = require("./sources");
@@ -62,7 +63,17 @@ module.exports = function build(settings, task) {
         });
     });
 
-    task("plain", ["cs2js"], function() {
+    // TypeScript
+    task("ts2js", [], function() {
+        let tssrc = this.input(src.tssrc);
+        var dst = this.output("build/js/TSCompiled.js");
+        this.addJob(function() {
+	    return tsc.compile(tssrc, '--module commonjs --sourceMap -t ES5 --out ' + dst, null,
+	    function(e) { console.log(e.formattedMessage); throw e})
+	});
+    });
+
+    task("plain", ["cs2js", "ts2js"], function() {
         version(this);
         this.concat(src.srcs, "build/js/Cindy.plain.js");
     });

--- a/make/sources.js
+++ b/make/sources.js
@@ -8,6 +8,7 @@ exports.libcs = [
     "src/js/libcs/Essentials.js",
     "src/js/libcs/Namespace.js",
     "build/js/Compiled.js",
+    "build/js/TSCompiled.js",
     "src/js/libcs/Accessors.js",
     "src/js/libcs/Operators.js",
     "src/js/libcs/OpDrawing.js",
@@ -64,4 +65,9 @@ exports.scss = [
 exports.ifs = [
     "src/js/ifs/worker.js",
     "src/js/ifs/ifs.asm.js",
+];
+
+// TypeScript sources
+exports.tssrc = [
+    //"src/ts/example.ts",
 ];

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "source-map-dummy": "^1.0.0",
     "st": "^1.2.0",
     "touch": "^1.0.0",
+    "typescript-compiler": "^1.4.1-2",
     "whole-line-stream": "^0.1.0",
     "yauzl": "^2.6.0"
   },

--- a/tools/prepare-deploy.js
+++ b/tools/prepare-deploy.js
@@ -27,6 +27,8 @@ var handlers = {
     "CindyJS.css": true,
     "CindyJS.css.map": map,
     "Compiled.js": false,
+    "TSCompiled.js": false,
+    "TSCompiled.js.map": false,
     "ComplexCurves.js": true,
     "ComplexCurves.js.map": false,
     "ComplexCurves.plugin.js": false,


### PR DESCRIPTION
Hi! 

This PR adds support for TypeScript (TS). 

TS is a superset of JavaScript that adds a lot of useful (everything is optional) features, foremost typing, to JS. Then the whole source code is transpiled to plain JS. 

Type annotations are much more concise than using the closure compiler:

```
// TypeScript
function greeter(person: string) {
    return "Hello, " + person;
}

// Closure Compiler
/**
 * @param {string} person
 */
function greeter(person) {
    return "Hello, " + person;
}
``` 

One can benefit from compiler warnings and errors like this:
```
src/ts/example.ts(3,61): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
```

The 5 Minute intro to TS shows some of the features: https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html

I'm not sure if we are willing to adopt this, but at least I wanted to show that there is quite an easy way to get typing support.