### PR TITLE
Flip axes on negative height/width in `visibleRect`

### DIFF
--- a/src/js/libgeo/GeoState.js
+++ b/src/js/libgeo/GeoState.js
@@ -131,6 +131,11 @@ csport.scaleAndOrigin = function(scale, originX, originY) {
 csport.visibleRect = function(left, top, right, bottom) {
     var width = right - left;
     var height = top - bottom;
+    var flipY = false;
+    if(height < 0) {
+      height = -height;
+      flipY = true;
+    }
     var scale;
     if (csw * height < csh * width)
         scale = csw / width;
@@ -138,7 +143,15 @@ csport.visibleRect = function(left, top, right, bottom) {
         scale = csh / height;
     var originX = (csw - scale * (left + right)) / 2;
     var originY = (csh - scale * (top + bottom)) / 2;
-    csport.setMat(scale, 0, 0, scale, originX, originY);
+
+    // Handle Axis Flipping
+    var scaleY = scale;
+    if(flipY) {
+      scaleY = -scaleY;
+      originY = csh - originY;
+    }
+
+    csport.setMat(scale, 0, 0, scaleY, originX, originY);
 };
 
 // TODO: This function looks broken. It seems as if the linear

--- a/src/js/libgeo/GeoState.js
+++ b/src/js/libgeo/GeoState.js
@@ -132,10 +132,16 @@ csport.visibleRect = function(left, top, right, bottom) {
     var width = right - left;
     var height = top - bottom;
     var flipY = false;
+    var flipX = false;
     if(height < 0) {
       height = -height;
       flipY = true;
     }
+    if(width < 0) {
+      width = -width;
+      flipX = true;
+    }
+
     var scale;
     if (csw * height < csh * width)
         scale = csw / width;
@@ -146,12 +152,17 @@ csport.visibleRect = function(left, top, right, bottom) {
 
     // Handle Axis Flipping
     var scaleY = scale;
+    var scaleX = scale;
     if(flipY) {
       scaleY = -scaleY;
       originY = csh - originY;
     }
+    if(flipX) {
+      scaleX = -scaleX;
+      originX = csw - originX;
+    }
 
-    csport.setMat(scale, 0, 0, scaleY, originX, originY);
+    csport.setMat(scaleX, 0, 0, scaleY, originX, originY);
 };
 
 // TODO: This function looks broken. It seems as if the linear


### PR DESCRIPTION
Possible fix for #798. Allows for visibleRect values like `[0,0,10,10]`, which would place the origin at the top left corner, with the y-axis pointing downwards