### PR TITLE
Buttontext color

### DIFF
--- a/examples/Buttons2.html
+++ b/examples/Buttons2.html
@@ -34,7 +34,7 @@ CindyJS({
     {name: "Text6", type: "Text", pos: [4.0, -0.0, 0.8], color: [0.0, 0.0, 0.0], text: "Right text", align: "right"},
     {name: "Text7", type: "Text", pos: [4.0, 1.6, 0.8], color: [0.0, 0.0, 0.0], text: "middle | middle", align: "mid"},
     {name: "Text8", type: "Text", pos: [4.0, 3.2, 0.8], color: [0.0, 0.0, 0.0], text: "Left text", align: "left"},
-    {name: "Text9", type: "ToggleButton", pos: [0.0, -4.0, 2.0], color: [0.0, 0.0, 0.0], text: "$B_1$", pressed: true},
+    {name: "Text9", type: "ToggleButton", pos: [0.0, -4.0, 2.0], color: [1.0, 1.0, 1.0], alpha: 0.8, text: "$B_1$", pressed: true},
     {name: "Text10", type: "ToggleButton", pos: [4.0, -1.6, 0.8], color: [0.0, 0.0, 0.0], text: "$\\sum_{i=1}^n a_ix^i$"},
     {name: "Text11", type: "ToggleButton", pos: [4.0, -0.8, 0.4], color: [0.0, 0.0, 0.0], text: "Button $B_2$ or $\\R^2$"}
   ],

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -46,7 +46,7 @@ geoOps._helper.getRandPointMove = function(el) {
     var ozabs = CSNumber.abs(oz).value.real;
 
     var rZ = CSNumber.real(0);
-    // far points 
+    // far points
     if (ozabs < CSNumber.eps) {
         rZ = CSNumber.getRandComplex(-0.05, 0.05);
         oz = CSNumber.real(1);
@@ -909,7 +909,7 @@ geoOps.CircleMr.updatePosition = function(el) {
     el.radius = r;
 };
 geoOps.CircleMr.getRandomMove = function(el) {
-    // radius 
+    // radius
     var r;
     var oldr = el.radius;
     var oabs = CSNumber.abs(oldr).value.real;
@@ -1475,7 +1475,7 @@ geoOps.ConicBy2Foci1P.updatePosition = function(el) {
     co1 = List.normalizeMax(List.adjoint3(co1));
     co2 = List.normalizeMax(List.adjoint3(co2));
 
-    // return ellipsoid first 
+    // return ellipsoid first
     if (geoOps._helper.getConicType(co1) !== "ellipsoid") {
         var temp = co1;
         co1 = co2;
@@ -3204,6 +3204,12 @@ function commonButton(el, event, button) {
         el.html.style.backgroundColor =
             Render2D.makeColor(el.fillcolor, el.fillalpha);
     }
+    if (!isFiniteNumber(el.alpha))
+        el.alpha = 1.0;
+    if (el.color) {
+        el.html.style.color =
+            Render2D.makeColor(el.color, el.alpha);
+    }
     var onEvent = scheduleUpdate;
     if (el.script) {
         var code = analyse(el.script);
@@ -3251,6 +3257,15 @@ geoOps.Button.set_fillcolor = function(el, value) {
             Render2D.makeColor(el.fillcolor, el.fillalpha);
     }
 };
+geoOps.Button.set_color = function(el, value) {
+    if (List._helper.isNumberVecN(value, 3)) {
+        el.color = value.value.map(function(i) {
+            return i.value.real;
+        });
+        el.html.style.color =
+            Render2D.makeColor(el.color, el.alpha);
+    }
+};
 
 geoOps.ToggleButton = {};
 geoOps.ToggleButton.kind = "Text";
@@ -3273,6 +3288,7 @@ geoOps.ToggleButton.getParamForInput = geoOps.Text.getParamForInput;
 geoOps.ToggleButton.getParamFromState = geoOps.Text.getParamFromState;
 geoOps.ToggleButton.putParamToState = geoOps.Text.putParamToState;
 geoOps.ToggleButton.set_fillcolor = geoOps.Button.set_fillcolor;
+geoOps.ToggleButton.set_color = geoOps.Button.set_color;
 
 geoOps.EditableText = {};
 geoOps.EditableText.kind = "Text";
@@ -3305,6 +3321,7 @@ geoOps.EditableText.getParamForInput = geoOps.Text.getParamForInput;
 geoOps.EditableText.getParamFromState = geoOps.Text.getParamFromState;
 geoOps.EditableText.putParamToState = geoOps.Text.putParamToState;
 geoOps.EditableText.set_fillcolor = geoOps.Button.set_fillcolor;
+geoOps.EditableText.set_color = geoOps.Button.set_color;
 geoOps.EditableText.get_currenttext = function(el) {
     return General.string(String(el.html.value));
 };


### PR DESCRIPTION
In http://www.mathe-vital.de/Physik/7-1.html the two ToggleButtons Strahlen and Ränder should have white text specified by the `color: [1.0, 1.0, 1.0]` attribute.

This PR implements this behaviour for Buttons together with the `alpha` attribute.