### PR TITLE
Snap distance

### DIFF
--- a/examples/158_more_snap.html
+++ b/examples/158_more_snap.html
@@ -53,6 +53,7 @@ var cdy = CindyJS({
     axes: true,
     grid: 1.0,
     snap: true,
+    snapdistance: 0.1,
     background: "rgb(168,176,192)"
   }],
   csconsole: false,

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -50,6 +50,7 @@ var csgridsize = 0;
 var cstgrid = 0;
 var csgridscript;
 var cssnap = false;
+var cssnapDistance = 0.2;
 var csaxes = false;
 
 //virtual resolution
@@ -268,6 +269,8 @@ function createCindyNow() {
                 cstgrid = port.tgrid;
             if (port.snap)
                 cssnap = true;
+            if (port.snapdistance && Number.isFinite(port.snapdistance))
+                cssnapDistance = Math.max(port.snapdistance, 0);
             if (port.axes)
                 csaxes = true;
         }
@@ -359,6 +362,9 @@ function createCindyNow() {
     }
     if (data.snap) {
         cssnap = true;
+    }
+    if (data.snapdistance && Number.isFinite(data.snapdistance)) {
+        cssnapDistance = Math.max(data.snapdistance, 0);
     }
 
     csgeo = {};

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -417,7 +417,7 @@ geoOps.Free.getParamForInput = function(el, pos, type) {
         var sy = pos.value[1].value.real;
         var rx = Math.round(sx / csgridsize) * csgridsize;
         var ry = Math.round(sy / csgridsize) * csgridsize;
-        if (Math.abs(rx - sx) < 0.2 && Math.abs(ry - sy) < 0.2) {
+        if (Math.abs(rx - sx) < cssnapDistance && Math.abs(ry - sy) < cssnapDistance) {
             pos = List.realVector([rx, ry, 1]);
         }
     }
@@ -3590,7 +3590,7 @@ geoOps._helper.snapPointToLine = function(pos, line) {
     var rx = Math.round(sx / csgridsize) * csgridsize;
     var ry = Math.round(sy / csgridsize) * csgridsize;
     var newpos = List.realVector([rx, ry, 1]);
-    if (Math.abs(rx - sx) < 0.2 && Math.abs(ry - sy) < 0.2 &&
+    if (Math.abs(rx - sx) < cssnapDistance && Math.abs(ry - sy) < cssnapDistance &&
         CSNumber._helper.isAlmostZero(List.scalproduct(line, newpos))) {
         pos = geoOps._helper.projectPointToLine(newpos, line);
     }


### PR DESCRIPTION
Currently the distance that triggers snap is fixed to 0.2 and hardcoded. In #806 it was argued that this is inflexible and I agree. This PR adds a snapdistance parameter to adjust the snap distance.