### PR TITLE
Fix snap distance

### DIFF
--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -269,7 +269,7 @@ function createCindyNow() {
                 cstgrid = port.tgrid;
             if (port.snap)
                 cssnap = true;
-            if (port.snapdistance && Number.isFinite(port.snapdistance))
+            if (Number.isFinite(port.snapdistance))
                 cssnapDistance = Math.max(port.snapdistance, 0);
             if (port.axes)
                 csaxes = true;
@@ -363,7 +363,7 @@ function createCindyNow() {
     if (data.snap) {
         cssnap = true;
     }
-    if (data.snapdistance && Number.isFinite(data.snapdistance)) {
+    if (Number.isFinite(data.snapdistance)) {
         cssnapDistance = Math.max(data.snapdistance, 0);
     }
 


### PR DESCRIPTION
Well this is a bit embarrassing, but nevertheless: the check for snap distance contains a bug:

In order to check if ```port.snapdistance``` exists, the code evaluated ```port.snapdistance``` which is correct of it would be an object, but this is of type number and therefore 0 would evaluate to false, which is unintended.

I really hope that https://github.com/tc39/proposal-optional-chaining is coming soon, to prevent such bugs.

Sorry for that! 