### PR TITLE
No es7-shim due to bad performance

### DIFF
--- a/editor/export.js
+++ b/editor/export.js
@@ -116,7 +116,7 @@ var Export = {
         </style>
         <link rel="stylesheet" href="https://cindyjs.org/dist/latest/CindyJS.css">
         <script type="text/javascript" src="https://cindyjs.org/dist/latest/Cindy.js"></script>
-        ${(configuration.use.indexOf("CindyGL")!=-1) ? '<script type="text/javascript" src="https://cindyjs.org/dist/latest/CindyGL.js"></script>' : ''}
+        ${(configuration.use.indexOf("CindyGL") !== -1) ? '<script type="text/javascript" src="https://cindyjs.org/dist/latest/CindyGL.js"></script>' : ''}
         
         ${csscripts}
     

--- a/make/sources.js
+++ b/make/sources.js
@@ -41,8 +41,7 @@ exports.liblab = [
 exports.lib = [
     "node_modules/iphone-inline-video/dist/iphone-inline-video.min.js",
     "lib/clipper/clipper.js",
-    "node_modules/es6-shim/es6-shim.min.js",
-    "node_modules/es7-shim/dist/es7-shim.min.js",
+    "node_modules/es6-shim/es6-shim.min.js"
 ];
 
 exports.cssrc = [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "chokidar": "^1.6.0",
     "concat-with-sourcemaps": "^1.0.4",
     "es6-shim": "^0.35.3",
-    "es7-shim": "^6.0.0",
     "gl-matrix": "^2.8.1",
     "glob": "^7.0.3",
     "http-proxy": "^1.11.2",

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -220,7 +220,7 @@ CodeBuilder.prototype.determineVariables = function(expr, bindings) {
         for (let i in expr['args']) {
             let needtobeconstant = forceconstant || (expr['oper'] === "repeat$2" && i == 0) || (expr['oper'] === "repeat$3" && i == 0) || (expr['oper'] === "_" && i == 1);
             let nbindings = bindings;
-            if (["repeat", "forall", "apply"].indexOf(getPlainName(expr['oper'])) != -1) {
+            if (["repeat", "forall", "apply"].indexOf(getPlainName(expr['oper'])) !== -1) {
                 if (i == 1) {
                     nbindings = (expr['oper'] === "repeat$2") ? addvar(bindings, '#', type.int) :
                         (expr['oper'] === "repeat$3") ? addvar(bindings, expr['args'][1]['name'], type.int) :
@@ -400,7 +400,7 @@ CodeBuilder.prototype.determineUniforms = function(expr) {
             'randomnormal',
             'verbatimglsl' //we dont analyse verbatimglsl functions
         ];
-        if (expr['ctype'] === 'function' && alwaysPixelDependent.indexOf(getPlainName(expr['oper'])) != -1) {
+        if (expr['ctype'] === 'function' && alwaysPixelDependent.indexOf(getPlainName(expr['oper'])) !== -1) {
             return expr["dependsOnPixel"] = true;
         }
 

--- a/plugins/cindyleap/src/js/leap-0.6.4.js
+++ b/plugins/cindyleap/src/js/leap-0.6.4.js
@@ -1050,7 +1050,7 @@ Controller.plugins = function() {
 
 var setPluginCallbacks = function(pluginName, type, callback){
   
-  if ( ['beforeFrameCreated', 'afterFrameCreated'].indexOf(type) != -1 ){
+  if ( ['beforeFrameCreated', 'afterFrameCreated'].indexOf(type) !== -1 ){
     
       // todo - not able to "unuse" a plugin currently
       this.on(type, callback);
@@ -8397,7 +8397,7 @@ if(typeof(exports) !== 'undefined') {
   // Aliased as `include`.
   _.contains = _.include = function(obj, target) {
     if (obj == null) return false;
-    if (nativeIndexOf && obj.indexOf === nativeIndexOf) return obj.indexOf(target) != -1;
+    if (nativeIndexOf && obj.indexOf === nativeIndexOf) return obj.indexOf(target) !== -1;
     return any(obj, function(value) {
       return value === target;
     });

--- a/plugins/cindyprint/src/js/MeshGraph.js
+++ b/plugins/cindyprint/src/js/MeshGraph.js
@@ -59,10 +59,10 @@ function MeshGraph(triangleMesh, orderIndices = true) {
  * Adds an (undirected) edge between the nodes i and j.
  */
 MeshGraph.prototype.addEdge = function(i, j) {
-	if (this.nodes[i].neighbors.includes(j)) {
+	if (this.nodes[i].neighbors.indexOf(j) !== -1) {
 		// Edge exists already. Just increase count of the edge.
 		for (let edgeIndex = 0; edgeIndex < this.nodes[i].edges.length; edgeIndex++) {
-			if (this.nodes[i].edges[edgeIndex].connectedNodes.includes(j)) {
+			if (this.nodes[i].edges[edgeIndex].connectedNodes.indexOf(j) !== -1) {
 				this.nodes[i].edges[edgeIndex].meshEdgeCount += 1;
 			}
 		}
@@ -118,7 +118,7 @@ MeshGraph.prototype.isFullyConnected = function() {
 
 		for (let i = 0; i < currentNode.neighbors.length; i++) {
 			let neighborIndex = currentNode.neighbors[i];
-			if (!closedSet.has(neighborIndex) && !bfsQueue.includes(neighborIndex)) {
+			if (!closedSet.has(neighborIndex) && !bfsQueue.indexOf(neighborIndex) !== -1) {
 				bfsQueue.push(neighborIndex);
 			}
 		}

--- a/plugins/cindyprint/src/js/csg/SimpleShell.js
+++ b/plugins/cindyprint/src/js/csg/SimpleShell.js
@@ -146,7 +146,7 @@ function getBorderEdgeLoops(meshGraph) {
 				let nextEdge = null;
 				for (let j = 0; j < meshGraph.edges.length; j++) {
 					if (meshGraph.edges[j].meshEdgeCount == 1
-							&& meshGraph.edges[j].connectedNodes.includes(i1)
+							&& meshGraph.edges[j].connectedNodes.indexOf(i1) !== -1
 							&& !visitedEdges.has(meshGraph.edges[j])) {
 						nextEdge = meshGraph.edges[j];
 						break;

--- a/src/js/libcs/Accessors.js
+++ b/src/js/libcs/Accessors.js
@@ -326,7 +326,7 @@ Accessor.setField = function(geo, field, value) {
         }
     }
 
-    if (field === "narrow" && ["P", "C"].includes(geo.kind)) {
+    if (field === "narrow" && ["P", "C"].indexOf(geo.kind) !== -1) {
         if (value.ctype === "boolean") geo.narrow = value.value;
         if (value.ctype === "number" && CSNumber._helper.isAlmostReal(value)) geo.narrow = value.value.real;
     }

--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -74,7 +74,7 @@ Json._helper.forall = function(li, runVar, fct, modifs) { // JSON
     if (modifs.iterator !== undefined) {
         let it = evaluate(modifs.iterator);
         let iterTypes = ["key", "value", "pair"];
-        if (it.ctype === 'string' && iterTypes.includes(it.value)) {
+        if (it.ctype === 'string' && iterTypes.indexOf(it.value) !== -1) {
             iteratorType = it.value;
         }
     }

--- a/src/js/libcs/OpSound.js
+++ b/src/js/libcs/OpSound.js
@@ -476,7 +476,7 @@ evaluator.playfunction$1 = function(args, modifs) {
         while (stack.length !== 0) { //DFS with handwritten stack.
             let v = stack.pop();
             if (v.ctype === "variable" && evaluate(v) === nada) {
-                if (["x", "y", "t"].includes(v.name))
+                if (["x", "y", "t"].indexOf(v.name) !== -1)
                     return v.name;
             }
             if (v.args) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -532,7 +532,7 @@ eval_helper.assigntake = function(data, what) { //TODO: Bin nicht ganz sicher ob
     }
     if (where.ctype === 'JSON') {
         const key = niceprint(ind);
-        if (!niceprint.errorTypes.includes(key)) {
+        if (!niceprint.errorTypes.indexOf(key) !== -1) {
             rhs = Json._helper.ShallowClone(where);
             rhs.value[key] = evaluate(what);
         }
@@ -2633,7 +2633,7 @@ function infix_take(args, modifs) {
         }
     } else if (v0.ctype === "JSON") {
         let np = niceprint(v1);
-        if (niceprint.errorTypes.includes(np)) {
+        if (niceprint.errorTypes.indexOf(np) !== -1) {
             return nada;
         }
         let val = v0.value[np];

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -532,7 +532,7 @@ eval_helper.assigntake = function(data, what) { //TODO: Bin nicht ganz sicher ob
     }
     if (where.ctype === 'JSON') {
         const key = niceprint(ind);
-        if (!niceprint.errorTypes.indexOf(key) !== -1) {
+        if (niceprint.errorTypes.indexOf(key) === -1) {
             rhs = Json._helper.ShallowClone(where);
             rhs.value[key] = evaluate(what);
         }


### PR DESCRIPTION
After being unhappy with the performance of a page that used several CindyJS instances in iframes, I did some performance profiling, and I realized that initializing the `es7-shim`, introduced in #672, takes more than 100ms on a modern machine running Chromium v80. On mobile devices, this overhead might be even higher. Dropping the `es7-shim`, the total initialization time for small CindyJS-applets drops to less than 50ms.
I feel we should avoid this dependence as I have the impression that we hardly used any ES7 features.
So far I have replaced
* all occurrences of `Array.prototype.includes`, which is an ES7 feature, with `indexOf(...)!=-1`.

Did I miss something? Did we use ES7 features at some place that we could easily replace with ES6?

@strobelm Please let me know if you do not have time for reviewing anymore.