### PR TITLE
Fix json precedence through individual parsing

### DIFF
--- a/src/js/libcs/Json.js
+++ b/src/js/libcs/Json.js
@@ -36,9 +36,8 @@ Json.setField = function(where, field, what) {
 };
 
 Json.GenFromUserDataEl = function(el) {
-    // key/obj are reversed due to the semantics of the ":" operator in CindyScript
-    var key = el.obj;
-    var obj = el.key;
+    var key = el.key;
+    var obj = el.value;
 
     if (!key || key.ctype !== "string") {
         console.log("Error: JSON keys have to be strings.");

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -688,6 +688,10 @@ Parser.prototype.postprocess = function(expr) {
             }
             if (expr.oper === ':') {
                 if (expr.jsonatom) {
+                    if (!(expr.args[1])) {
+                        throw ParseError(
+                            'JSON: Value undefined', expr.start, expr.text);
+                    }
                     expr.ctype = 'jsonatom';
                     expr.key = expr.args[0];
                     expr.value = expr.args[1];
@@ -695,7 +699,7 @@ Parser.prototype.postprocess = function(expr) {
                 } else {
                     if (!(expr.args[1])) {
                         throw ParseError(
-                            'UserData/JSON: Key or Value undefined', expr.start, expr.text);
+                            'UserData: Key undefined', expr.start, expr.text);
                     }
                     expr.ctype = 'userdata';
                     expr.obj = expr.args[0];

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -453,6 +453,7 @@ function parseRec(tokens, closing) {
     // in the sequence can have equal precedence.
     var seq = [];
     var tok; // last token to be processed
+    var parsejsonatom = (closing === "}");
     parseLoop: while (true) {
         tok = tokens.next();
         switch (tok.toktype) {
@@ -474,6 +475,14 @@ function parseRec(tokens, closing) {
                     applyOperator(seq);
                 if (op.rassoc)
                     tok.precedence++;
+                if (parsejsonatom && op.sym === ":") {
+                    tok.jsonatom = true;
+                    tok.precedence = operators[','].precedence; //use different precedence for JSON
+                    parsejsonatom = false;
+                }
+                if (closing === "}" &&
+                    (op.sym === "," && seq.length > 0 && (!!seq[seq.length - 1].jsonatom)))
+                    parsejsonatom = true;
                 seq.push(tok);
                 break;
             case 'ID':
@@ -678,13 +687,21 @@ Parser.prototype.postprocess = function(expr) {
                 delete expr.args;
             }
             if (expr.oper === ':') {
-                if (!(expr.args[1])) {
-                    throw ParseError(
-                        'UserData/JSON: Key or Value undefined', expr.start, expr.text);
+                if (expr.jsonatom) {
+                    expr.ctype = 'jsonatom';
+                    expr.key = expr.args[0];
+                    expr.value = expr.args[1];
+                    delete expr.jsonatom;
+                } else {
+                    if (!(expr.args[1])) {
+                        throw ParseError(
+                            'UserData/JSON: Key or Value undefined', expr.start, expr.text);
+                    }
+                    expr.ctype = 'userdata';
+                    expr.obj = expr.args[0];
+                    expr.key = expr.args[1];
                 }
-                expr.ctype = 'userdata';
-                expr.obj = expr.args[0];
-                expr.key = expr.args[1];
+
 
                 delete expr.args;
             }
@@ -754,6 +771,13 @@ Parser.prototype.postprocess = function(expr) {
             ctype: 'userdata',
             obj: expr.obj,
             key: expr.key,
+        };
+    }
+    if (expr.ctype === 'jsonatom') {
+        return {
+            ctype: 'jsonatom',
+            key: expr.key,
+            value: expr.value,
         };
     }
     throw Error("Unsupported AST node of type " + expr.ctype);

--- a/tests/JSON_tests.js
+++ b/tests/JSON_tests.js
@@ -112,4 +112,16 @@ describe("JSON operations", function(){
     //deleting keys from a dictionary
     itCmd('json = {"a":1, "b": 2}; json.a = nada; keys(json)','[b]');
 
+
+    //expressions on the right hand side
+    itCmd('{"a":1+1}','{a:2}');
+
+    //user-data sanity check
+    itCmd('A:"a"=41; A:"a1"=100; A:"a"+1', '42');
+
+    //user-data together with JSON
+    itCmd('A:"x"=100; {"a":A:"x"*2,"b":3} ', '{a:200, b:3}');
+
+    //complicated nested JSON with user-data
+    itCmd('A:"x"=100; {"a":A:"x"*2,"b":{"c":1+3, "ef": [1,2,3, A:"x"], "ghi": "jkl"}} ', '{a:200, b:{c:4, ef:[1, 2, 3, 100], ghi:jkl}}');
 });


### PR DESCRIPTION
This PR should fix #819 without changing the functionality of the userdata-operator (this side effect occurred in https://github.com/CindyJS/CindyJS/pull/820).

In particular, constructions such as
```
A:"x"=100;
errc({"a":A:"x"*2,"b":3}); // ===> {a:200, b:3}
```
should now be parsed and interpreted well. 
