### PR TITLE
Use forked version of leapjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "iphone-inline-video": "2.0.2",
     "js-beautify": "1.6.8",
     "jshint": "^2.10.2",
-    "leapjs": "^0.6.4",
+    "leapjs": "github:CindyJS/leapjs",
     "marked": ">=0.3.5 <=0.3.12",
     "mocha": "^5.2.0",
     "node-sass": "^4.12.0",


### PR DESCRIPTION
The forked version of leapjs is compatible with the recent version of
nodejs. Thank @chrismile for pointing out this.