### PR TITLE
Enable setting of Texts

### DIFF
--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -3106,6 +3106,9 @@ geoOps.Text.initialize = function(el) {
             el.dock.offset = List.realVector([0, 0]);
     }
 };
+geoOps.Text.set_text = function(el, value) {
+   el.text = niceprint(value);
+};
 geoOps.Text.getParamForInput = function(el, pos, type) {
     return geoOps.Free.getParamForInput(el, pos, type);
 };


### PR DESCRIPTION
A student complained that CindyJS is not compatible with Cinderella when setting .text attributes of texts. This should enable setting this attribute.