### PR TITLE
Fix download of text files in CindyPrint

### DIFF
--- a/plugins/cindyprint/src/js/DownloadFile.js
+++ b/plugins/cindyprint/src/js/DownloadFile.js
@@ -5,7 +5,7 @@
  */
 function downloadTextFile(filename, fileContent) {
 	let blob = new Blob([fileContent], { type : "text/plain;charset=utf-8" });
-	downloadBlobAsFile(blob);
+	downloadBlobAsFile(filename, blob);
 }
 
 /**


### PR DESCRIPTION
`downloadTextFile` in plugins/cindyprint/src/js/DownloadFile.js fails to pass the file name parameter to `downloadBlobAsFile`. This PR fixes the problem.
It seems like I didn't test this well, as CindyPrint by default uses binary meshes instead of textual representations in its final version (due to smaller sizes and more performant parsing of binary meshes).