### PR TITLE
correct modifier name xoffset and yoffset 

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1036,8 +1036,8 @@ evaluator.drawtable$2 = function (args, modifs) {
         italics: true,
         family: true,
         align: true,
-        x_offset: true,
-        y_offset: true,
+        xoffset: true,
+        yoffset: true,
         offset: true,
         width: function (v) {
             if (v.ctype === "number") sx = v.value.real;

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -620,7 +620,7 @@ eval_helper.assigncolon = function (data, what) {
         infix_assign([lhs, rhs]);
     } else {
         if (!(key && key.ctype === "string")) console.log("Key is undefined");
-        else console.log("User data can only be assigned to geo objects and lists.");
+        else console.log("User data " + key.value + " can only be assigned to geo objects and lists, not to "+where.ctype);
     }
 
     return nada;
@@ -653,7 +653,7 @@ eval_helper.assigncolonNoVal = function (data, what) {
         infix_assign([lhs, rhs]);
     } else {
         if (!(key && key.ctype === "string")) console.log("Key is undefined");
-        else console.log("User data can only be assigned to geo objects and lists.");
+        else console.log("User data " + key.value + " can only be assigned to geo objects and lists, not to "+where.ctype);
     }
 
     return nada;

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -251,11 +251,11 @@ Render2D.modifHandlers = {
         }
     },
 
-    x_offset: function (v) {
+    xoffset: function (v) {
         if (v.ctype === "number") Render2D.xOffset = v.value.real;
     },
 
-    y_offset: function (v) {
+    yoffset: function (v) {
         if (v.ctype === "number") Render2D.yOffset = v.value.real;
     },
 
@@ -357,8 +357,8 @@ Render2D.textModifs = {
     family: true,
     align: true,
     angle: true,
-    x_offset: true,
-    y_offset: true,
+    xoffset: true,
+    yoffset: true,
     offset: true,
 };
 

--- a/src/js/libgeo/GeoRender.js
+++ b/src/js/libgeo/GeoRender.js
@@ -22,8 +22,8 @@ function drawlabel(el, lbl, pos, lpos, color) {
 
     var alpha = el.alpha || CSNumber.real(defaultAppearance.alpha);
     eval_helper.drawtext([pos, General.wrap(lbl)], {
-        x_offset: General.wrap(factor * lpos.x),
-        y_offset: General.wrap(factor * lpos.y),
+        xoffset: General.wrap(factor * lpos.x),
+        yoffset: General.wrap(factor * lpos.y),
         size: General.wrap(textsize),
         bold: General.wrap(bold),
         italics: General.wrap(italics),


### PR DESCRIPTION
The modifier names are xoffset and yoffset instead of x_offset and y_offset (which cannot be parsed anyway). I do not know how these sneaked in, but it is a straightforward fix to remove the ugly _ character.

Fixes  #862.