### PR TITLE
do not print stack trace  when if condition is undefined

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -823,7 +823,7 @@ evaluator.if$3 = function (args, modifs) {
         } else if (args.length === 3) {
             return evaluate(args[2]);
         }
-    } else {
+    } else if (v0.ctype !== "undefined") {
         printStackTrace("Condition for if is not boolean");
     }
 

--- a/tests/Operators_tests.js
+++ b/tests/Operators_tests.js
@@ -32,3 +32,9 @@ describe("Reverse", function () {
     itCmd("reverse([1, 2, 3])", "[3, 2, 1]");
     itCmd('reverse("Hello")', "olleH");
 });
+
+describe("if", function() {
+	itCmd('isundefined(if(blabla,"a","b"))',"true");
+	itCmd('if(true,"a","b")',"a");
+	itCmd('if(false,"a","b")',"b");
+})


### PR DESCRIPTION
This fixes #868 - there should be no stack trace when the if condition is undefined.