### PR TITLE
Fix to prefer WebGL 2.0 to GL_EXT_frag_depth

### DIFF
--- a/examples/cindygl/77_thetaviewer.html
+++ b/examples/cindygl/77_thetaviewer.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Webcam in Cindy JS</title>
+        <meta charset="UTF-8" />
+        <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+        <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+        <script id="csinit" type="text/x-cindyscript">
+            video = camera video();
+            createimage("output", 1920, 960);
+            createimage("output2", 1920, 960);
+            //createimage("output", 480, 240);
+            //createimage("output2", 480, 240);
+			
+        </script>
+        <script id="csdraw" type="text/x-cindyscript">
+			min=1000;
+            if (image ready(video),
+              //draw image (A, B, video);
+              colorplot("output",imagergb(video, #));			
+              colorplot("output2", imagergb(video,(mod(#.x+E.x+10.2,20.4),#.y)));
+			  
+            );
+			drawimage(A,B,"output");
+			drawimage(C,D,"output2");
+        </script>
+        <script type="text/javascript">
+            var cdy = CindyJS({
+                ports: [{ id: "CSCanvas", transform: [{ visibleRect: [-0.4, 20.4, 20.4, -0.4] }] }],
+                scripts: "cs*",
+                language: "en",
+                defaultAppearance: {},
+                geometry: [
+                    { name: "A", type: "Free", pos: [0, 10.21] },
+                    { name: "B", type: "Free", pos: [20, 10.1] },
+
+                    { name: "C", type: "Free", pos: [0, -.1] },
+                    { name: "D", type: "Free", pos: [20, -.1] },
+                    { name: "E", type: "Free", pos: [5, 14.5] },
+                ],
+                use: ["CindyGL"],
+            });
+        </script>
+    </head>
+
+    <body style="font-family: Arial">
+        <div id="CSCanvas" style="width: 840px; height: 840px; border: 2px solid black"></div>
+    </body>
+</html>

--- a/examples/cindygl/78_thetaviewer-2.html
+++ b/examples/cindygl/78_thetaviewer-2.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Webcam in Cindy JS</title>
+        <meta charset="UTF-8" />
+        <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+        <script type="text/javascript" src="../../build/js/CindyGL.js"></script>
+        <script id="csinit" type="text/x-cindyscript">
+            video = camera video();
+            createimage("output2", 1920, 960);
+			
+			coordtoangle(x,y):=(x/20.4*2*π, y/20.4*2*π-π/2);
+			err(mod(20.5,20.4));
+        </script>
+        <script id="csdraw" type="text/x-cindyscript">
+			min=1000;
+            if (image ready(video),
+				drawimage(A,B,video);
+	            //  	colorplot("output2", imagergb(video,(mod(#.x+E.x+10.20,20.4),#.y)));
+	            colorplot("output2",
+					angles = coordtoangle(mod(#.x+E.x+10.20,20.4),#.y);
+					imagergb(video,#);
+				);
+				drawimage(C,D,"output2");
+			);
+        </script>
+        <script type="text/javascript">
+            var cdy = CindyJS({
+                ports: [{ id: "CSCanvas", transform: [{ visibleRect: [-0.4, 20.4, 20.4, -0.4] }] }],
+                scripts: "cs*",
+                language: "en",
+                defaultAppearance: {},
+                geometry: [
+                    { name: "A", type: "Free", pos: [0, 10.21] },
+                    { name: "B", type: "Free", pos: [20, 10.1] },
+
+                    { name: "C", type: "Free", pos: [0, -.1] },
+                    { name: "D", type: "Free", pos: [20, -.1] },
+                    { name: "E", type: "Free", pos: [5, 14.5] },
+                ],
+                use: ["CindyGL"],
+            });
+        </script>
+    </head>
+
+    <body style="font-family: Arial">
+        <div id="CSCanvas" style="width: 840px; height: 840px; border: 2px solid black"></div>
+    </body>
+</html>

--- a/plugins/cindy3d/src/str/common-frag.glsl
+++ b/plugins/cindy3d/src/str/common-frag.glsl
@@ -23,14 +23,14 @@ vec3 sphere(in vec3 ray, in vec3 center, in float radius, in float face) {
   return lambda * dir;
 }
 
-void finish(in vec3 pos, in vec3 normal) {
-  shade(pos, normal);
-#ifdef GL_EXT_frag_depth
-  vec4 projPoint = uProjectionMatrix * vec4(pos, 1);
-  gl_FragDepthEXT = (projPoint.z / projPoint.w + 1.0) / 2.0;
-#endif
+void finish(in vec3 pos,in vec3 normal){
+shade(pos,normal);
+vec4 projPoint=uProjectionMatrix*vec4(pos,1);
 #ifdef webgl2
-  vec4 projPoint = uProjectionMatrix * vec4(pos, 1);
-  gl_FragDepth = (projPoint.z / projPoint.w + 1.0) / 2.0;
+gl_FragDepth= (projPoint.z/projPoint.w+1.0) /2.0;
+#else
+#ifdef GL_EXT_frag_depth
+gl_FragDepthEXT= (projPoint.z/projPoint.w+1.0) /2.0;
+#endif
 #endif
 }


### PR DESCRIPTION
The shader code in Cindy3D used gl_FragDepthEXT when the GL_EXT_frag_depth extension is available, although WebGL 2.0 supports gl_FragDepth without using an extension. This made the Cindy3D plugin fail on the recent versions of Safari.

This fix now prefers the WebGL 2.0 version when available. I could not figure out why the extension claims to be available on WebGL 2.0, and why it does not work then, but I don't think that we should care too much about it.