### PR TITLE
Fix travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ deploy:
       on:
           repo: CindyJS/CindyJS
           branch: main
+			skip_cleanup: true
     - provider: script
       script: tools/travis-deploy.sh
       on:
           repo: CindyJS/CindyJS
           tags: true
           condition: "${TRAVIS_TAG} == v*([0-9]).*([0-9]).*([0-9])"
+			skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ deploy:
       on:
           repo: CindyJS/CindyJS
           branch: main
-			skip_cleanup: true
+      skip_cleanup: true
     - provider: script
       script: tools/travis-deploy.sh
       on:
           repo: CindyJS/CindyJS
           tags: true
           condition: "${TRAVIS_TAG} == v*([0-9]).*([0-9]).*([0-9])"
-			skip_cleanup: true
+      skip_cleanup: true


### PR DESCRIPTION
Seems like I was a bit too overoptimistic with the cleanup. We use a custom deployment script that was removed by the cleanup and hence the deployment was not working. I think re-adding the clean up skip should fix the issue. 