### PR TITLE
Enable access to JSON objects via : notation; enable code storage

### DIFF
--- a/examples/cmdline.html
+++ b/examples/cmdline.html
@@ -14,7 +14,7 @@
                 inp = document.getElementById("inp");
                 function doit() {
                     var i = inp.value;
-                    var t1 = document.createTextNode("> " + i);
+                    var t1 = document.createTextNode("In["+count+"]=" + i);
                     var p1 = document.createElement("p");
                     var s = document.createElement("span");
                     p1.appendChild(t1);
@@ -25,13 +25,21 @@
                     console.log(o1);
                     var o2 = cindy.niceprint(o1);
                     console.log(o2);
-                    var t2 = document.createTextNode("< " + o2);
+                    var t2 = document.createTextNode("out["+count+"]=" + o2);
                     var p2 = document.createElement("p");
                     p2.appendChild(t2);
                     s.appendChild(p2);
                     inp.value = "";
+                    inp.scrollIntoView();
+                    count=count+1;
                 }
+                document.getElementById("inp").onkeypress = function(event) {
+                    if (event.key == "Enter") {
+                        doit();
+                    }
+                };
                 document.getElementById("do").onclick = doit;
+                count=1;
             });
         </script>
     </head>

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -9,9 +9,9 @@ import { namespace } from "libcs/Namespace";
 import { Accessor } from "libcs/Accessors";
 import { Parser } from "libcs/Parser";
 
-//****************************************************************
-// this function is responsible for evaluation an expression tree
-//****************************************************************
+//*******************************************
+// this function evaluates an expression tree
+//*******************************************
 
 function evaluate(a) {
     if (a === undefined) {
@@ -41,7 +41,7 @@ function evaluate(a) {
             return List.getField(obj, a.key);
         }
         if (obj.ctype === "JSON") {
-            return Json.getField(obj, a.key);
+            return evaluate(Json.getField(obj, a.key));
         }
         return nada;
     }

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -35,7 +35,7 @@ function evaluate(a) {
     if (a.ctype === "field") {
         var obj = evaluate(a.obj);
         if (obj.ctype === "geo") {
-            return Accessor.getField(obj.value, a.key);
+            return evaluate(Accessor.getField(obj.value, a.key));
         }
         if (obj.ctype === "list") {
             return List.getField(obj, a.key);
@@ -55,6 +55,9 @@ function evaluate(a) {
         }
         if (uobj.ctype === "list" || uobj.ctype === "string") {
             return evaluate(Accessor.getuserData(uobj, key));
+        }
+        if (uobj.ctype === "JSON") {
+            return evaluate(Json.getField(uobj, key.value));
         }
         return nada;
     }

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -602,7 +602,6 @@ eval_helper.assigndotNoVal = function (data, what) {
         Accessor.setField(where.value, field, what);
     }
     if (where.ctype === "JSON" && typeof field === "string") {
-        console.log(evaluate(what));
         Json.setField(where.value, field, what);
     }
 
@@ -618,6 +617,8 @@ eval_helper.assigncolon = function (data, what) {
 
     if (where.ctype === "geo" && key) {
         Accessor.setuserData(where.value, key, evaluateAndVal(what));
+    } else if (where.ctype === "JSON" && key) {
+        Json.setField(where.value, key.value, evaluateAndVal(what));
     } else if (where.ctype === "list" || (where.ctype === "string" && key)) {
         var rhs = { ...where };
 
@@ -653,6 +654,8 @@ eval_helper.assigncolonNoVal = function (data, what) {
 
     if (where.ctype === "geo" && key) {
         Accessor.setuserData(where.value, key, evaluate(what));
+    } else if (where.ctype === "JSON" && key) {
+        Json.setField(where.value, key.value, what);
     } else if (where.ctype === "list" || (where.ctype === "string" && key)) {
         // copy object
         var rhs = {};

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -594,6 +594,21 @@ eval_helper.assigndot = function (data, what) {
     return nada;
 };
 
+eval_helper.assigndotNoVal = function (data, what) {
+    var where = evaluate(data.obj);
+    var field = data.key;
+
+    if (where.ctype === "geo" && typeof field === "string") {
+        Accessor.setField(where.value, field, what);
+    }
+    if (where.ctype === "JSON" && typeof field === "string") {
+        console.log(evaluate(what));
+        Json.setField(where.value, field, what);
+    }
+
+    return nada;
+};
+
 eval_helper.assigncolon = function (data, what) {
     var lhs = data.obj;
     var where = evaluate(lhs);
@@ -637,7 +652,7 @@ eval_helper.assigncolonNoVal = function (data, what) {
     if (key.value === "_?_") key = nada;
 
     if (where.ctype === "geo" && key) {
-        Accessor.setuserData(where.value, key, evaluateAndVal(what));
+        Accessor.setuserData(where.value, key, evaluate(what));
     } else if (where.ctype === "list" || (where.ctype === "string" && key)) {
         // copy object
         var rhs = {};
@@ -791,11 +806,11 @@ function infix_define(args, modifs, self) {
             definer: self,
             generation: generation,
         };
-    }
-    if (args[0].ctype === "variable") {
+    } else if (args[0].ctype === "variable") {
         namespace.setvar(args[0].name, args[1]);
-    }
-    if (args[0].ctype === "userdata") {
+    } else if (args[0].ctype === "field") {
+        eval_helper.assigndotNoVal(args[0], args[1]);
+    } else if (args[0].ctype === "userdata") {
         eval_helper.assigncolonNoVal(args[0], args[1]);
     }
     return nada;

--- a/tests/ColonOp_tests.js
+++ b/tests/ColonOp_tests.js
@@ -120,3 +120,7 @@ describe("Nested UserData for Lists", function () {
     itCmd('l:"ref":"pos"', "[2, 1]");
     itCmd('x:"ref":"pos"', "[2, 1]");
 });
+
+describe("Assign code to JSON objects", function () {
+    itCmd("obj={};obj.code:=(x=x+1);x=5;obj.code;obj.code;x", "7");
+});

--- a/tests/ColonOp_tests.js
+++ b/tests/ColonOp_tests.js
@@ -123,4 +123,7 @@ describe("Nested UserData for Lists", function () {
 
 describe("Assign code to JSON objects", function () {
     itCmd("obj={};obj.code:=(x=x+1);x=5;obj.code;obj.code;x", "7");
+    itCmd("obj={};obj.code:=(x=x*7);x=1;obj.code;obj.code;x", "49");
+    itCmd('obj={};obj:"code":=(x=x*7);x=1;obj.code;obj.code;x', "49");
+    itCmd('obj={};obj:"code":=(x=x*7);x=1;obj:"code";obj.code;x', "49");
 });


### PR DESCRIPTION
This pull request contains code to support the getting and setting of user data and JSON fields via : notation. Also, it is possible to execute code through this mechanism.

As the `:=` define needs to be used to assign code without evaluating it, it is not possible to assign code to JSON objects using `{…}`. However, you can put code in the JSON object using `:=` on fields:

```
obj = { "test" : "bla"};
obj:"code" := sin(x);
obj.othercode := cos(x);
x = 5;
println(obj:"othercode");
println(obj.code);
```

This pull request also contains a few tests to check whether this mechanism works, please feel free to add more.