### PR TITLE
(bugfix) 873: range operator should use floor

### DIFF
--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -118,22 +118,15 @@ List.fund = List.realMatrix([
 ]);
 
 List.sequence = function (a, b) {
-    var erg = [];
-    var ct = 0;
-    for (var i = Math.round(a.value.real); i < Math.round(b.value.real) + 1; i++) {
-        erg[ct] = {
-            ctype: "number",
-            value: {
-                real: i,
-                imag: 0,
-            },
-        };
-        ct++;
+    const start = Math.ceil(a.value.real);
+    const stop = Math.floor(b.value.real) + 1;
+
+    let res = [];
+    for (let i = start, ct = 0; i < stop; i++, ct++) {
+        res[ct] = CSNumber.real(i);
     }
-    return {
-        ctype: "list",
-        value: erg,
-    };
+
+    return List.turnIntoCSList(res);
 };
 
 List.pairs = function (a) {

--- a/tests/Operators_tests.js
+++ b/tests/Operators_tests.js
@@ -44,3 +44,10 @@ describe("angles", function () {
     itCmd("round(37°/15°) * 15°", "30°");
     itCmd("mod(456°, 360°)", "96°");
 });
+
+describe("sequence", function () {
+    itCmd("-2.5..2.5", "[-2, -1, 0, 1, 2]");
+    itCmd("-1.1..1.4", "[-1, 0, 1]");
+    itCmd("-1.9..1.6", "[-1, 0, 1]");
+    itCmd("sum(1..10)", "55");
+});


### PR DESCRIPTION
This fixes the issue with non-integer values in ranges. I did some experiments to determine the behavior of Cinderella.

Closes https://github.com/CindyJS/CindyJS/issues/873