### PR TITLE
CindyScript import

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 *.commit        text
 *.conf          text
 *.cdy           -text
+*.cjs           text
 *.cs            text
 *.css           text
 *.enc           -text

--- a/examples/cindyscript_libraries/libraryA.cjs
+++ b/examples/cindyscript_libraries/libraryA.cjs
@@ -1,0 +1,3 @@
+println("Library A");
+test = 5;
+println("test is " + test);

--- a/examples/cindyscript_libraries/libraryB.cjs
+++ b/examples/cindyscript_libraries/libraryB.cjs
@@ -1,0 +1,3 @@
+println("Library B");
+test = test^2;
+println("test is " + test);

--- a/examples/import_cindyscript.html
+++ b/examples/import_cindyscript.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Cindy JS Example</title>
+        <meta charset="UTF-8" />
+        <link rel="stylesheet" href="../build/js/CindyJS.css" />
+        <script type="text/javascript" src="../build/js/Cindy.js"></script>
+        <script id="csinit" type="text/x-cindyscript">
+            println("Main code");
+            test = test^2;
+            println("test is " + test);
+        </script>
+        <script id="csdraw" type="text/x-cindyscript">
+        </script>
+        <script type="text/javascript">
+            var cdy = CindyJS({
+                // See ref/createCindy documentation for details.
+                ports: [{ id: "CSCanvas", width: 500, height: 500 }],
+                scripts: "cs*",
+                import: ["cindyscript_libraries/libraryA", "cindyscript_libraries/libraryB"]
+
+            });
+
+            // Remove all comments after adjusting this template for your use case.
+        </script>
+    </head>
+
+
+
+
+    <body style="font-family: Arial">
+        <div id="CSCanvas" style="border: 2px solid black"></div>
+    </body>
+</html>

--- a/examples/import_cindyscript.html
+++ b/examples/import_cindyscript.html
@@ -17,7 +17,7 @@
                 // See ref/createCindy documentation for details.
                 ports: [{ id: "CSCanvas", width: 500, height: 500 }],
                 scripts: "cs*",
-                import: ["cindyscript_libraries/libraryA", "cindyscript_libraries/libraryB"]
+                import: ["cindyscript_libraries/libraryA.cjs", "cindyscript_libraries/libraryB"]
 
             });
 

--- a/examples/import_cindyscript.html
+++ b/examples/import_cindyscript.html
@@ -11,6 +11,7 @@
             println("test is " + test);
         </script>
         <script id="csdraw" type="text/x-cindyscript">
+        drawtext([-5,0], "test is equal to " + test, size -> 30);
         </script>
         <script type="text/javascript">
             var cdy = CindyJS({
@@ -29,6 +30,7 @@
 
 
     <body style="font-family: Arial">
+        <h1>CindyJS: Importing CindyScript files</h1>
         <div id="CSCanvas" style="border: 2px solid black"></div>
     </body>
 </html>

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -371,6 +371,7 @@ CAUTION!
 Since this uses the 'fetch' command, it only works on a web server. So, for local testing, start one with 'python -m http.server' or however else you are comfortable with.
 If the key 'import' doesn't exists or its value is an empty array, opening the file locally works as always.
 */
+
     if (data.import && Array.isArray(data.import) && data.import.length > 0) {
         let initId = "csinit";
         if (data.initscript) {
@@ -391,15 +392,27 @@ If the key 'import' doesn't exists or its value is an empty array, opening the f
             console.log("Loading " + library + " ...");
 
             let query = library.search(/.+\.cjs$/) == -1 ? library + ".cjs" : library;
-            let response = await fetch(query);
 
-            if (response.status === 200) {
-                let code = await response.text();
-                let safety = code[code.length - 1] == ";" ? "" : ";";
-                fullCode = code + safety + "\n" + fullCode;
-                console.log(library + " loaded!");
-            } else {
-                console.log("CAUTION! Import of " + library + " failed.");
+            try {
+                let response = await fetch(query);
+
+                if (response.status === 200) {
+                    let code = await response.text();
+                    let safety = code[code.length - 1] == ";" ? "" : ";";
+                    fullCode = code + safety + "\n" + fullCode;
+                    console.log(library + " loaded!");
+                } else {
+                    console.log("CAUTION! Import of " + library + " failed.");
+                }
+            } catch (e) {
+                if (e.message === "Failed to fetch") {
+                    console.log("CAUTION! Import of " + library + " failed.");
+                    console.log(
+                        "This website seems to not run on a web server. CindyJS will continue without importing CindyScript libraries."
+                    );
+                } else {
+                    throw e;
+                }
             }
         }
 

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -372,25 +372,6 @@ Since this uses the 'fetch' command, it only works on a web server. So, for loca
 If the key 'import' doesn't exists or its value is an empty array, opening the file locally works as always.
 */
     if (data.import && Array.isArray(data.import) && data.import.length > 0) {
-        console.log("Importing CindyScript libraries...");
-
-        let fullCode = "";
-
-        for (let library of data.import.reverse()) {
-            if (typeof library !== "string") continue;
-
-            console.log("Loading " + library + " ...");
-
-            let response = await fetch(library + ".cjs");
-
-            if (response.status === 200) {
-                let code = await response.text();
-                let safety = code[code.length - 1] == ";" ? "" : ";";
-                fullCode = code + safety + "\n" + fullCode;
-                console.log(library + " loaded!");
-            }
-        }
-
         let initId = "csinit";
         if (data.initscript) {
             initId = data.initscript;
@@ -399,8 +380,31 @@ If the key 'import' doesn't exists or its value is an empty array, opening the f
         } else {
             return;
         }
-        console.log("Importing libraries to " + initId + ".");
+
+        console.log("===== Importing CindyScript libraries to " + initId + " =====");
+
+        let fullCode = "";
+
+        for (let library of data.import.reverse()) {
+            if (typeof library !== "string") continue;
+
+            console.log("Loading " + library + " ...");
+
+            let query = library.search(/.+\.cjs$/) == -1 ? library + ".cjs" : library;
+            let response = await fetch(query);
+
+            if (response.status === 200) {
+                let code = await response.text();
+                let safety = code[code.length - 1] == ";" ? "" : ";";
+                fullCode = code + safety + "\n" + fullCode;
+                console.log(library + " loaded!");
+            } else {
+                console.log("CAUTION! Import of " + library + " failed.");
+            }
+        }
+
         prependCindyScript(fullCode, initId);
+        console.log("===== Import of libraries to " + initId + " finished ========");
     }
 
     // Continue with compiling scripts.

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -365,7 +365,7 @@ The file names (and paths) have to be listed in the dictionary that's passed to 
                 import: ["cindyscript_libraries/libraryA", "cindyscript_libraries/libraryB"]
 
             });
-Note that the libraries get prepended to the init-script BACK TO FRONT. So, in the example above, the code from libraryA comes before the code from libraryB whoch comes before the custom user code. That way, libraries can reference each others code.
+The libraries are prepended as a whole in the order listed, so libraryA is loaded before libraryB. That way, libraries farther back can reference code of libraries farther up front.
 
 CAUTION!
 Since this uses the 'fetch' command, it only works on a web server. So, for local testing, start one with 'python -m http.server' or however else you are comfortable with.

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -403,7 +403,9 @@ If the key 'import' doesn't exists or its value is an empty array, opening the f
             }
         }
 
-        prependCindyScript(fullCode, initId);
+        let initElement = getCodeElement(initId);
+        let initCode = document.createTextNode(fullCode);
+        prependCode(initElement, initCode);
         console.log("===== Import of libraries to " + initId + " finished ========");
     }
 
@@ -490,9 +492,7 @@ If the key 'import' doesn't exists or its value is an empty array, opening the f
     doneLoadingModule();
 }
 
-function prependCindyScript(codeString, scriptId = "csinit") {
-    var codeNode = document.createTextNode(codeString);
-
+function getCodeElement(scriptId) {
     var scriptElement = document.getElementById(scriptId);
     if (!scriptElement) {
         scriptElement = document.createElement("script");
@@ -500,11 +500,19 @@ function prependCindyScript(codeString, scriptId = "csinit") {
         scriptElement.type = "text/x-cindyscript";
         document.head.appendChild(scriptElement);
     }
+    return scriptElement;
+}
+
+function prependCode(scriptElement, codeNode) {
     if (scriptElement.firstChild) {
         scriptElement.insertBefore(codeNode, scriptElement.firstChild);
     } else {
         scriptElement.appendChild(codeNode);
     }
+}
+
+function appendCode(scriptElement, codeNode) {
+    scriptElement.appendChild(codeNode);
 }
 
 /*


### PR DESCRIPTION
Loads CindyScript files (marked by `.cjs` file ending) and adds their code **at the beginning** of the init-script. The file names (and relative paths) have to be listed in the dictionary that's passed to CindyJS/createCindy as an array for the key `import`. I.e., like this:
```
          var cdy = CindyJS({
                ports: [{ id: "CSCanvas", width: 500, height: 500 }],
                scripts: "cs*",
                import: ["cindyscript_libraries/libraryA.cjs", "cindyscript_libraries/libraryB"]

            });
```
Adding the file ending to the path is optional.

Note that the libraries get prepended to the init-script **back to front**. So, in the example above, the code from libraryA comes before the code from libraryB which comes before the custom user code. That way, libraries can reference each other's code.

Since this uses the `fetch` command in JavaScript, it only works on a web server. So, for local testing, start one with `python -m http.server` or however else you are comfortable with.

If the import key doesn't exist or its value is an empty array, opening the file locally works as always.

---

See `examples/cindyscript_import.html` for a very minimalistic example. It uses two libraries created in `examples/cindyscript_libraries`
