### PR TITLE
rolling back to ECMAScript5 in order to support OpenBoard

### DIFF
--- a/make/Settings.js
+++ b/make/Settings.js
@@ -16,7 +16,7 @@ module.exports = function Settings() {
         build: "release",
         closure_urlbase: "https://repo1.maven.org/maven2/com/google/javascript/closure-compiler",
         closure_language_in: "ECMASCRIPT_NEXT",
-        closure_language_out: "ECMASCRIPT_2016",
+        closure_language_out: "ECMASCRIPT5",
         closure_level: "SIMPLE",
         closure_version: "v20220719",
         verbose: "true",


### PR DESCRIPTION
No big changes, only configuring the closure output language to ECMASCRIPT5 in order to support really old JavaScript engines, in particular QT WebKit in [OpenBoard](https://openboard.org) for widget creation.