### PR TITLE
drawtext will return the coordinates of the bounding box of the text

### DIFF
--- a/examples/166_boxsize.html
+++ b/examples/166_boxsize.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Construction.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <link rel="stylesheet" href="../build/js/CindyJS.css">
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+//Script (CindyScript)
+x=drawtext((0,0),"Hello World, are you OK in your box?",size->24);
+drawpoly(x);
+x=drawtext((0,3),"$\frac{4}{x+2}$",size->24);
+drawpoly(x);
+;
+
+</script>
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  ports: [{
+    id: "CSCanvas",
+    width: 680,
+    height: 333,
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -3.98]}],
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  cinderella: {build: 2069, version: [3, 0, 2069]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -993,12 +993,15 @@ eval_helper.drawtext = function (args, modifs, callback) {
 };
 
 evaluator.drawtext$2 = function (args, modifs) {
-    let box = eval_helper.drawtext(args, modifs, null);
-    const pt1 = General.withUsage(List.realVector(csport.to(box.left, box.bottom)), "Point");
-    const pt2 = General.withUsage(List.realVector(csport.to(box.right, box.bottom)), "Point");
-    const pt3 = General.withUsage(List.realVector(csport.to(box.right, box.top)), "Point");
-    const pt4 = General.withUsage(List.realVector(csport.to(box.left, box.top)), "Point");
-    return List.turnIntoCSList([pt1, pt2, pt3, pt4]);
+    const box = eval_helper.drawtext(args, modifs, null);
+    const points = [
+        csport.to(box.left, box.bottom),
+        csport.to(box.right, box.bottom),
+        csport.to(box.right, box.top),
+        csport.to(box.left, box.top),
+    ].map((point) => General.withUsage(List.realVector(point), "Point"));
+
+    return List.turnIntoCSList(points);
 };
 
 evaluator.drawtable$2 = function (args, modifs) {

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -993,8 +993,12 @@ eval_helper.drawtext = function (args, modifs, callback) {
 };
 
 evaluator.drawtext$2 = function (args, modifs) {
-    eval_helper.drawtext(args, modifs, null);
-    return nada;
+    let box = eval_helper.drawtext(args, modifs, null);
+    const pt1 = General.withUsage(List.realVector(csport.to(box.left, box.bottom)), "Point");
+    const pt2 = General.withUsage(List.realVector(csport.to(box.right, box.bottom)), "Point");
+    const pt3 = General.withUsage(List.realVector(csport.to(box.right, box.top)), "Point");
+    const pt4 = General.withUsage(List.realVector(csport.to(box.left, box.top)), "Point");
+    return List.turnIntoCSList([pt1, pt2, pt3, pt4]);
 };
 
 evaluator.drawtable$2 = function (args, modifs) {


### PR DESCRIPTION
Currently it is very difficult to find out the screen bounds of a text. This small change gives access to the coordinates of the bounding rectangle for a text that has been output through `drawtext`. I plan to add this to Cinderella classic, too, but right now there is a semantic problem when using several ports. I will discuss this with @richter-gebert soon, but until then it would be nice to use this in production code already. 