### PR TITLE
fixes creating local variables in eval

### DIFF
--- a/src/js/libcs/Namespace.js
+++ b/src/js/libcs/Namespace.js
@@ -41,7 +41,7 @@ namespace.create = function (name) {
 };
 
 namespace.newvar = function (name) {
-    const v = this.vars[name];
+    const v = this.create(name);
     v.push(nada); // nada not null for deeper levels
     return v;
 };


### PR DESCRIPTION
When using a variable as a modifier in eval that has never been used before, CindyJS crashes. This should fix it.