### PR TITLE
Enable prettier pre-commit for typescript files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm test
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "homepage": "https://github.com/CindyJS/CindyJS#readme",
     "lint-staged": {
         "*.js": "eslint --cache --fix",
-        "*.{js,css,md}": "prettier --write"
+        "*.{ts,js,css,md}": "prettier --write"
     }
 }


### PR DESCRIPTION
This enables automated formatting of typescript files when you commit code. It also removes the tests on every commit (turned out to be a bit annoying). 

How to test this:

```
git clone https://github.com/strobelm/CindyJS.git
cd CindyJS
git checkout husky-ts
npm install
```

Then change the format in some code: e.g. add some tabs in a line in CSNumber.ts. Commit your changes.

Then you should see sth like

✔ Preparing...
✔ Running tasks...
✔ Applying modifications...
✔ Cleaning up...
[husky-ts 77103175] tmp
 1 file changed, 1 insertion(+)

And the file should be formatted.