### PR TITLE
Added the `import` function to CindyScript.

### DIFF
--- a/examples/cindyscript_libraries/libraryC.cjs
+++ b/examples/cindyscript_libraries/libraryC.cjs
@@ -1,0 +1,8 @@
+
+
+println("Library C");
+col = 1 - col;
+println("This is executed during runtime.");
+
+
+

--- a/examples/import_cindyscript.html
+++ b/examples/import_cindyscript.html
@@ -9,16 +9,24 @@
             println("Main code");
             test = test^2;
             println("test is " + test);
+            
+            col = 1;
         </script>
         <script id="csdraw" type="text/x-cindyscript">
-            drawtext([-5,0], "test is equal to " + test, size -> 30);
+            fillpoly(screenbounds(), color -> col * (1,1,1));
+            drawtext([-5,0], "test is equal to " + test, size -> 30, color -> (1 - col) * (1,1,1));
         </script>
+        <script id="csmousedown" type="text/x-cindyscript">
+            import("cindyscript_libraries/libraryC.cjs");
+        </script>
+        
         <script type="text/javascript">
             var cdy = CindyJS({
                 // See ref/createCindy documentation for details.
                 ports: [{ id: "CSCanvas", width: 500, height: 500 }],
                 scripts: "cs*",
-                import: ["cindyscript_libraries/libraryA.cjs", "cindyscript_libraries/libraryB"],
+                import: ["cindyscript_libraries/libraryA.cjs", "cindyscript_libraries/libraryB"]
+
             });
 
             // Remove all comments after adjusting this template for your use case.

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3554,6 +3554,44 @@ evaluator.parse$1 = function (args, modifs) {
     return nada;
 };
 
+evaluator.import$1 = async function (args, modifs) {
+    let fullCode = "";
+    let library = evaluate(args[0]);
+    if (library.ctype !== "string") return nada;
+    library = library.value;
+
+    console.log("Loading " + library + " ...");
+
+    let query = library.search(/.+\.cjs$/) == -1 ? library + ".cjs" : library;
+
+    try {
+        let response = await fetch(query);
+
+        if (response.status === 200) {
+            let code = await response.text();
+            let safety = code[code.length - 1] == ";" ? "" : ";";
+            fullCode = code + safety;
+            console.log(library + " loaded!");
+            return evaluator.parse$1([{ ctype: "string", value: fullCode }], {});
+        } else {
+            console.log("CAUTION! Import of " + library + " failed.");
+        }
+    } catch (e) {
+        if (e.message === "Failed to fetch") {
+            console.log("CAUTION! Import of " + library + " failed.");
+            console.log(
+                "This website seems to not run on a web server. CindyJS will continue without importing " +
+                    library +
+                    "."
+            );
+        } else {
+            throw e;
+        }
+    }
+
+    return nada;
+};
+
 evaluator.unicode$1 = function (args, modifs) {
     let codepoint, str;
     const arg = evaluate(args[0]);


### PR DESCRIPTION
It loads the cjs file it is given via its path as an argument, assumes the file contains CindyScript code and executes it on the spot. In particular, it behaves like the `import` function in Cinderella. Note that it uses fetch and therefore only works when the CindyJS applet runs on a web server. (Just like the code import on CindyJS start.)
In the example file `import_cindyscript.html` this is shown by loading the file `cindyscript_libraries/libraryC.cjs` on every mousedown which then changes the colour of the applet. Not the intended main use, but shows the functionality.