### PR TITLE
Bug #912: handle case where bounding box is undefine

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1027,6 +1027,8 @@ eval_helper.drawtext = function (args, modifs, callback) {
 
 evaluator.drawtext$2 = function (args, modifs) {
     const box = eval_helper.drawtext(args, modifs, null);
+    if (!box) return nada;
+
     const pt1 = General.withUsage(List.realVector(csport.to(box.left, box.bottom)), "Point");
     const pt2 = General.withUsage(List.realVector(csport.to(box.right, box.bottom)), "Point");
     const pt3 = General.withUsage(List.realVector(csport.to(box.right, box.top)), "Point");


### PR DESCRIPTION
When we introduced the bounding box, we did not take care of the case when `box` is undefined. E.g. here: 

https://github.com/CindyJS/CindyJS/blob/85add6015766a7037977ba072c5f85684893aca1/src/js/libcs/OpDrawing.js#L982-L989

@BernhardWerner could you test if this fixes your crash? If so, this closes  #912. 