### PR TITLE
fixes color of plots, bug report by Iritani-san

### DIFF
--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1427,8 +1427,7 @@ evaluator.plot$2 = function (args, modifs) {
                         }
                     }
                 }
-                csctx.stroke();
-
+                if (stroking) csctx.stroke();
                 namespace.removevar(runv);
             }
         }
@@ -1447,8 +1446,8 @@ evaluator.plot$2 = function (args, modifs) {
         vo = v;
     }
 
-    namespace.removevar(runv);
     if (stroking) csctx.stroke();
+    namespace.removevar(runv);
 
     return nada;
 };


### PR DESCRIPTION
Iritani-san reported that colorplots might have the wrong color in some circumstances. This is related to a wrong logic when *not* plotting a curve. This fixes it.