### PR TITLE
Name variables for export functions

### DIFF
--- a/examples/export-with-names.html
+++ b/examples/export-with-names.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Cindy JS Example</title>
+        <meta charset="UTF-8" />
+        <link rel="stylesheet" href="../build/js/CindyJS.css" />
+        <script type="text/javascript" src="../build/js/Cindy.js"></script>
+        <script id="csinit" type="text/x-cindyscript">
+
+            // Initialization code, executed once up front.
+        </script>
+        <script id="csdraw" type="text/x-cindyscript">
+
+            // Drawing code, executed whenever the canvas gets redrawn.
+        </script>
+        <script type="text/javascript">
+            var cdy = CindyJS({
+                // See ref/createCindy documentation for details.
+                ports: [{ id: "CSCanvas", width: 500, height: 500 }],
+                scripts: "cs*",
+                language: "en",
+                defaultAppearance: {
+                    // See GeoBasics.js for possible attributes.
+                },
+                geometry: [
+                    { name: "A", type: "Free", pos: [0, 0] },
+                    // For allowed types, see GeoOps.js.
+                    // For allowed properties, see csinit in GeoBasics.js.
+                ], // End of geometry array.
+            });
+
+            // Remove all comments after adjusting this template for your use case.
+        </script>
+    </head>
+
+    <body style="font-family: Arial">
+        <div id="CSCanvas" style="border: 2px solid black"></div>
+    </body>
+
+    <script>
+        // On click in canvas, trigger the function foo.
+        document.getElementById("CSCanvas").addEventListener("click", function() {
+            cdy.exportPNG();
+            cdy.exportPNG("alice");
+            cdy.exportSVG();
+            cdy.exportSVG("bob");
+            cdy.exportPDF();
+            cdy.exportPDF("charlie");
+        });
+    </script>
+</html>

--- a/src/js/libcs/RenderBackends.js
+++ b/src/js/libcs/RenderBackends.js
@@ -855,7 +855,7 @@ shutdownHooks.push(releaseExportedObject);
 // result in a new tab.  Note that Firefox fails to show images embedded
 // into an SVG.  So in the long run, saving is probably better than opening.
 // Note: See https://github.com/eligrey/FileSaver.js/ for saving Blobs
-function exportWith(Context) {
+function exportWith(Context, name) {
     cacheImages(function () {
         const origctx = csctx;
         try {
@@ -866,33 +866,33 @@ function exportWith(Context) {
             const blob = csctx.toBlob();
             exportedCanvasURL = window.URL.createObjectURL(blob);
 
-            downloadHelper(exportedCanvasURL);
+            downloadHelper(exportedCanvasURL, name);
         } finally {
             setCsctx(origctx);
         }
     });
 }
 
-globalInstance.exportSVG = function () {
-    exportWith(SvgWriterContext);
+globalInstance.exportSVG = function (name = "CindyJSExport") {
+    exportWith(SvgWriterContext, name);
 };
 
-globalInstance.exportPDF = function () {
+globalInstance.exportPDF = function (name = "CindyJSExport") {
     CindyJS.loadScript("pako", "pako.min.js", function () {
-        exportWith(PdfWriterContext);
+        exportWith(PdfWriterContext, name);
     });
 };
 
-globalInstance.exportPNG = function () {
-    downloadHelper(csctx.canvas.toDataURL());
+globalInstance.exportPNG = function (name = "CindyJSExport") {
+    downloadHelper(csctx.canvas.toDataURL(), name);
 };
 
-var downloadHelper = function (data) {
+var downloadHelper = function (data, name) {
     const a = document.createElement("a");
     document.body.appendChild(a);
     a.style = "display: none";
     a.href = data;
-    a.download = "CindyJSExport";
+    a.download = name;
     a.click();
     setTimeout(function () {
         document.body.removeChild(a);


### PR DESCRIPTION
The functions `exportPDF`, `exportPNG` and `exportSVG` can now be called with an argument that specifies the file name of the exported file. If no argument is given, the old "CindyJSExport" will be uses as the default. Cf. example `export-with-names.html`