### PR TITLE
Optional indices in array functions + compatability fix for max/min

### DIFF
--- a/examples/cindyscript_libraries/another_package/config.json
+++ b/examples/cindyscript_libraries/another_package/config.json
@@ -1,0 +1,5 @@
+{
+    "init": [
+        {"name": "init.cjs", "place": 10}
+    ]
+}

--- a/examples/cindyscript_libraries/another_package/init.cjs
+++ b/examples/cindyscript_libraries/another_package/init.cjs
@@ -1,0 +1,1 @@
+println("This is a second package");

--- a/examples/indices-in-array-functions.html
+++ b/examples/indices-in-array-functions.html
@@ -8,23 +8,39 @@
         <script id="csinit" type="text/x-cindyscript">
 
         array = ["abc", "xy", "cindy", "array", "test"];
+        json = {
+            "i": 2,
+            "ii": 3,
+            "iii": 5,
+            "iv": 7,
+            "v": 11
+        };
 
         println("apply:");
         println(apply(array, entry, index, entry + index));
+        println(apply(json, value, key, length(key) + value));
+        println("====================================");
         
         println("forall:");
         forall(array, entry, index, println(index + ": " + entry));
+        forall(json, value, key, println("Key " + key + " has value " + value));
+        println("====================================");
         
         println("sort:");
         println(sort(array, entry, index, length(entry) - index));
+        println("====================================");
         
         println("select:");
         println(select(array, entry, index, length(entry) + index <= 8));
-
+        println(select(json, value, key, length(key) + value > 5));
+        println("====================================");
+        
         println("min:");
+        println(min(array, entry, index, entry + index));
+        println("====================================");
 
         println("max:");
-        println(max(array));
+        println(max(array, entry, index, entry + index));
 
         </script>
         <script id="csdraw" type="text/x-cindyscript">

--- a/examples/indices-in-array-functions.html
+++ b/examples/indices-in-array-functions.html
@@ -22,9 +22,10 @@
         println(select(array, entry, index, length(entry) + index <= 8));
 
         println("min:");
-        println(min(1,2));
+        println(min(array, entry, index, length(entry) + index));
 
         println("max:");
+        println(max(array, entry, index, length(entry) + index));
 
         </script>
         <script id="csdraw" type="text/x-cindyscript">

--- a/examples/indices-in-array-functions.html
+++ b/examples/indices-in-array-functions.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Cindy JS Example</title>
+        <meta charset="UTF-8" />
+        <link rel="stylesheet" href="../build/js/CindyJS.css" />
+        <script type="text/javascript" src="../build/js/Cindy.js"></script>
+        <script id="csinit" type="text/x-cindyscript">
+
+        array = ["abc", "xy", "cindy", "array", "test"];
+
+        println("apply:");
+        println(apply(array, entry, index, entry + index));
+        
+        println("forall:");
+        forall(array, entry, index, println(index + ": " + entry));
+        
+        println("sort:");
+        println(sort(array, entry, index, length(entry) - index));
+        
+        println("select:");
+        println(select(array, entry, index, length(entry) + index <= 8));
+
+        println("min:");
+        println(min(1,2));
+
+        println("max:");
+
+        </script>
+        <script id="csdraw" type="text/x-cindyscript">
+
+
+        </script>
+
+
+
+        <script type="text/javascript">
+            var cdy = CindyJS({
+                // See ref/createCindy documentation for details.
+                ports: [{ id: "CSCanvas", width: 500, height: 500 }],
+                scripts: "cs*",
+                language: "en",
+
+            });
+
+        </script>
+    </head>
+
+    <body style="font-family: Arial">
+        <h1>Indices in Array Functions</h1>
+        <p>Affected functions: apply, forall, sort, select, max, min</p>
+        <div id="CSCanvas" style="border: 2px solid black"></div>
+    </body>
+</html>

--- a/examples/indices-in-array-functions.html
+++ b/examples/indices-in-array-functions.html
@@ -22,10 +22,9 @@
         println(select(array, entry, index, length(entry) + index <= 8));
 
         println("min:");
-        println(min(array, entry, index, length(entry) + index));
 
         println("max:");
-        println(max(array, entry, index, length(entry) + index));
+        println(max(array));
 
         </script>
         <script id="csdraw" type="text/x-cindyscript">

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1249,7 +1249,11 @@ eval_helper.genericListMathGen = function (name, op, emptyval) {
     evaluator[name + "$2"] = function (args, modifs) {
         return evaluator[name$3]([args[0], null, args[1]]);
     };
+    const name$4 = name + "$4";
     evaluator[name$3] = function (args, modifs) {
+        return evaluator[name$4]([args[0], args[1], null, args[2]]);
+    };
+    evaluator[name$4] = function (args, modifs) {
         const v0 = evaluateAndVal(args[0]);
         if (v0.ctype !== "list") {
             return nada;
@@ -1266,14 +1270,35 @@ eval_helper.genericListMathGen = function (name, op, emptyval) {
             }
         }
 
-        namespace.newvar(lauf);
-        namespace.setvar(lauf, li[0]);
-        let erg = evaluate(args[2]);
-        for (let i = 1; i < li.length; i++) {
-            namespace.setvar(lauf, li[i]);
-            const b = evaluate(args[2]);
-            erg = op(erg, b);
+        let indexVar;
+        if (args[2] !== null) {
+            if (args[2].ctype === "variable") {
+                indexVar = args[2].name;
+                namespace.newvar(indexVar);
+            }
         }
+
+        namespace.newvar(lauf);
+        namespace.setvar(indexVar, CSNumber.real(1));
+        namespace.setvar(lauf, li[0]);
+        let erg = evaluate(args[3]);
+
+        if (indexVar !== undefined) {
+            for (let i = 1; i < li.length; i++) {
+                namespace.setvar(indexVar, CSNumber.real(i + 1));
+                namespace.setvar(lauf, li[i]);
+                const b = evaluate(args[3]);
+                erg = op(erg, b);
+            }
+            namespace.removevar(indexVar);
+        } else {
+            for (let i = 1; i < li.length; i++) {
+                namespace.setvar(lauf, li[i]);
+                const b = evaluate(args[3]);
+                erg = op(erg, b);
+            }
+        }
+
         namespace.removevar(lauf);
         return erg;
     };

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1282,27 +1282,21 @@ eval_helper.genericListMathGen = function (name, op, emptyval) {
 eval_helper.genericListMathGen("product", General.mult, CSNumber.real(1));
 eval_helper.genericListMathGen("sum", General.add, CSNumber.real(0));
 
-/*
-eval_helper.genericListMathGen("max", General.max, nada);
-eval_helper.genericListMathGen("min", General.min, nada);
-
-evaluator.max$2 = function (args, modifs) {
-    const v1 = evaluateAndVal(args[0]);
-    if (v1.ctype === "list") return evaluator.max$3([v1, null, args[1]]);
-    const v2 = evaluateAndVal(args[1]);
-    return evaluator.max$1([List.turnIntoCSList([v1, v2])]);
-};
-
-evaluator.min$2 = function (args, modifs) {
-    const v1 = evaluateAndVal(args[0]);
-    if (v1.ctype === "list") return evaluator.min$3([v1, null, args[1]]);
-    const v2 = evaluateAndVal(args[1]);
-    return evaluator.min$1([List.turnIntoCSList([v1, v2])]);
-};
-*/
-
 evaluator.max$1 = function (args, modifs) {
-    return evaluator.max$2([args[0], null]);
+    const v0 = evaluate(args[0]);
+    if (v0.ctype !== "list") {
+        return nada;
+    }
+    const li = v0.value;
+    if (li.length === 0) {
+        return nada;
+    }
+
+    let erg = li[0];
+    for (let i = 1; i < li.length; i++) {
+        erg = General.compare(erg, li[i]) > 0 ? erg : li[i];
+    }
+    return erg;
 };
 evaluator.max$2 = function (args, modifs) {
     const v1 = evaluateAndVal(args[0]);
@@ -1340,12 +1334,11 @@ evaluator.max$4 = function (args, modifs) {
 
     namespace.newvar(lauf);
     namespace.setvar(lauf, li[0]);
-    let erg = evaluate(args[3]);
-
-    console.log("C");
+    let erg;
 
     if (indexVar !== undefined) {
         namespace.setvar(indexVar, CSNumber.real(1));
+        erg = evaluate(args[3]);
         for (let i = 1; i < li.length; i++) {
             namespace.setvar(indexVar, CSNumber.real(i + 1));
             namespace.setvar(lauf, li[i]);
@@ -1354,10 +1347,90 @@ evaluator.max$4 = function (args, modifs) {
         }
         namespace.removevar(indexVar);
     } else {
+        erg = evaluate(args[3]);
         for (let i = 1; i < li.length; i++) {
             namespace.setvar(lauf, li[i]);
             const b = evaluate(args[3]);
             erg = General.compare(erg, b) > 0 ? erg : b;
+        }
+    }
+
+    namespace.removevar(lauf);
+    return erg;
+};
+
+evaluator.min$1 = function (args, modifs) {
+    const v0 = evaluate(args[0]);
+    if (v0.ctype !== "list") {
+        return nada;
+    }
+    const li = v0.value;
+    if (li.length === 0) {
+        return nada;
+    }
+
+    let erg = li[0];
+    for (let i = 1; i < li.length; i++) {
+        erg = General.compare(erg, li[i]) < 0 ? erg : li[i];
+    }
+    return erg;
+};
+evaluator.min$2 = function (args, modifs) {
+    const v1 = evaluateAndVal(args[0]);
+    if (v1.ctype === "list") return evaluator.min$3([v1, null, args[1]]);
+    const v2 = evaluateAndVal(args[1]);
+    return evaluator.min$1([List.turnIntoCSList([v1, v2])]);
+};
+evaluator.min$3 = function (args, modifs) {
+    return evaluator.min$4([args[0], null, args[1], args[2]]);
+};
+evaluator.min$4 = function (args, modifs) {
+    const v0 = evaluateAndVal(args[0]);
+    if (v0.ctype !== "list") {
+        return nada;
+    }
+    const li = v0.value;
+    if (li.length === 0) {
+        return nada;
+    }
+
+    let lauf = "#";
+    if (args[1] !== null) {
+        if (args[1].ctype === "variable") {
+            lauf = args[1].name;
+        }
+    }
+
+    let indexVar;
+    if (args[2] !== null) {
+        if (args[2].ctype === "variable") {
+            indexVar = args[2].name;
+            namespace.newvar(indexVar);
+        }
+    }
+
+    namespace.newvar(lauf);
+    namespace.setvar(lauf, li[0]);
+    let erg;
+
+    if (indexVar !== undefined) {
+        namespace.setvar(indexVar, CSNumber.real(1));
+        erg = evaluate(args[3]);
+
+        for (let i = 1; i < li.length; i++) {
+            namespace.setvar(indexVar, CSNumber.real(i + 1));
+            namespace.setvar(lauf, li[i]);
+            const b = evaluate(args[3]);
+            erg = General.compare(erg, b) < 0 ? erg : b;
+        }
+        namespace.removevar(indexVar);
+    } else {
+        erg = evaluate(args[3]);
+
+        for (let i = 1; i < li.length; i++) {
+            namespace.setvar(lauf, li[i]);
+            const b = evaluate(args[3]);
+            erg = General.compare(erg, b) < 0 ? erg : b;
         }
     }
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1249,11 +1249,7 @@ eval_helper.genericListMathGen = function (name, op, emptyval) {
     evaluator[name + "$2"] = function (args, modifs) {
         return evaluator[name$3]([args[0], null, args[1]]);
     };
-    const name$4 = name + "$4";
     evaluator[name$3] = function (args, modifs) {
-        return evaluator[name$4]([args[0], args[1], null, args[2]]);
-    };
-    evaluator[name$4] = function (args, modifs) {
         const v0 = evaluateAndVal(args[0]);
         if (v0.ctype !== "list") {
             return nada;
@@ -1270,35 +1266,14 @@ eval_helper.genericListMathGen = function (name, op, emptyval) {
             }
         }
 
-        let indexVar;
-        if (args[2] !== null) {
-            if (args[2].ctype === "variable") {
-                indexVar = args[2].name;
-                namespace.newvar(indexVar);
-            }
-        }
-
         namespace.newvar(lauf);
-        namespace.setvar(indexVar, CSNumber.real(1));
         namespace.setvar(lauf, li[0]);
-        let erg = evaluate(args[3]);
-
-        if (indexVar !== undefined) {
-            for (let i = 1; i < li.length; i++) {
-                namespace.setvar(indexVar, CSNumber.real(i + 1));
-                namespace.setvar(lauf, li[i]);
-                const b = evaluate(args[3]);
-                erg = op(erg, b);
-            }
-            namespace.removevar(indexVar);
-        } else {
-            for (let i = 1; i < li.length; i++) {
-                namespace.setvar(lauf, li[i]);
-                const b = evaluate(args[3]);
-                erg = op(erg, b);
-            }
+        let erg = evaluate(args[2]);
+        for (let i = 1; i < li.length; i++) {
+            namespace.setvar(lauf, li[i]);
+            const b = evaluate(args[2]);
+            erg = op(erg, b);
         }
-
         namespace.removevar(lauf);
         return erg;
     };
@@ -1306,6 +1281,8 @@ eval_helper.genericListMathGen = function (name, op, emptyval) {
 
 eval_helper.genericListMathGen("product", General.mult, CSNumber.real(1));
 eval_helper.genericListMathGen("sum", General.add, CSNumber.real(0));
+
+/*
 eval_helper.genericListMathGen("max", General.max, nada);
 eval_helper.genericListMathGen("min", General.min, nada);
 
@@ -1321,6 +1298,71 @@ evaluator.min$2 = function (args, modifs) {
     if (v1.ctype === "list") return evaluator.min$3([v1, null, args[1]]);
     const v2 = evaluateAndVal(args[1]);
     return evaluator.min$1([List.turnIntoCSList([v1, v2])]);
+};
+*/
+
+evaluator.max$1 = function (args, modifs) {
+    return evaluator.max$2([args[0], null]);
+};
+evaluator.max$2 = function (args, modifs) {
+    const v1 = evaluateAndVal(args[0]);
+    if (v1.ctype === "list") return evaluator.max$3([v1, null, args[1]]);
+    const v2 = evaluateAndVal(args[1]);
+    return evaluator.max$1([List.turnIntoCSList([v1, v2])]);
+};
+evaluator.max$3 = function (args, modifs) {
+    return evaluator.max$4([args[0], null, args[1], args[2]]);
+};
+evaluator.max$4 = function (args, modifs) {
+    const v0 = evaluateAndVal(args[0]);
+    if (v0.ctype !== "list") {
+        return nada;
+    }
+    const li = v0.value;
+    if (li.length === 0) {
+        return nada;
+    }
+
+    let lauf = "#";
+    if (args[1] !== null) {
+        if (args[1].ctype === "variable") {
+            lauf = args[1].name;
+        }
+    }
+
+    let indexVar;
+    if (args[2] !== null) {
+        if (args[2].ctype === "variable") {
+            indexVar = args[2].name;
+            namespace.newvar(indexVar);
+        }
+    }
+
+    namespace.newvar(lauf);
+    namespace.setvar(lauf, li[0]);
+    let erg = evaluate(args[3]);
+
+    console.log("C");
+
+    if (indexVar !== undefined) {
+        namespace.setvar(indexVar, CSNumber.real(1));
+        for (let i = 1; i < li.length; i++) {
+            namespace.setvar(indexVar, CSNumber.real(i + 1));
+            namespace.setvar(lauf, li[i]);
+            const b = evaluate(args[3]);
+            erg = General.compare(erg, b) > 0 ? erg : b;
+        }
+        namespace.removevar(indexVar);
+    } else {
+        for (let i = 1; i < li.length; i++) {
+            namespace.setvar(lauf, li[i]);
+            const b = evaluate(args[3]);
+            erg = General.compare(erg, b) > 0 ? erg : b;
+        }
+    }
+
+    namespace.removevar(lauf);
+    return erg;
 };
 
 evaluator.add$2 = infix_add;


### PR DESCRIPTION
Functions that iterate over an array and apply some sort of code to the entries now have a version with four arguments where the third one specifies a reference to the index. E.g. one can now do something like this:
```
points = [(1,2), (3,4), (5,6), (7,8), (9,0)];
forall(points, p, index,
     fillcircle(point, index);
);
```
and get diferently sized circles.

This was already implemented for `apply` in the past, but is now also available for `forall`, `sort`, `select`, `max` and `min`. Moreover, it also works with JSON objects  (when it makes sense) and a reference to the key instead of the index. Again, this was available for `apply`  before and now also works  for `forall` and `select`.

---

Additionally, this pull request is a compatability fix: In the past, `max` and `min` only worked for numbers and lists of number. Now they can take every datatype that `sort` also takes.