### PR TITLE
Bug fix and new modifier in min/max

### DIFF
--- a/examples/indices-in-array-functions.html
+++ b/examples/indices-in-array-functions.html
@@ -7,7 +7,8 @@
         <script type="text/javascript" src="../build/js/Cindy.js"></script>
         <script id="csinit" type="text/x-cindyscript">
 
-        array = ["abc", "xy", "cindy", "array", "test"];
+
+        array = ["abcdef", "uvwxyz", "cinderella", "cindyjs", "testing"];
         json = {
             "i": 2,
             "ii": 3,
@@ -35,12 +36,21 @@
         println(select(json, value, key, length(key) + value > 5));
         println("====================================");
         
-        println("min:");
-        println(min(array, entry, index, entry + index));
+        println("min, element false:");
+        println(min(array, entry, index, entry_index, element -> false));
         println("====================================");
 
-        println("max:");
-        println(max(array, entry, index, entry + index));
+        println("min, element true:");
+        println(min(array, entry, index, entry_index, element -> true));
+        println("====================================");
+
+        println("max, element false:");
+        println(max(array, entry, index, entry_index, element -> false));
+        println("====================================");
+
+        println("max, element true:");
+        println(max(array, entry, index, entry_index, element -> true));
+        
 
         </script>
         <script id="csdraw" type="text/x-cindyscript">

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1305,7 +1305,7 @@ evaluator.max$2 = function (args, modifs) {
     return evaluator.max$1([List.turnIntoCSList([v1, v2])]);
 };
 evaluator.max$3 = function (args, modifs) {
-    return evaluator.max$4([args[0], null, args[1], args[2]]);
+    return evaluator.max$4([args[0], args[1], null, args[2]]);
 };
 evaluator.max$4 = function (args, modifs) {
     const v0 = evaluateAndVal(args[0]);
@@ -1335,28 +1335,48 @@ evaluator.max$4 = function (args, modifs) {
     namespace.newvar(lauf);
     namespace.setvar(lauf, li[0]);
     let erg;
+    let return_element = evaluate(modifs.element);
+    return_element = return_element.ctype === "boolean" ? return_element.value : false;
 
     if (indexVar !== undefined) {
         namespace.setvar(indexVar, CSNumber.real(1));
-        erg = evaluate(args[3]);
+        erg = {
+            element: li[0],
+            value: evaluate(args[3]),
+        };
         for (let i = 1; i < li.length; i++) {
             namespace.setvar(indexVar, CSNumber.real(i + 1));
             namespace.setvar(lauf, li[i]);
             const b = evaluate(args[3]);
-            erg = General.compare(erg, b) > 0 ? erg : b;
+            erg =
+                General.compare(erg.value, b) > 0
+                    ? erg
+                    : {
+                          element: li[i],
+                          value: b,
+                      };
         }
         namespace.removevar(indexVar);
     } else {
-        erg = evaluate(args[3]);
+        erg = {
+            element: li[0],
+            value: evaluate(args[3]),
+        };
         for (let i = 1; i < li.length; i++) {
             namespace.setvar(lauf, li[i]);
             const b = evaluate(args[3]);
-            erg = General.compare(erg, b) > 0 ? erg : b;
+            erg =
+                General.compare(erg.value, b) > 0
+                    ? erg
+                    : {
+                          element: li[i],
+                          value: b,
+                      };
         }
     }
 
     namespace.removevar(lauf);
-    return erg;
+    return return_element ? erg.element : erg.value;
 };
 
 evaluator.min$1 = function (args, modifs) {
@@ -1382,7 +1402,7 @@ evaluator.min$2 = function (args, modifs) {
     return evaluator.min$1([List.turnIntoCSList([v1, v2])]);
 };
 evaluator.min$3 = function (args, modifs) {
-    return evaluator.min$4([args[0], null, args[1], args[2]]);
+    return evaluator.min$4([args[0], args[1], null, args[2]]);
 };
 evaluator.min$4 = function (args, modifs) {
     const v0 = evaluateAndVal(args[0]);
@@ -1412,30 +1432,50 @@ evaluator.min$4 = function (args, modifs) {
     namespace.newvar(lauf);
     namespace.setvar(lauf, li[0]);
     let erg;
+    let return_element = evaluate(modifs.element);
+    return_element = return_element.ctype === "boolean" ? return_element.value : false;
 
     if (indexVar !== undefined) {
         namespace.setvar(indexVar, CSNumber.real(1));
-        erg = evaluate(args[3]);
+        erg = {
+            element: li[0],
+            value: evaluate(args[3]),
+        };
 
         for (let i = 1; i < li.length; i++) {
             namespace.setvar(indexVar, CSNumber.real(i + 1));
             namespace.setvar(lauf, li[i]);
             const b = evaluate(args[3]);
-            erg = General.compare(erg, b) < 0 ? erg : b;
+            erg =
+                General.compare(erg.value, b) < 0
+                    ? erg
+                    : {
+                          element: li[i],
+                          value: b,
+                      };
         }
         namespace.removevar(indexVar);
     } else {
-        erg = evaluate(args[3]);
+        erg = {
+            element: li[0],
+            value: evaluate(args[3]),
+        };
 
         for (let i = 1; i < li.length; i++) {
             namespace.setvar(lauf, li[i]);
             const b = evaluate(args[3]);
-            erg = General.compare(erg, b) < 0 ? erg : b;
+            erg =
+                General.compare(erg.value, b) < 0
+                    ? erg
+                    : {
+                          element: li[i],
+                          value: b,
+                      };
         }
     }
 
     namespace.removevar(lauf);
-    return erg;
+    return return_element ? erg.element : erg.value;
 };
 
 evaluator.add$2 = infix_add;


### PR DESCRIPTION
In the three-argument versions of min/max, the element was used as the index in the four-argument versions instead of the element again. E.g., code like 
```
max([5, -3, 1, -7], v, |v|)
```
returned `4` instead of `7`. This is now fixed.

This PR also added a modifier to min/max to return the element itself in the versions that provide code. E.g., while

```
max([5, -3, 1, -7], v, |v|)
```
returns `7`, the code

```
max([5, -3, 1, -7], v, |v|, element -> true)
```
returns `-7`.