### PR TITLE
Bug fix for text outline

### DIFF
--- a/examples/text-outline.html
+++ b/examples/text-outline.html
@@ -18,8 +18,12 @@
         fillpoly(screenbounds(), color -> 0.5 * (1,1,1));
 
         SX = |mouse().x - screenbounds()_1.x| / |screenbounds()_2.x - screenbounds()_1.x|;
+        
         drawtext([-8, 6], "This text has an outline of size: $" + round(25 * SX) + "$", size -> 50, color -> [1,1,1], outlinecolor -> (0,0,0), outlinewidth -> 25 * SX);
-        drawtext([-8, 0], "$\displaystyle \begin{bmatrix}1 & 2 \\ 3 & 4\end{bmatrix} \enspace \sum_{i=0}^{n-1} q^i = \frac{q^n - 1}{q - 1} \enspace \sin\left(135.7^\circ\right)$", size -> 50, color -> [1,1,1], outlinecolor -> (0,0,0), outlinewidth -> 25 * SX);
+        drawtext([-8, 0], "$\displaystyle \begin{bmatrix}1 & 2 \\ 3 & 4\end{bmatrix} \enspace \sum_{i=0}^{n-1} q^i = \frac{q^n - 1}{q - 1} \enspace \sin\left(135.7^\circ\right)$", size -> 40, color -> [0,0,0], outlinecolor -> (1,1,1), outlinewidth -> 20  * SX);
+        drawtext([-8, -6], "This text has no outline", size -> 30, color -> [0,0,1]);
+        drawtext([8, -4], "This text has alpha", size -> 30, color -> [0,0,0], alpha -> 1 - SX, outlinecolor -> (1,0,0), outlinewidth -> 10);
+        drawtext([8, -8], "This text is invisible", size -> 30, color -> [1,0,0], alpha -> 0);
         </script>
 
 

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -1002,8 +1002,8 @@ eval_helper.drawtext = function (args, modifs, callback) {
     csctx.fillStyle = Render2D.textColor;
 
     csctx.lineWidth = Render2D.outlinewidth;
-    csctx.lineJoin = "round";
-    csctx.strokeStyle = Render2D.outlineColor;
+    csctx.lineJoin = Render2D.linejoin;
+    csctx.strokeStyle = Render2D.outlinecolor;
 
     const m = csport.drawingstate.matrix;
     const xx = pt.x * m.a - pt.y * m.b + m.tx + Render2D.xOffset;

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -71,12 +71,10 @@ Render2D.handleModifs = function (modifs, handlers) {
         Render2D.pointColor = csport.drawingstate.pointcolor;
         Render2D.lineColor = csport.drawingstate.linecolor;
         Render2D.textColor = csport.drawingstate.textcolor;
-        Render2D.outlineColor = csport.drawingstate.textoutlinecolor;
     } else {
         Render2D.pointColor = Render2D.makeColor(csport.drawingstate.pointcolorraw);
         Render2D.lineColor = Render2D.makeColor(csport.drawingstate.linecolorraw);
         Render2D.textColor = Render2D.makeColor(csport.drawingstate.textcolorraw);
-        Render2D.outlineColor = Render2D.makeColor(csport.drawingstate.textoutlinecolorraw);
     }
     if (Render2D.alpha === 1) {
         Render2D.black = "rgb(0,0,0)";
@@ -89,9 +87,9 @@ Render2D.handleModifs = function (modifs, handlers) {
         Render2D.fillColor = null;
     }
     if (Render2D.outlinecolorraw && Render2D.outlinewidth > 0) {
-        Render2D.outlineColor = Render2D.makeColor(Render2D.outlinecolorraw);
+        Render2D.outlinecolor = Render2D.makeColor(Render2D.outlinecolorraw, Render2D.alpha);
     } else {
-        Render2D.outlineColor = null;
+        Render2D.outlinecolor = "rgb(0,0,0,0)";
     }
 };
 

--- a/src/js/libgeo/GeoState.js
+++ b/src/js/libgeo/GeoState.js
@@ -17,7 +17,7 @@ csport.drawingstate.alpha = 1.0;
 csport.drawingstate.pointsize = 4.0;
 csport.drawingstate.linesize = 1.0;
 csport.drawingstate.textsize = null; // use defaultAppearance.textsize
-csport.drawingstate.textoutlinewidth = 0;
+csport.drawingstate.textoutlinewidth = 0.0;
 
 csport.drawingstate.matrix = {};
 csport.drawingstate.matrix.a = 25;
@@ -243,6 +243,13 @@ csport.settextcolor = function (co) {
     csport.drawingstate.textcolor = csport.makecolor(r, g, b);
     csport.drawingstate.textcolorraw = [r, g, b];
 };
+csport.settextoutlinecolor = function (co) {
+    const r = co.value[0].value.real;
+    const g = co.value[1].value.real;
+    const b = co.value[2].value.real;
+    csport.drawingstate.textoutlinecolor = csport.makecolor(r, g, b);
+    csport.drawingstate.textoutlinecolorraw = [r, g, b];
+};
 
 csport.setpointcolor = function (co) {
     const r = co.value[0].value.real;
@@ -269,6 +276,11 @@ csport.setalpha = function (al) {
         csport.drawingstate.textcolorraw[1],
         csport.drawingstate.textcolorraw[2]
     );
+    csport.drawingstate.textoutlinecolor = csport.makecolor(
+        csport.drawingstate.textoutlinecolorraw[0],
+        csport.drawingstate.textoutlinecolorraw[1],
+        csport.drawingstate.textoutlinecolorraw[2]
+    );
 };
 
 csport.setpointsize = function (si) {
@@ -281,6 +293,9 @@ csport.setlinesize = function (si) {
 
 csport.settextsize = function (si) {
     csport.drawingstate.textsize = si.value.real;
+};
+csport.settextoutlinewidth = function (si) {
+    csport.drawingstate.textoutlinewidth = si.value.real;
 };
 
 export { csport, csgstorage };


### PR DESCRIPTION
Render2D did not properly reset and handle outline width and outline color when `drawtext` was called without outline modifiers or with alpha. This is now fixed.