### PR TITLE
Fix webgl

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ src/js/Tail.js
 src/js/ifs/ifs.asm.js
 lib/katex/katex.min.js
 plugins/katex/src/js/katex-plugin.js
+plugins/cindygl/src/js/CodeBuilder.js

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -1063,7 +1063,7 @@ CodeBuilder.prototype.generateColorPlotProgram = function(expr) { //TODO add arg
     code += this.generateSection('uniforms');
     code += this.generateListOfUniforms();
     code += generateHeaderOfTextureReaders(this);
-    code += this.generateSection('includedfunctions');
+    code += this.generateSection('includedfunctions');;
     code += this.generateSection('functions');
 
 
@@ -1074,7 +1074,16 @@ CodeBuilder.prototype.generateColorPlotProgram = function(expr) { //TODO add arg
 
     code += this.generateSection('compiledfunctions');
 
-    code += `void main(void) {\n${r.code}gl_FragColor = ${colorterm};\n}\n`;
+    //JRG: THis snipped is used to bypass an error caused
+    //by the current WebGL implementation on most machines
+    //see https://stackoverflow.com/questions/79053598/bug-in-current-webgl-shader-implementation-concerning-variable-settings
+    let randompatch="";
+    if (this.sections['includedfunctions']) 
+      if(this.sections['includedfunctions'].marked.random)
+        randompatch="last_rnd=0.1231;\n"; //This must be included in "main"
+    //////////////////////
+
+    code += `void main(void) {\n ${randompatch} ${r.code}gl_FragColor = ${colorterm};\n}\n`;
 
     console.log(code);
 

--- a/plugins/cindygl/src/js/CodeBuilder.js
+++ b/plugins/cindygl/src/js/CodeBuilder.js
@@ -5,9 +5,7 @@ function CodeBuilder(api) {
     this.variables = {};
     this.uniforms = {};
     this.scopes = {};
-
     this.sections = {};
-
     this.typetime = 0; //the last time when a type got changed
     this.myfunctions = {};
     this.api = api;

--- a/ref/Texts_and_Tables.md
+++ b/ref/Texts_and_Tables.md
@@ -46,6 +46,8 @@ The code
     > )
     D fillStyle = "rgba(229,0,25,1)"
     D font = "bold 17px sans-serif"
+    D lineWidth = 0
+    D strokeStyle = "rgb(0,0,0,0)"
     D fillText("Text", 275.5, 229.5)
     D fillStyle = "rgba(204,0,51,1)"
     D font = "bold 19px sans-serif"


### PR DESCRIPTION
This is a fix for `random()` no longer working in CindyGL due to changes in the recent WebGL implementation.

Originally provided by @richter-gebert . See also https://stackoverflow.com/questions/79053598/bug-in-current-webgl-shader-implementation-concerning-variable-settings