### PR TITLE
drawall also uses point modifiers, not only line modifiers.

### DIFF
--- a/examples/bugs/drawall-border.html
+++ b/examples/bugs/drawall-border.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>test.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+        
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+        <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+        <link rel="stylesheet" href="../../css/cindy.css" />
+
+<script id="csdraw" type="text/x-cindyscript">
+  drawall(apply(1..10,(#,#/2)),border->false);
+  drawall(apply(1..10,(#+1,#/2)),border->true);
+  forall(apply(1..10,(#+2,#/2)),draw(#,border->false));
+  forall(apply(1..10,(#+3,#/2)),draw(#,border->true));
+  
+</script>
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  animation: {
+    autoplay: false,
+    controls: false,
+    speed: 0.44329896907216493,
+    speedRange: [0.0, 1.0],
+    accuracy: 1
+  },
+  autoplay: false,
+  animcontrols: false,
+  ports: [{
+    width: 772,
+    height: 462,
+    id: "CSCanvas",
+    transform: [{visibleRect: [-4.62, 13.02, 26.26, -5.46]}],
+    axes: true,
+    grid: 1.0,
+    snap: true,
+    background: "rgb(255,255,255)"
+  }],
+  csconsole: false,
+  cinderella: {build: 2083, version: [3, 0, 2088]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -787,7 +787,7 @@ evaluator.drawall$1 = function (args, modifs) {
     if (v1.ctype === "list") {
         Render2D.handleModifs(modifs, Render2D.pointAndLineModifs);
         for (let i = 0; i < v1.value.length; i++) {
-            evaluator.draw$1([v1.value[i]], null);
+            evaluator.draw$1([v1.value[i]], null); // modifs are null because they have been handled already
         }
     }
     return nada;

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -348,11 +348,11 @@ Render2D.pointModifs = {
     size: true,
     color: true,
     alpha: true,
-    noborder: true,
+    noborder: false,
     border: true,
 };
 
-Render2D.pointAndLineModifs = Render2D.lineModifs;
+Render2D.pointAndLineModifs = { ...Render2D.lineModifs, ...Render2D.pointModifs };
 
 Render2D.conicModifs = {
     size: true,


### PR DESCRIPTION
This solves an issue reported by T Leuders, `drawall` did not obey the `border` modifier.