### PR TITLE
Fixing pixelsize for TeX strings

### DIFF
--- a/examples/168_test-pixelsize.html
+++ b/examples/168_test-pixelsize.html
@@ -22,14 +22,19 @@
     </style>
         <link rel="stylesheet" href="../build/js/CindyJS.css" />
         <script type="text/javascript" src="../build/js/Cindy.js"></script>
+        <script id="csinit" type="text/x-cindyscript">
+
+
+
+        </script>
 <script id="csdraw" type="text/x-cindyscript">
 //Script (CindyScript)
-string="Hello, how are you? $f(x)=\sum_1^{\infty}\frac{1}{x}$";
+string="Hello, how are you? $\displaystyle f(x)=\sum_1^{\infty}\frac{1}{x}\begin{bmatrix}3\end{bmatrix}$";
 ps = pixelsize(string,size->25,family->"Times New Roman");
 ps = ps/screenresolution();
 drawtext((0,0),string,size->25,family->"Times New Roman");
 drawpoly([(0,0), (0,ps_2),(ps_1,ps_2), (ps_1,-ps_3), (0,-ps_3),(0,0),(ps_1,0)]);
-;
+
 
 </script>
     <script type="text/javascript">

--- a/examples/168_test-pixelsize.html
+++ b/examples/168_test-pixelsize.html
@@ -29,7 +29,7 @@
         </script>
 <script id="csdraw" type="text/x-cindyscript">
 //Script (CindyScript)
-string="Hello, how are you? $\displaystyle f(x)=\sum_1^{\infty}\frac{1}{x}\begin{bmatrix}3\end{bmatrix}$";
+string="Hello, how are you? $\displaystyle f(x)=\sum_1^{\frac{1}{0}}\frac{1}{x}\begin{bmatrix}3 & \sqrt[5]{7}\\ i^2 & -345\end{bmatrix}\cdot 1$";
 ps = pixelsize(string,size->25,family->"Times New Roman");
 ps = ps/screenresolution();
 drawtext((0,0),string,size->25,family->"Times New Roman");

--- a/src/js/libcs/OpDrawing.js
+++ b/src/js/libcs/OpDrawing.js
@@ -925,7 +925,7 @@ function defaultTextRendererCanvas(ctx, text, x, y, align, size, lineHeight, ang
     };
 }
 
-function measureNoRendererCanvas(ctx, text, x, y, align, size, lineHeight, angle = 0) {
+function defaultMeasureNoRendererCanvas(ctx, text, x, y, align, size, lineHeight, angle = 0) {
     if (text.includes("\n")) {
         let left = Infinity;
         let right = -Infinity;
@@ -957,6 +957,15 @@ function measureNoRendererCanvas(ctx, text, x, y, align, size, lineHeight, angle
         bottom: y + 0.3 * 1.2 * size,
     };
 }
+
+let measureNoRendererCanvas = defaultMeasureNoRendererCanvas;
+
+function setMeasureNoRendererCanvas(fct) {
+    measureNoRendererCanvas = fct;
+}
+
+
+
 
 // This is a hook: the following function may get replaced by a plugin.
 let textRendererCanvas = defaultTextRendererCanvas;
@@ -1067,7 +1076,7 @@ eval_helper.pixelsize = function (args, modifs) {
     }
 
     csctx.font = Render2D.bold + Render2D.italics + Math.round(size * 10) / 10 + "px " + Render2D.family;
-    return measureNoRendererCanvas(
+    let result = measureNoRendererCanvas(
         csctx,
         txt,
         0,
@@ -1076,7 +1085,11 @@ eval_helper.pixelsize = function (args, modifs) {
         size,
         size * defaultAppearance.lineHeight,
         Render2D.angle
-    );
+    ); 
+    if (result === undefined) return nada;
+
+    return result;
+    
 };
 evaluator.pixelsize$1 = function (args, modifs) {
     const box = eval_helper.pixelsize(args, modifs);
@@ -1807,4 +1820,4 @@ evaluator.layer$1 = function (args, modifs) {
     // See https://gitlab.cinderella.de:8082/cindyjs/cindyjs/issues/17
 };
 
-export { textRendererCanvas, setTextRendererCanvas, textRendererHtml, setTextRendererHtml };
+export { textRendererCanvas, setTextRendererCanvas, textRendererHtml, setTextRendererHtml, measureNoRendererCanvas, setMeasureNoRendererCanvas };

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4773,6 +4773,9 @@ evaluator.use$1 = function (args, modifs) {
                     setTextRendererCanvas(handlerCanvas);
                     if (handlerHtml) setTextRendererHtml(handlerHtml);
                 },
+                setMeasure: function (handler) {
+                    setMeasureNoRendererCanvas(handler);
+                },
                 getImage: function (name, lazy) {
                     if (typeof name === "string") name = General.string(name);
                     const img = imageFromValue(name);


### PR DESCRIPTION
This adds appropriate text measure functions to the KaTeX plugin so that `pixelsize` now works for strings containing TeX formulas. Due to the asynchronous and comparatively slow loading of fonts within the KaTeX plugin, this does not properly work if called in the init script.