### PR TITLE
Compatibility fix for #934 – length should return a value for single elements

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -2927,8 +2927,7 @@ evaluator.length$1 = function (args, modifs) {
     const v0 = evaluate(args[0]);
     if (v0.ctype === "list" || v0.ctype === "string") {
         return CSNumber.real(v0.value.length);
-    }
-    return nada;
+    } else return CSNumber.real(List.asList(v0).value.length);
 };
 
 evaluator.pairs$1 = function (args, modifs) {

--- a/tests/Operators_tests.js
+++ b/tests/Operators_tests.js
@@ -51,3 +51,11 @@ describe("sequence", function () {
     itCmd("-1.9..1.6", "[-1, 0, 1]");
     itCmd("sum(1..10)", "55");
 });
+
+describe("length", function () {
+    itCmd("length([1,2,3])", "3");
+    itCmd('length("1234")', "4");
+    itCmd("length(42)", "1");
+    itCmd("length(var)", "0");
+    itCmd("variable=1;length(variable)", "1");
+});


### PR DESCRIPTION
The title says it all – this fixes the compatibility behaviour reported in #934.