### PR TITLE
Fix #936 – list removal

### DIFF
--- a/examples/bugs/list-remove.html
+++ b/examples/bugs/list-remove.html
@@ -20,13 +20,16 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="https://cindyjs.org/dist/v0.8/CindyJS.css">
-    <script type="text/javascript" src="https://cindyjs.org/dist/v0.8/Cindy.js"></script>
+        <script type="text/javascript" src="../../build/js/Cindy.js"></script>
+        <link rel="stylesheet" href="../../css/cindy.css" />
+        
 <script id="csdraw" type="text/x-cindyscript">
 //Script (CindyScript)
-drawtext((0,0),[1,2,3,4,5]--3,size->50);
-drawtext((0,2),[1,2,3,4,5]--[3],size->50);
-drawtext((0,4),"These should be the same",size->25);
+drawtext((0,-2),[1,2,4]++[5],size->50);
+drawtext((0,0),[1,2,4]++5,size->50);
+drawtext((0,2),[1,2,3,4,5]--3,size->50);
+drawtext((0,4),[1,2,3,4,5]--[3],size->50);
+drawtext((0,6),"These should be the same",size->25);
 ;
 
 </script>

--- a/examples/bugs/list-remove.html
+++ b/examples/bugs/list-remove.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Construction.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+        
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <link rel="stylesheet" href="https://cindyjs.org/dist/v0.8/CindyJS.css">
+    <script type="text/javascript" src="https://cindyjs.org/dist/v0.8/Cindy.js"></script>
+<script id="csdraw" type="text/x-cindyscript">
+//Script (CindyScript)
+drawtext((0,0),[1,2,3,4,5]--3,size->50);
+drawtext((0,2),[1,2,3,4,5]--[3],size->50);
+drawtext((0,4),"These should be the same",size->25);
+;
+
+</script>
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  ports: [{
+    width: 680,
+    height: 333,
+    id: "CSCanvas",
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -3.98]}],
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  cinderella: {build: 2088, version: [3, 0, 2088]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3024,11 +3024,13 @@ evaluator.remove$2 = infix_remove;
 function infix_remove(args, modifs) {
     const v0 = evaluate(args[0]);
     const v1 = evaluate(args[1]);
-    if (v0.ctype === "list" && v1.ctype === "list") {
-        return List.remove(v0, v1);
-    }
     if (v0.ctype === "shape" && v1.ctype === "shape") {
         return eval_helper.shaperemove(v0, v1);
+    }
+    const l0 = List.asList(v0);
+    const l1 = List.asList(v1);
+    if (l0.ctype === "list" && l1.ctype === "list") {
+        return List.remove(l0, l1);
     }
     return nada;
 }


### PR DESCRIPTION
This fixes the odd behaviour when removing a single element from a list as reported in #936 . Elements passed to `infix_remove` are converted to lists automatically. This should not introduce any bugs, as this is the same behaviour as in Classic. 