### PR TITLE
946 numerical differentiation is not supported in cindyjs

### DIFF
--- a/examples/170-derivative.html
+++ b/examples/170-derivative.html
@@ -20,8 +20,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="https://cindyjs.org/dist/v0.8/CindyJS.css">
-    <script type="text/javascript" src="https://cindyjs.org/dist/v0.8/Cindy.js"></script>
+    <link rel="stylesheet" href="../build/js/CindyJS.css">
+    <script type="text/javascript" src="../build/js/Cindy.js"></script>
 <script id="csinit" type="text/x-cindyscript">
 //Script (CindyScript)
 f(x):=0.05*x^3;
@@ -34,9 +34,7 @@ f(x):=0.05*x^3;
 plot(f(#));
 A.y=f(A.x);
 draw(A,A+5*(1,d(f(#),A.x)),color->red(1));
-err(d(f(#),1));
-;
-
+draw(A,A+5*(1,d(f(#),A.x,eps->3)),color->grey(1));
 </script>
     <script type="text/javascript">
 var cdy = CindyJS({

--- a/examples/170-derivative.html
+++ b/examples/170-derivative.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Construction.cdy</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+        
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+    <link rel="stylesheet" href="https://cindyjs.org/dist/v0.8/CindyJS.css">
+    <script type="text/javascript" src="https://cindyjs.org/dist/v0.8/Cindy.js"></script>
+<script id="csinit" type="text/x-cindyscript">
+//Script (CindyScript)
+f(x):=0.05*x^3;
+
+;
+
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+//Script (CindyScript)
+plot(f(#));
+A.y=f(A.x);
+draw(A,A+5*(1,d(f(#),A.x)),color->red(1));
+err(d(f(#),1));
+;
+
+</script>
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  geometry: [
+    {name: "A", type: "Free", pos: [4.0, 0.4862824410143571, -2.565255899852482], color: [1.0, 0.0, 0.0], labeled: true}
+  ],
+  ports: [{
+    width: 680,
+    height: 333,
+    id: "CSCanvas",
+    transform: [{visibleRect: [-23.215108943081603, 13.40896034861407, 39.315468617894005, -17.212631309922514]}],
+    axes: true,
+    grid: 5.0,
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  cinderella: {build: 2089, version: [3, 0, 2089]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1544,6 +1544,30 @@ evaluator.mod$2 = function (args, modifs) {
     return nada;
 };
 
+evaluator.d$2 = function (args, modifs) {
+    let lauf = "#";
+    let eps = modifs.eps;
+
+    if (eps === undefined) {
+        eps = CSNumber.real(0.0001);
+    } else {
+        eps = evaluate(eps);
+        if (eps.ctype !== "number") {
+            eps = CSNumber.real(0.0001);
+        }
+    }
+
+    const prog = args[0];
+    const x = evaluateAndVal(args[1]);
+    namespace.newvar(lauf);
+    namespace.setvar(lauf, CSNumber.add(x, eps));
+    let f1 = evaluate(prog);
+    namespace.setvar(lauf, CSNumber.sub(x, eps));
+    let f2 = evaluate(prog);
+    namespace.removevar(lauf);
+    return CSNumber.div(CSNumber.sub(f1, f2), CSNumber.mult(eps, CSNumber.real(2)));
+};
+
 evaluator.pow$2 = infix_pow;
 
 function infix_pow(args, modifs) {

--- a/src/js/libcs/Render2D.js
+++ b/src/js/libcs/Render2D.js
@@ -348,7 +348,7 @@ Render2D.pointModifs = {
     size: true,
     color: true,
     alpha: true,
-    noborder: false,
+    noborder: true,
     border: true,
 };
 


### PR DESCRIPTION
This implements the missing `d(f(#),x)` function.