### PR TITLE
fix vec rendering in Chrome

### DIFF
--- a/lib/katex/katex.min.js
+++ b/lib/katex/katex.min.js
@@ -2843,8 +2843,7 @@
                                     g = -10 / 18;
                                     break;
                                 case "accent-vec":
-                                    //d += 0.326;
-                                    d -= 0.1;
+                                    d += window.chrome ? 0.326 : -0.1;
                                     break;
                                 case "accent-body":
                                     y = this.x;

--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
     "lint-staged": {
         "*.js": "eslint --cache --fix",
         "*.{ts,js,css,md}": "prettier --write"
+    },
+    "dependencies": {
+        "typescript": "^5.7.3"
     }
 }


### PR DESCRIPTION
This is a hot fix to render $\vec a$ correctly in Safari __and__ Chrome. It works by checking for the chrome property of the window and using the result for deciding on the offset needed for rendering. Unfortunately, this is a change in the minified JavaScript code for KaTeX.