### PR TITLE
fix position of \vec on firefox (hack)

### DIFF
--- a/lib/katex/katex.min.js
+++ b/lib/katex/katex.min.js
@@ -2843,7 +2843,7 @@
                                     g = -10 / 18;
                                     break;
                                 case "accent-vec":
-                                    d += window.chrome ? 0.326 : -0.1;
+                                    d += window.chrome || navigator.userAgent.search("Firefox") != -1 ? 0.326 : -0.1;
                                     break;
                                 case "accent-body":
                                     y = this.x;


### PR DESCRIPTION
As reported by the KeTCindy group, the position of \vec is still wrong on Firefox. This adds another bad hack to improve the positioning there. Still, it would be much better to upgrade KaTeX.