### PR TITLE
less verbose output of err(…)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
     "lint-staged": {
         "*.js": "eslint --cache --fix",
         "*.{ts,js,css,md}": "prettier --write"
+    },
+    "dependencies": {
+        "typescript": "^5.8.3"
     }
 }

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -217,7 +217,7 @@ function printStackTrace(msg) {
         msg +
             callStack
                 .map(function (frame) {
-                    return "\n  at " + frame.oper;
+                    return "  at " + frame.oper;
                 })
                 .join("\n")
     );

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -73,9 +73,8 @@ evaluator.err$1 = function (args, modifs) {
         s = args[0];
     }
     s = varname + " ===> " + niceprint(evaluate(s));
-
-    printStackTrace(s);
-
+    //printStackTrace(s);
+    csconsole.err(s);
     return nada;
 };
 


### PR DESCRIPTION
`err(…)` is awfully verbose, also in comparison with Cindy classic. This will remove the stack from output. If there is need for it, please open an issue.