### PR TITLE
Port support for "lambda-functions" from CindyGL3D to main interpreter

### DIFF
--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -173,7 +173,7 @@ function niceprint(a, modifs) {
         return "IMAGE";
     }
     if (a.ctype === "lambda") {
-        return "lambda(" + a.params.map((v) => v.name).join(",") + ",...)";
+        return "lambda((" + a.params.map((v) => v.name).join(",") + "),...)";
     }
 
     return "_?_";

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4815,12 +4815,12 @@ evaluator.lambda = function (args, modifs) {
 evaluator.eval = function (args, modifs) {
     //VARIADIC!
     if (args.length == 0) return nada;
-    args[0] = evaluate(args[0]);
-    if (args[0].ctype !== "lambda") return nada; // TODO? handle eval for non-lambda argument
-    if (args[0].params.length != args.length - 1) {
+    let lambda = evaluate(args[0]);
+    if (lambda.ctype !== "lambda") return nada; // TODO? handle eval for non-lambda argument
+    if (lambda.params.length != args.length - 1) {
         console.warn("wrong number of arguments for lambda expression");
         // pad arguments to correct length
-        while (args.length < args[0].params.length + 1) {
+        while (args.length < lambda.params.length + 1) {
             args.push(nada);
         }
     }
@@ -4829,10 +4829,10 @@ evaluator.eval = function (args, modifs) {
         callModifs[key] = value;
     });
     // prefer lambda modifiers over modifiers passed to eval
-    Object.entries(args[0].modifs).forEach(function ([key, value]) {
+    Object.entries(lambda.modifs).forEach(function ([key, value]) {
         callModifs[key] = value;
     });
-    return evalfunction(args[0].params, args[0].body, args.slice(1, args.length), callModifs);
+    return evalfunction(lambda.params, lambda.body, args.slice(1, args.length), callModifs);
 };
 evaluator.islambda$1 = function (args, modifs) {
     const v0 = evaluate(args[0]);

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -4790,12 +4790,12 @@ evaluator.eval$1 = function (args, modifs) {
 //      LAMBDA FUNCTIONS     //
 ///////////////////////////////
 
-evaluator.lambda = function (args, modifs) {
-    //VARIADIC!
+evaluator.lambda$2 = function (args, modifs) {
     if (args.length == 0) return nada;
-    let paramCount = args.length - 1;
-    for (let i = 0; i < paramCount; i++) {
-        if (args[i].ctype !== "variable") {
+    if (args[0].oper.toLowerCase() !== "genlist") return nada;
+    let params = args[0].args;
+    for (let i = 0; i < params.length; i++) {
+        if (params[i].ctype !== "variable") {
             console.error("lambda parameter should be variable got: " + args[i].ctype);
             return nada;
         }
@@ -4807,8 +4807,8 @@ evaluator.lambda = function (args, modifs) {
     });
     return {
         ctype: "lambda",
-        body: args[paramCount],
-        params: args.slice(0, paramCount),
+        body: args[1],
+        params: params,
         modifs: modValues,
     };
 };


### PR DESCRIPTION
As far as I can tell CindyScript currently provides no convenient way treat functions as values that can be passed to other functions/stored in variables. (correct me if I am wrong).
  The closest possible solution (used by Cindy in Cindy) seems to be, that code can be stored in dictionary entries and will be evaluated every time that entry is read, but this approach still depends on global variables to pass arguments to that "function".
Being able to treat functions as values is useful in larger projects, for instance for defining callback functions in UI application, or for implementing a simplified version of polymorphism.

In CindyGL3D I use "cglLazy"-values (created wrapping the passed in expression in a CindyScript object at the plugin level using the `cglLazy()` function) that can be used to pass CindyScript expressions through multiple layers of function calls to the CindyGL compiler (or be evaluated as code using `cglEval()`).

This pull-request adds a less hacky version of that feature to the main CindyScript interpreter.
To archive this functionality I would add three new functions to the interpreter (two of them variadic):

    * `lambda(<vars...>,<expr>)`: create a value representing a function with `expr` (an expression) as body and `vars` (zero or more variables) as parameters. Modifiers will be evaluated on creation and stored with the function.
    * `eval(<lambda>,<args..>)`: evaluate the lambda value `lambda` with the given arguments `args`, if both lambda and eval define the same modifier the modifier given to lambda will be used.
    * `islambda(<val>)` check if a value is lambda expression

Currently there is no function ending with `lambda` in the GitRepository, while `eval` already is already a built-in function, so code-collisions should be minimal. I am open to changes to the function names and signatures, as well tweaks the behavior of modifiers.

Optionally it could be usefull to allow to refer to "normal" functions as objects using an expression of the form `<func-name>$<arity>`  (e.g. `sin$1` to get a lambda object for the sin function). This might require changes to how CindyScript code is parsed

  Example Code:
  ```
  plus = lambda(x,y,x+y);
  times = lambda(x,y,x*y);
  reduce(aList,op):=(
    if(len(aList)==0,
      nada
    ,
      res = aList_1;
      forall(2..len(aList),i,
        res = eval(op,res,aList_i);
      )
    );
  );

  reduce([1,2,3,4,5,6,7,8,9,10],plus); // 55
  reduce([1,2,3,4,5,6,7,8,9,10],times); // 3628800
  ```

  ```
  movePoint(name,newPos):=(
    p = points_name;
    p_"pos" = newPos;
    if(!isundefined(p_"onMove"),
      eval(p_"onMove",newPos)
    );
  )

  newPoint((0,0),onMove->lambda(pos,print("moved point to "+text(pos))));
  newPoint((0,1),onMove->lambda(pos,print("|point2|="+text(pos*pos))));
  ```