### PR TITLE
Minor improvements to CindyScript

### DIFF
--- a/src/js/libcs/Dict.js
+++ b/src/js/libcs/Dict.js
@@ -61,6 +61,18 @@ Dict.get = function (dict, key, dflt) {
     return dflt;
 };
 
+// returns copy of dictionary without the given key, or the original dictionary if the key does not exist
+Dict.without = function (dict, key) {
+    const keyName = Dict.key(key);
+    const kv = dict.value[keyName];
+    if (kv) {
+        let copy = Dict.clone(dict);
+        delete copy.value[keyName];
+        return copy;
+    }
+    return dict;
+};
+
 Dict.niceprint = function (dict) {
     return (
         "{" +

--- a/src/js/libcs/Dict.js
+++ b/src/js/libcs/Dict.js
@@ -72,6 +72,18 @@ Dict.without = function (dict, key) {
     }
     return dict;
 };
+// returns a directory containing all elements appearing in at least one of the arguments,
+//   for duplicate keys the value from the second directory will be used
+// if one of the directories is empty the other one will be returned, otherwise a new directory is created
+Dict.union = function (a, b) {
+    if (Object.keys(b.value).length === 0) return a;
+    if (Object.keys(a.value).length === 0) return b;
+    let c = Dict.clone(a);
+    Object.entries(b.value).forEach(function ([key, value]) {
+        c.value[key] = value;
+    });
+    return c;
+};
 
 Dict.niceprint = function (dict) {
     return (

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -31,6 +31,8 @@ import {
     infix_nin,
     infix_and,
     infix_or,
+    infix_and_shortcircuit,
+    infix_or_shortcircuit,
     comp_notalmostequals,
     infix_sequence,
     infix_concat,
@@ -76,6 +78,8 @@ infixmap["∈"] = infix_in;
 infixmap["∉"] = infix_nin;
 infixmap["&"] = infix_and;
 infixmap["%"] = infix_or;
+infixmap["&&"] = infix_and_shortcircuit;
+infixmap["%%"] = infix_or_shortcircuit;
 infixmap["!="] = comp_notequals;
 infixmap["~!="] = comp_notalmostequals;
 infixmap[".."] = infix_sequence;

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -322,6 +322,15 @@ List.remove = function (a, b) {
         value: erg,
     };
 };
+List.removeAt = function (a, index) {
+    if (index < 1 || index > a.value.length) return a; // index out of range
+    // remove element index-1 from JS list (JS is 0 indexed while CindyScript is 1 indexed)
+    const erg = a.value.slice(0, index - 1).concat(a.value.slice(index));
+    return {
+        ctype: "list",
+        value: erg,
+    };
+};
 
 List.sort1 = function (a) {
     const erg = a.value.slice();

--- a/src/js/libcs/Namespace.js
+++ b/src/js/libcs/Namespace.js
@@ -20,6 +20,7 @@ namespace.vars = (function () {
         true: General.bool(true),
         false: General.bool(false),
         "#": nada,
+        nada: nada,
         nil: List.turnIntoCSList([]),
         newline: General.string("\n"),
         tab: General.string("\t"),

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3114,6 +3114,41 @@ function infix_remove(args, modifs) {
     return nada;
 }
 
+evaluator.removeat$2 = function (args, modifs) {
+    const v0 = evaluate(args[0]);
+    const ind = evaluateAndVal(args[1]);
+    if (v0.ctype === "list" || v0.ctype === "string") {
+        if (ind.ctype !== "number") return v0; // index is not a real number
+        let ind1 = Math.floor(ind.value.real);
+        if (ind1 < 0) {
+            ind1 = v0.value.length + ind1 + 1;
+        }
+        if (ind1 > 0 && ind1 <= v0.value.length) {
+            if (v0.ctype === "list") {
+                return List.removeAt(v0, ind1);
+            } else {
+                // string
+                let str = v0.value;
+                str = str.substring(0, ind1 - 1) + str.substring(ind1, str.length);
+                return General.string(str);
+            }
+        }
+    }
+    if (v0.ctype === "JSON") {
+        const key = niceprint(ind);
+        if (!niceprint.errorTypes.includes(key)) {
+            let elts = { ...v0.value };
+            delete elts[key];
+            return {
+                ctype: "JSON",
+                value: elts,
+            };
+        }
+    }
+    // TODO? handle user-data?, handle dictionaries
+    return v0;
+};
+
 evaluator.append$2 = infix_append;
 
 function infix_append(args, modifs) {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3076,6 +3076,20 @@ function infix_concat(args, modifs) {
     if (v0.ctype === "shape" && v1.ctype === "shape") {
         return eval_helper.shapeconcat(v0, v1);
     }
+    if (v0.ctype === "JSON" && v1.ctype === "JSON") {
+        let elts = { ...v0.value };
+        // for duplicate keys use second argument
+        Object.entries(v1.value).forEach(function ([key, value]) {
+            elts[key] = value;
+        });
+        return {
+            ctype: "JSON",
+            value: elts,
+        };
+    }
+    if (v0.ctype === "dict" && v1.ctype === "dict") {
+        return Dict.union(v0, v1);
+    }
     const l0 = List.asList(v0);
     const l1 = List.asList(v1);
     if (l0.ctype === "list" && l1.ctype === "list") {

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -101,6 +101,17 @@ evaluator.println$1 = function (args, modifs) {
     csconsole.out(niceprint(evaluate(args[0], modifs)));
     return nada;
 };
+// variadic print functions
+evaluator.print = function (args, modifs) {
+    //VARIADIC!
+    csconsole.out(args.map((arg) => niceprint(evaluate(arg), modifs)).join(" "), true);
+    return nada;
+};
+evaluator.println = function (args, modifs) {
+    //VARIADIC!
+    csconsole.out(args.map((arg) => niceprint(evaluate(arg, modifs))).join(" "));
+    return nada;
+};
 
 evaluator.assert$2 = function (args, modifs) {
     const v0 = evaluate(args[0]);

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3145,7 +3145,10 @@ evaluator.removeat$2 = function (args, modifs) {
             };
         }
     }
-    // TODO? handle user-data?, handle dictionaries
+    if (v0.ctype === "dict") {
+        return Dict.without(v0, ind);
+    }
+    // TODO? support removing user-data?
     return v0;
 };
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1051,6 +1051,22 @@ function infix_or(args, modifs) {
 
     return nada;
 }
+function infix_and_shortcircuit(args, modifs) {
+    const v0 = evaluateAndVal(args[0]);
+    if (v0.ctype !== "boolean") return nada;
+    if (!v0.value) return v0;
+    const v1 = evaluateAndVal(args[1]);
+    if (v0.ctype !== "boolean") return nada;
+    return v1;
+}
+function infix_or_shortcircuit(args, modifs) {
+    const v0 = evaluateAndVal(args[0]);
+    if (v0.ctype !== "boolean") return nada;
+    if (v0.value) return v0;
+    const v1 = evaluateAndVal(args[1]);
+    if (v0.ctype !== "boolean") return nada;
+    return v1;
+}
 
 evaluator.xor$2 = function (args, modifs) {
     const v0 = evaluateAndVal(args[0]);
@@ -5859,6 +5875,8 @@ export {
     infix_nin,
     infix_and,
     infix_or,
+    infix_and_shortcircuit,
+    infix_or_shortcircuit,
     comp_notalmostequals,
     infix_sequence,
     infix_concat,

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -937,7 +937,7 @@ evaluator.if$3 = function (args, modifs) {
         } else if (args.length === 3) {
             return evaluate(args[2]);
         }
-    } else if (v0.ctype !== "undefined") {
+    } else {
         printStackTrace("Condition for if is not boolean");
     }
 

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -60,6 +60,10 @@ const operatorLevels = [
         or: ["%", "∨"],
     },
     {
+        shortand: ["&&"],
+        shortor: ["%%"],
+    },
+    {
         rassoc: true,
         prepend: ["<:"],
     },


### PR DESCRIPTION
This pull request adds a few features to CindyScript that were noticeably missing while creating CindyGL3D:

I could not find these functions anywhere in the source-code or documentation, please tell me if this functionality already exists under a different name. If the current version causes any problems, I am open to changing the names/signatures/edge-case behavior.

* `if` should creates a warning/error when the condition is undefined:
    Currently `if` statements silently execute neither of the branches when the condition is undefined, there might by a few niche use-cases where this is the intended behavior, but when writing scripts it is relatively easy to accidentally pass undefined as an if condition (e.g. comparing complex numbers), which creates hard to pinpoint/confusing bugs without any visible error messages.

* add a variadic version of the print function:
   While debugging code it is useful to be able to print multiple values, while this is possible by printing a list containing the values a variadic print (like in most other scripting languages) is more convenient.

* add short-circuiting versions of and/or:
  Make writing code of the form `if(islist(arg) && length(arg) > 2 && arg_1 == 5, doSomething())` more convenient to write.
  Currently the short circuit versions are mapped to operators `%%` and `&&`

* add a `removeAt(<container>,<index/key>)` function that removes the element with a specific index/key from a string, list, JSON, or dictionary
    One use is to implement stacks in sub-linear time (as far as I can tell currently the best way to remove the last element of a list is `apply(1..(length(list)-1),list_#)` which could be more efficiently written as `removeAt(list,length(list))`

* `concat` can now also merge JSON-values and dictionaries (for duplicates the value from the second argument is used).
   **Does anyone depend on concatenation converting _both_ arguments to lists**? It might be better to map this behavior to a new `union()` function (which as far as I can tell is also a missing set operation)?

*  make `nada` a constant that is set to Cindy-Scripts `undefined` 
  The constant `#` already is set to undefined, but will not be accessible in loop.