### PR TITLE
proof of concept for early return

### DIFF
--- a/examples/earlyReturn.html
+++ b/examples/earlyReturn.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    
+    <title>Modifier Evaluation Context</title>
+    <style type="text/css">
+        * {
+            margin: 0px;
+            padding: 0px;
+        }
+        
+        #CSConsole {
+            background-color: #FAFAFA;
+            border-top: 1px solid #333333;
+            bottom: 0px;
+            height: 200px;
+            overflow-y: scroll;
+            position: fixed;
+            width: 100%;
+        }
+    </style>
+        <script type="text/javascript" src="../build/js/Cindy.js"></script>
+        <link rel="stylesheet" href="../css/cindy.css" />
+        
+<script id="csinit" type="text/x-cindyscript">
+    // ensure each draw-statement uses a separate line
+    reset():=(h=7);
+    dh = -0.6;
+    iota():=(
+        regional(res);
+        res = h;
+        h = h + dh;
+        res;
+    );
+    reset();
+    printRes(value) := (
+        drawtext((0,iota()),"returned "+text(value),size->10);
+    );
+    // define functions with return statements
+    test(a,b):=(
+        drawtext((0,iota()),"called test "+text(a),size->10);
+        if(a,return(b));
+        drawtext((0,iota()),"reached end of function body",size->10);
+        -1;
+    );
+    d = {};
+    d:"retTest" := (
+        drawtext((0,iota()),"called test "+text(a),size->10);
+        if(a,return(b));
+        drawtext((0,iota()),"reached end of function body",size->10);
+        -1;
+    );
+</script>
+<script id="csdraw" type="text/x-cindyscript">
+    reset();
+    printRes(test(false,0));
+    printRes(test(true,3));
+    printRes(eval(d:"retTest",a->false,b->4));
+    printRes(eval(d:"retTest",a->true,b->6));
+    a = true; b = 8;
+    printRes(d:"retTest"); // exceptions should not leak out of user-modifiers
+    a = false; b = 10;
+    printRes(d:"retTest"); // exceptions should not leak out of user-modifiers
+    return(0); // this should terminate the current script, but not produce any visible exceptions
+    drawtext((0,iota()),"this line is never reached!",size->10);
+</script>
+    <script type="text/javascript">
+var cdy = CindyJS({
+  scripts: "cs*",
+  defaultAppearance: {
+    dimDependent: 0.7,
+    fontFamily: "sans-serif",
+    lineSize: 1,
+    pointSize: 5.0,
+    textsize: 12.0
+  },
+  angleUnit: "°",
+  ports: [{
+    width: 680,
+    height: 333,
+    id: "CSCanvas",
+    transform: [{visibleRect: [-9.06, 9.34, 18.14, -3.98]}],
+    background: "rgb(168,176,192)"
+  }],
+  csconsole: false,
+  cinderella: {build: 2088, version: [3, 0, 2088]}
+});
+    </script>
+</head>
+<body>
+    <div id="CSCanvas"></div>
+</body>
+</html>

--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -27,7 +27,7 @@ import { document, nada, window, instanceInvocationArguments } from "expose";
 import { CSNumber } from "libcs/CSNumber";
 import { List } from "libcs/List";
 import { General } from "libcs/General";
-import { evaluate } from "libcs/Evaluator";
+import { evaluateR } from "libcs/Evaluator";
 import { manage } from "libcs/Tools";
 import { csport } from "libgeo/GeoState";
 import { draw_traces, render } from "libgeo/GeoRender";
@@ -782,7 +782,7 @@ function keyEvent(e, script) {
     const actualkey = String.fromCharCode(unicode);
     cskey = actualkey;
     cskeycode = unicode;
-    evaluate(script);
+    evaluateR(script);
     scheduleUpdate();
 }
 
@@ -799,43 +799,43 @@ function cs_keytyped(e) {
 }
 
 function cs_mousedown(e) {
-    evaluate(cscompiled.mousedown);
+    evaluateR(cscompiled.mousedown);
 }
 
 function cs_mouseup(e) {
-    evaluate(cscompiled.mouseup);
+    evaluateR(cscompiled.mouseup);
 }
 
 function cs_mousedrag(e) {
-    evaluate(cscompiled.mousedrag);
+    evaluateR(cscompiled.mousedrag);
 }
 
 function cs_multidown(id) {
     multiid = id;
     if (id === 0) multipos[0] = csmouse;
-    evaluate(cscompiled.multidown);
+    evaluateR(cscompiled.multidown);
     multiid = 0;
 }
 
 function cs_multiup(id) {
     multiid = id;
-    evaluate(cscompiled.multiup);
+    evaluateR(cscompiled.multiup);
     delete multipos[id];
     multiid = 0;
 }
 
 function cs_multidrag(id) {
     multiid = id;
-    evaluate(cscompiled.multidrag);
+    evaluateR(cscompiled.multidrag);
     multiid = 0;
 }
 
 function cs_mousemove(e) {
-    evaluate(cscompiled.mousemove);
+    evaluateR(cscompiled.mousemove);
 }
 
 function cs_mouseclick(e) {
-    evaluate(cscompiled.mouseclick);
+    evaluateR(cscompiled.mouseclick);
 }
 
 function cs_tick(e) {
@@ -848,26 +848,26 @@ function cs_tick(e) {
     }
     setSimTime(time);
     if (csanimating) {
-        evaluate(cscompiled.tick);
+        evaluateR(cscompiled.tick);
     }
 }
 
 function cs_simulationstep(e) {
-    evaluate(cscompiled.simulationstep);
+    evaluateR(cscompiled.simulationstep);
 }
 
 function cs_simulationstart(e) {
-    evaluate(cscompiled.simulationstart);
+    evaluateR(cscompiled.simulationstart);
 }
 
 function cs_simulationstop(e) {
-    evaluate(cscompiled.simulationstop);
+    evaluateR(cscompiled.simulationstop);
 }
 
 function cs_onDrop(lst, pos) {
     setDropped(List.turnIntoCSList(lst));
     setDropPoint(pos);
-    evaluate(cscompiled.ondrop);
+    evaluateR(cscompiled.ondrop);
     setDropped(nada);
     setDropPoint(nada);
     scheduleUpdate();

--- a/src/js/Setup.js
+++ b/src/js/Setup.js
@@ -9,7 +9,7 @@ import { window, nada, document, instanceInvocationArguments } from "expose";
 import { General } from "libcs/General";
 import { niceprint, evaluator } from "libcs/Essentials";
 import { setStatusBar } from "libcs/Operators";
-import { evaluate, analyse, labelCode, usedFunctions } from "libcs/Evaluator";
+import { evaluateR, analyse, labelCode, usedFunctions } from "libcs/Evaluator";
 import { csport } from "libgeo/GeoState";
 import { csinit } from "libgeo/GeoBasics";
 import { stateArrays, stateIn, recalcAll } from "libgeo/Tracing";
@@ -90,13 +90,13 @@ function dumpcs(a) {
 
 function evalcs(a) {
     const prog = evaluator.parse$1([General.wrap(a)], []);
-    const erg = evaluate(prog);
+    const erg = evaluateR(prog);
     dumpcs(erg);
 }
 
 function evokeCS(code) {
     const parsed = analyse(code, false);
-    evaluate(parsed);
+    evaluateR(parsed);
     scheduleUpdate();
 }
 
@@ -920,7 +920,7 @@ function doneLoadingModule(skipInit) {
 
     if (!skipInit) {
         //Evaluate Init script
-        evaluate(cscompiled.init);
+        evaluateR(cscompiled.init);
 
         if ((instanceInvocationArguments.animation || instanceInvocationArguments).autoplay) csplay();
 
@@ -1054,7 +1054,7 @@ var globalInstance = {
     pause: cspause,
     stop: csstop,
     evalcs: function (code) {
-        return evaluate(analyse(code, false));
+        return evaluateR(analyse(code, false));
     },
     parse: function (code) {
         return analyse(code);

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -43,7 +43,7 @@ import {
     postfix_undefine,
     infix_semicolon,
 } from "libcs/Operators";
-import { evaluate } from "libcs/Evaluator";
+import { evaluate, evaluateR } from "libcs/Evaluator";
 
 const myfunctions = {};
 
@@ -209,7 +209,7 @@ function evalmyfunctions(name, args, modifs) {
     });
 
     namespace.pushVstack("*");
-    const erg = evaluate(tt.body);
+    const erg = evaluateR(tt.body);
     namespace.cleanVstack();
 
     // remove modifiers again

--- a/src/js/libcs/Evaluator.js
+++ b/src/js/libcs/Evaluator.js
@@ -57,19 +57,19 @@ function evaluate(a) {
         if (obj.ctype === "geo") {
             let oldobject = Json._helper.self;
             Json._helper.self = obj;
-            let result = evaluate(Accessor.getuserData(obj.value, key));
+            let result = evaluateR(Accessor.getuserData(obj.value, key));
             Json._helper.self = oldobject;
             return result;
         } else if (obj.ctype === "list" || obj.ctype === "string") {
             let oldobject = Json._helper.self;
             Json._helper.self = obj;
-            let result = evaluate(Accessor.getuserData(obj, key));
+            let result = evaluateR(Accessor.getuserData(obj, key));
             Json._helper.self = oldobject;
             return result;
         } else if (obj.ctype === "JSON") {
             let oldobject = Json._helper.self;
             Json._helper.self = obj;
-            let result = evaluate(Json.getField(obj, key.value));
+            let result = evaluateR(Json.getField(obj, key.value));
             Json._helper.self = oldobject;
             return result;
         } else return nada;
@@ -114,6 +114,26 @@ function evaluateAndHomog(a) {
     }
 
     return nada;
+}
+
+// exception representing a returned CindyScript value, should be caught when interpreting a function body
+class CindyScriptReturn extends Error {
+    constructor(value) {
+        super("unexpected return");
+        this.name = this.constructor.name;
+        this.value = value;
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+// evaluate expression, catch return statements
+function evaluateR(expr) {
+    // TODO better name
+    try {
+        return evaluate(expr);
+    } catch (errOrReturn) {
+        if (!(errOrReturn instanceof CindyScriptReturn)) throw errOrReturn;
+        return errOrReturn.value;
+    }
 }
 
 //*******************************************************

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -38,7 +38,15 @@ import {
     setTextRendererHtml,
 } from "libcs/OpDrawing";
 import { imageFromValue } from "libcs/OpImageDrawing";
-import { evaluate, printStackTrace, evaluateAndVal, evaluateAndHomog, analyse } from "libcs/Evaluator";
+import {
+    evaluate,
+    printStackTrace,
+    evaluateAndVal,
+    evaluateAndHomog,
+    analyse,
+    evaluateR,
+    CindyScriptReturn,
+} from "libcs/Evaluator";
 import { CSad } from "libcs/CSad";
 import { tools, setActiveTool } from "libcs/Tools";
 import { csport, csgstorage } from "libgeo/GeoState";
@@ -1606,6 +1614,10 @@ function infix_pow(args, modifs) {
     }
     return nada;
 }
+
+evaluator.return$1 = function (args, modifs) {
+    throw new CindyScriptReturn(evaluate(args[0]));
+};
 
 ///////////////////////////////
 //     UNARY MATH OPS        //
@@ -4776,7 +4788,7 @@ evaluator.eval$1 = function (args, modifs) {
     });
 
     namespace.pushVstack("*");
-    const erg = evaluate(args[0]);
+    const erg = evaluateR(args[0]);
     namespace.cleanVstack();
     Object.entries(modifs).forEach(function ([key, value]) {
         namespace.removevar(key);

--- a/src/js/libgeo/GeoOps.js
+++ b/src/js/libgeo/GeoOps.js
@@ -18,7 +18,7 @@ import { CSNumber, TWOPI } from "libcs/CSNumber";
 import { List } from "libcs/List";
 import { General } from "libcs/General";
 import { eval_helper, niceprint } from "libcs/Essentials";
-import { analyse, evaluate } from "libcs/Evaluator";
+import { analyse, evaluateR } from "libcs/Evaluator";
 import { Render2D } from "libcs/Render2D";
 import { csport } from "libgeo/GeoState";
 import { onSegment } from "libgeo/GeoBasics";
@@ -3121,7 +3121,7 @@ geoOps.Calculation.initialize = function (el) {
     el.calculation = analyse(el.text);
 };
 geoOps.Calculation.getText = function (el) {
-    return niceprint(evaluate(el.calculation));
+    return niceprint(evaluateR(el.calculation));
 };
 geoOps.Calculation.getParamForInput = geoOps.Text.getParamForInput;
 geoOps.Calculation.getParamFromState = geoOps.Text.getParamFromState;
@@ -3137,7 +3137,7 @@ geoOps.Equation.initialize = function (el) {
     el.calculation = analyse(el.text);
 };
 geoOps.Equation.getText = function (el) {
-    return el.text + " = " + niceprint(evaluate(el.calculation));
+    return el.text + " = " + niceprint(evaluateR(el.calculation));
 };
 geoOps.Equation.getParamForInput = geoOps.Text.getParamForInput;
 geoOps.Equation.getParamFromState = geoOps.Text.getParamFromState;
@@ -3153,7 +3153,7 @@ geoOps.Evaluate.initialize = function (el) {
     el.calculation = analyse(el.text);
 };
 geoOps.Evaluate.getText = function (el) {
-    evaluate(el.calculation); // ugly: side effects in draw
+    evaluateR(el.calculation); // ugly: side effects in draw
     return el.text;
 };
 geoOps.Evaluate.getParamForInput = geoOps.Text.getParamForInput;
@@ -3171,7 +3171,7 @@ geoOps.Plot.initialize = function (el) {
     el.calculation = analyse("plot((" + el.text + "))");
 };
 geoOps.Plot.getText = function (el) {
-    evaluate(el.calculation);
+    evaluateR(el.calculation);
     return el.text;
 };
 geoOps.Plot.getParamForInput = geoOps.Text.getParamForInput;
@@ -3205,7 +3205,7 @@ function commonButton(el, event, button) {
     if (el.script) {
         const code = analyse(el.script);
         onEvent = function () {
-            evaluate(code);
+            evaluateR(code);
             scheduleUpdate();
         };
     }

--- a/src/js/libgeo/Tracing.js
+++ b/src/js/libgeo/Tracing.js
@@ -5,7 +5,7 @@ import { CSNumber } from "libcs/CSNumber";
 import { List } from "libcs/List";
 import { General } from "libcs/General";
 import { minCostMatching } from "libcs/Operators";
-import { evaluate } from "libcs/Evaluator";
+import { evaluateR } from "libcs/Evaluator";
 import { getGeoDependants, isShowing } from "libgeo/GeoBasics";
 import { geoOps } from "libgeo/GeoOps";
 
@@ -139,8 +139,8 @@ function traceMouseAndScripts() {
         move.prev.x = mouse.x;
         move.prev.y = mouse.y;
     }
-    evaluate(cscompiled.move);
-    evaluate(cscompiled.draw);
+    evaluateR(cscompiled.move);
+    evaluateR(cscompiled.draw);
     if (!tracingFailed) {
         stateContinueFromHere();
     }


### PR DESCRIPTION
**This is currently only a proof of concept**

It is possible to implement early return without significant changes to the interpreter using exception based control flow:
* `return(...)` is a function that takes the return value as argument, internally this function throws a `CindyScriptReturn` exception
* When evaluating a function body `CindyScriptReturn` exceptions can be caught to obtain the return value, for convenience this pull request adds a `evaluateR` function for this purpose
* The top-level evaluation function for each script should use `evaluateR` to prevent the exception from leaking out of the interpreter.
The same approach can also be using to add the ability to break out of loops early.

Currently unanswered questions:
* Does a return statement fit into CindyScript
* Should `return` be a function or a keyword/operator
* Should return be caught by `eval`
* Should return in userData expression be caught
* How should a return outside a function be handled
* Is using exceptions for control-flow a good idea
* If yes how can we reliably prevent the exception from leaking out of the interpreter