### PR TITLE
Add variadic print functions

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -101,6 +101,17 @@ evaluator.println$1 = function (args, modifs) {
     csconsole.out(niceprint(evaluate(args[0], modifs)));
     return nada;
 };
+// variadic print functions
+evaluator.print = function (args, modifs) {
+    //VARIADIC!
+    csconsole.out(args.map((arg) => niceprint(evaluate(arg), modifs)).join(" "), true);
+    return nada;
+};
+evaluator.println = function (args, modifs) {
+    //VARIADIC!
+    csconsole.out(args.map((arg) => niceprint(evaluate(arg, modifs))).join(" "));
+    return nada;
+};
 
 evaluator.assert$2 = function (args, modifs) {
     const v0 = evaluate(args[0]);


### PR DESCRIPTION
When debugging it is often useful to print multiples values at once, which leads to slightly confusing error messages of the form `print$2` does not exist.
While printing multiple values is possible by putting all elements in an array having a single variadic print function is more convenient.

Variadic printing would also make concatenating multiple values slightly easier:
`print(text(x)+" + "+text(y)+" = "+text(x+y))` -> `print(x,"+",y,"=",x+y)`