### PR TITLE
add short circuiting versions of and/or operators

### DIFF
--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -31,6 +31,8 @@ import {
     infix_nin,
     infix_and,
     infix_or,
+    infix_and_shortcircuit,
+    infix_or_shortcircuit,
     comp_notalmostequals,
     infix_sequence,
     infix_concat,
@@ -76,6 +78,8 @@ infixmap["∈"] = infix_in;
 infixmap["∉"] = infix_nin;
 infixmap["&"] = infix_and;
 infixmap["%"] = infix_or;
+infixmap["&&"] = infix_and_shortcircuit;
+infixmap["%%"] = infix_or_shortcircuit;
 infixmap["!="] = comp_notequals;
 infixmap["~!="] = comp_notalmostequals;
 infixmap[".."] = infix_sequence;

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -1040,6 +1040,22 @@ function infix_or(args, modifs) {
 
     return nada;
 }
+function infix_and_shortcircuit(args, modifs) {
+    const v0 = evaluateAndVal(args[0]);
+    if (v0.ctype !== "boolean") return nada;
+    if (!v0.value) return v0;
+    const v1 = evaluateAndVal(args[1]);
+    if (v0.ctype !== "boolean") return nada;
+    return v1;
+}
+function infix_or_shortcircuit(args, modifs) {
+    const v0 = evaluateAndVal(args[0]);
+    if (v0.ctype !== "boolean") return nada;
+    if (v0.value) return v0;
+    const v1 = evaluateAndVal(args[1]);
+    if (v0.ctype !== "boolean") return nada;
+    return v1;
+}
 
 evaluator.xor$2 = function (args, modifs) {
     const v0 = evaluateAndVal(args[0]);
@@ -5848,6 +5864,8 @@ export {
     infix_nin,
     infix_and,
     infix_or,
+    infix_and_shortcircuit,
+    infix_or_shortcircuit,
     comp_notalmostequals,
     infix_sequence,
     infix_concat,

--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -60,6 +60,10 @@ const operatorLevels = [
         or: ["%", "∨"],
     },
     {
+        shortand: ["&&"],
+        shortor: ["%%"],
+    },
+    {
         rassoc: true,
         prepend: ["<:"],
     },


### PR DESCRIPTION
Short circuiting and/or are very useful for conditions that depend on values having the right type (e.g. ( if(islist(arg) && length(arg) > 0 && arg_1 == 5, ... ) )

Currently implemented as operators, it might be better to map this behavior to the `and` / `or` functions or add a third variant of and/or that uses short circuit evaluation e.g.  `ifand(<cond1>,<cond2>)` `ifor(<cond1>,<cond2>)`