### PR TITLE
add ability to remove elements with specific index

### DIFF
--- a/src/js/libcs/Dict.js
+++ b/src/js/libcs/Dict.js
@@ -61,6 +61,18 @@ Dict.get = function (dict, key, dflt) {
     return dflt;
 };
 
+// returns copy of dictionary without the given key, or the original dictionary if the key does not exist
+Dict.without = function (dict, key) {
+    const keyName = Dict.key(key);
+    const kv = dict.value[keyName];
+    if (kv) {
+        let copy = Dict.clone(dict);
+        delete copy.value[keyName];
+        return copy;
+    }
+    return dict;
+};
+
 Dict.niceprint = function (dict) {
     return (
         "{" +

--- a/src/js/libcs/List.js
+++ b/src/js/libcs/List.js
@@ -322,6 +322,15 @@ List.remove = function (a, b) {
         value: erg,
     };
 };
+List.removeAt = function (a, index) {
+    if (index < 1 || index > a.value.length) return a; // index out of range
+    // remove element index-1 from JS list (JS is 0 indexed while CindyScript is 1 indexed)
+    const erg = a.value.slice(0, index - 1).concat(a.value.slice(index));
+    return {
+        ctype: "list",
+        value: erg,
+    };
+};
 
 List.sort1 = function (a) {
     const erg = a.value.slice();

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3118,7 +3118,10 @@ evaluator.removeat$2 = function (args, modifs) {
             };
         }
     }
-    // TODO? handle user-data?, handle dictionaries
+    if (v0.ctype === "dict") {
+        return Dict.without(v0, ind);
+    }
+    // TODO? support removing user-data?
     return v0;
 };
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3087,6 +3087,41 @@ function infix_remove(args, modifs) {
     return nada;
 }
 
+evaluator.removeat$2 = function (args, modifs) {
+    const v0 = evaluate(args[0]);
+    const ind = evaluateAndVal(args[1]);
+    if (v0.ctype === "list" || v0.ctype === "string") {
+        if (ind.ctype !== "number") return v0; // index is not a real number
+        let ind1 = Math.floor(ind.value.real);
+        if (ind1 < 0) {
+            ind1 = v0.value.length + ind1 + 1;
+        }
+        if (ind1 > 0 && ind1 <= v0.value.length) {
+            if (v0.ctype === "list") {
+                return List.removeAt(v0, ind1);
+            } else {
+                // string
+                let str = v0.value;
+                str = str.substring(0, ind1 - 1) + str.substring(ind1, str.length);
+                return General.string(str);
+            }
+        }
+    }
+    if (v0.ctype === "JSON") {
+        const key = niceprint(ind);
+        if (!niceprint.errorTypes.includes(key)) {
+            let elts = { ...v0.value };
+            delete elts[key];
+            return {
+                ctype: "JSON",
+                value: elts,
+            };
+        }
+    }
+    // TODO? handle user-data?, handle dictionaries
+    return v0;
+};
+
 evaluator.append$2 = infix_append;
 
 function infix_append(args, modifs) {


### PR DESCRIPTION
add ability to remove list/string/JSON/dictionary entries by their index/key

Like all other CindyScript operations these operations keep the original container and return a modified copy without the specified key.

One use is to implement the pop operation in a  stack as  `list=removeAt(list,length(list))` (I know that CindyScript treats all functions as lower-case but camelCase is easier to read) without having to explicitly copy the elements of a list with a construct of the form `list=apply(1..(length(list)-1),list_#)`.