### PR TITLE
allow concatenating dictionaries

### DIFF
--- a/src/js/libcs/Dict.js
+++ b/src/js/libcs/Dict.js
@@ -61,6 +61,19 @@ Dict.get = function (dict, key, dflt) {
     return dflt;
 };
 
+// returns a directory containing all elements appearing in at least one of the arguments,
+//   for duplicate keys the value from the second directory will be used
+// if one of the directories is empty the other one will be returned, otherwise a new directory is created
+Dict.union = function (a, b) {
+    if (Object.keys(b.value).length === 0) return a;
+    if (Object.keys(a.value).length === 0) return b;
+    let c = Dict.clone(a);
+    Object.entries(b.value).forEach(function ([key, value]) {
+        c.value[key] = value;
+    });
+    return c;
+};
+
 Dict.niceprint = function (dict) {
     return (
         "{" +

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -3049,6 +3049,20 @@ function infix_concat(args, modifs) {
     if (v0.ctype === "shape" && v1.ctype === "shape") {
         return eval_helper.shapeconcat(v0, v1);
     }
+    if (v0.ctype === "JSON" && v1.ctype === "JSON") {
+        let elts = { ...v0.value };
+        // for duplicate keys use second argument
+        Object.entries(v1.value).forEach(function ([key, value]) {
+            elts[key] = value;
+        });
+        return {
+            ctype: "JSON",
+            value: elts,
+        };
+    }
+    if (v0.ctype === "dict" && v1.ctype === "dict") {
+        return Dict.union(v0, v1);
+    }
     const l0 = List.asList(v0);
     const l1 = List.asList(v1);
     if (l0.ctype === "list" && l1.ctype === "list") {


### PR DESCRIPTION
Add the ability to merge dictionaries (union of keys, for duplicate entries pick values in second operand)

This pull request currently uses the `concat` function for these operations, it might be better to introduce a new `union` function (which then could also work as a set operation)