### PR TITLE
if(undefined,) should produce a warning

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -937,7 +937,7 @@ evaluator.if$3 = function (args, modifs) {
         } else if (args.length === 3) {
             return evaluate(args[2]);
         }
-    } else if (v0.ctype !== "undefined") {
+    } else {
         printStackTrace("Condition for if is not boolean");
     }
 


### PR DESCRIPTION
If statements silently not executing either of the branches is the source of some hard to find/confusing bugs.

Intentionally passing undefined to an `if` statement to not execute either of the branches should be relatively rare, while it is relatively easy to accidentally produce undefined as the condition of an if-statement (e.g. by comparing complex numbers).

