### PR TITLE
Use e.key in keyEvent for improved keyboard event handling

### DIFF
--- a/src/js/Events.js
+++ b/src/js/Events.js
@@ -777,6 +777,14 @@ function updateCindy() {
 }
 
 function keyEvent(e, script) {
+    e = e || window.event;
+    cskey = e.key || String.fromCharCode(e.keyCode || e.charCode || 0);
+    cskeycode = e.keyCode || e.charCode || 0;
+    if (script) {
+        evaluate(script);
+    }
+    scheduleUpdate();
+    /*
     const evtobj = window.event ? event : e;
     const unicode = evtobj.charCode ? evtobj.charCode : evtobj.keyCode;
     const actualkey = String.fromCharCode(unicode);
@@ -784,6 +792,7 @@ function keyEvent(e, script) {
     cskeycode = unicode;
     evaluate(script);
     scheduleUpdate();
+    */
 }
 
 function cs_keydown(e) {


### PR DESCRIPTION
This pull request updates the keyEvent function to use the e.key property for keyboard event handling. This change improves compatibility with current browsers and provides more accurate key detection, especially for special keys. The fallback to keyCode/charCode remains for older browser support.
Additionally, the code is simplified and made more robust against undefined or missing event properties.
Tested with various key events to ensure correct behavior.

Fixes #964 