### PR TITLE
Custom modifiers

### DIFF
--- a/examples/custom_modifiers.html
+++ b/examples/custom_modifiers.html
@@ -10,20 +10,34 @@
 
         red = (0.8, 0.2, 0.3);
         green = (0.3, 0.8, 0.2);
+        blue = (0.2, 0.3, 0.8);
 
-        functionA(x) := drawtext([0, 3], x, color -> col);
+        functionA(x) := drawtext([0, 6], x, color -> col);
+        
+        functionB(x, customColor -> blue) := drawtext([0, 2], x, color -> customColor);
+        
+        functionC(x) := drawtext([0, -2], x, color -> col);
+        
+        functionD(x, customColor -> blue) := drawtext([0, -6], x, color -> customColor);
 
-        functionB(x, customColor -> (0, 0, 1)) := drawtext([0, -3], x, color -> customColor);
         
         </script>
 
         <script id="csdraw" type="text/x-cindyscript">
-        // old version of modifier passing-through
+        // Old version of modifier passing-through.
         functionA("testA", col -> red);
+        
+        // New functionality of custom default values.
+        functionB("testB");
 
-        // new functionality of custom default values
-        functionB("testB part 1");
 
+        // For completeness, the other two cases. But they are uninteresting
+        // Throws error and uses default value of whatever the built-in function uses as default value. As expected. Nothing changed here; nothing should change here.
+        functionC("testC");
+
+        // Calling a function with a custom modifier in a way that gives said custom modifier a non-default value.
+        // Uninteresting in the sense that the parser handles this exactly the same as the functionA example of the already existing modifier pass-through.
+        functionD("testD", customColor -> green);
         </script>
 
         <script type="text/javascript">

--- a/examples/custom_modifiers.html
+++ b/examples/custom_modifiers.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Cindy JS Example</title>
+        <meta charset="UTF-8" />
+        <link rel="stylesheet" href="../build/js/CindyJS.css" />
+        <script type="text/javascript" src="../build/js/Cindy.js"></script>
+
+        <script id="csinit" type="text/x-cindyscript">
+
+        red = (0.8, 0.2, 0.3);
+        green = (0.3, 0.8, 0.2);
+
+        functionA(x) := drawtext([0, 3], x, color -> col);
+
+        functionB(x, customColor -> (0, 0, 1)) := drawtext([0, -3], x, color -> customColor);
+        
+        </script>
+
+        <script id="csdraw" type="text/x-cindyscript">
+        // old version of modifier passing-through
+        functionA("testA", col -> red);
+
+        // new functionality of custom default values
+        functionB("testB part 1");
+
+        </script>
+
+        <script type="text/javascript">
+            var cdy = CindyJS({
+                ports: [{ id: "CSCanvas", width: 500, height: 500 }],
+                scripts: "cs*",
+            });
+        </script>
+    </head>
+
+    <body style="font-family: Arial">
+        <h1>CindyJS: Defining your own modifiers</h1>
+        <div id="CSCanvas" style="border: 2px solid black"></div>
+    </body>
+</html>

--- a/src/js/libcs/Essentials.js
+++ b/src/js/libcs/Essentials.js
@@ -196,6 +196,9 @@ function evalmyfunctions(name, args, modifs) {
     }
     //  evaluate modifiers in caller-scope
     let modValues = {};
+    Object.entries(tt.defaultModifs || {}).forEach(function ([key, value]) {
+        modValues[key] = evaluate(value);
+    });
     Object.entries(modifs).forEach(function ([key, value]) {
         modValues[key] = evaluate(value);
     });
@@ -213,7 +216,7 @@ function evalmyfunctions(name, args, modifs) {
     namespace.cleanVstack();
 
     // remove modifiers again
-    Object.entries(modifs).forEach(function ([key, value]) {
+    Object.entries(modValues).forEach(function ([key]) {
         namespace.removevar(key);
     });
 

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -896,6 +896,7 @@ function infix_define(args, modifs, self) {
             oper: fname,
             body,
             arglist: ar,
+            defaultModifs: args[0].modifs || {},
             definer: self,
             generation,
         };


### PR DESCRIPTION
This allows users to define modifiers for their own functions via 
```
foo(x, customColor -> (1,0,0)) := drawtext([0, 0], x, color -> customColor);
```
It is then called as 
```
foo("text", customColor -> (0,1,0));
```