### PR TITLE
Support `regional` in loops

### DIFF
--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -229,11 +229,17 @@ evaluator.while$2 = function (args, modifs) {
 
     const prog = args[1];
     const test = args[0];
+    namespace.pushVstack("*");
     let bo = evaluate(test);
+    namespace.cleanVstack();
     let erg = nada;
     while (bo.ctype !== "list" && bo.value) {
+        namespace.pushVstack("*");
         erg = evaluate(prog);
+        namespace.cleanVstack();
+        namespace.pushVstack("*");
         bo = evaluate(test);
+        namespace.cleanVstack();
     }
 
     return erg;

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -205,6 +205,7 @@ evaluator.repeat$3 = function (args, modifs) {
             n = Math.floor((stop - start) / step);
         }
 
+    namespace.pushVstack("*");
     namespace.newvar(lauf);
     let erg = nada;
     for (let i = 0; i < n; i++) {
@@ -218,6 +219,7 @@ evaluator.repeat$3 = function (args, modifs) {
         erg = evaluate(args[2]);
     }
     namespace.removevar(lauf);
+    namespace.cleanVstack();
 
     return erg;
 };
@@ -259,6 +261,7 @@ evaluator.apply$4 = function (args, modifs) {
         }
     }
 
+    namespace.pushVstack("*");
     let keyVar;
     if (args[2] !== null) {
         if (args[2].ctype === "variable") {
@@ -307,6 +310,7 @@ evaluator.apply$4 = function (args, modifs) {
     }
 
     namespace.removevar(valueVar);
+    namespace.cleanVstack();
 
     return v1.ctype === "list" ? List.turnIntoCSList(erg) : Json.turnIntoCSJson(erg);
 };
@@ -335,6 +339,7 @@ evaluator.forall$4 = function (args, modifs) {
         }
     }
 
+    namespace.pushVstack("*");
     let indexVar;
     if (args[2] !== null) {
         if (args[2].ctype === "variable") {
@@ -378,6 +383,7 @@ evaluator.forall$4 = function (args, modifs) {
     }
 
     namespace.removevar(runVar);
+    namespace.cleanVstack();
 
     return res;
 };
@@ -405,6 +411,7 @@ evaluator.select$4 = function (args, modifs) {
         }
     }
 
+    namespace.pushVstack("*");
     let keyVar;
     if (args[2] !== null) {
         if (args[2].ctype === "variable") {
@@ -497,6 +504,7 @@ evaluator.select$4 = function (args, modifs) {
     }
 
     namespace.removevar(lauf);
+    namespace.cleanVstack();
 
     return ret;
 };
@@ -1271,6 +1279,7 @@ eval_helper.genericListMathGen = function (name, op, emptyval) {
             }
         }
 
+        namespace.pushVstack("*");
         namespace.newvar(lauf);
         namespace.setvar(lauf, li[0]);
         let erg = evaluate(args[2]);
@@ -1280,6 +1289,7 @@ eval_helper.genericListMathGen = function (name, op, emptyval) {
             erg = op(erg, b);
         }
         namespace.removevar(lauf);
+        namespace.cleanVstack();
         return erg;
     };
 };
@@ -1329,6 +1339,7 @@ evaluator.max$4 = function (args, modifs) {
         }
     }
 
+    namespace.pushVstack("*");
     let indexVar;
     if (args[2] !== null) {
         if (args[2].ctype === "variable") {
@@ -1384,6 +1395,7 @@ evaluator.max$4 = function (args, modifs) {
     }
 
     namespace.removevar(lauf);
+    namespace.cleanVstack();
     return return_element ? erg.element : erg.value;
 };
 
@@ -1429,6 +1441,7 @@ evaluator.min$4 = function (args, modifs) {
         }
     }
 
+    namespace.pushVstack("*");
     let indexVar;
     if (args[2] !== null) {
         if (args[2].ctype === "variable") {
@@ -1486,6 +1499,7 @@ evaluator.min$4 = function (args, modifs) {
     }
 
     namespace.removevar(lauf);
+    namespace.cleanVstack();
     return return_element ? erg.element : erg.value;
 };
 
@@ -1558,12 +1572,14 @@ evaluator.d$2 = function (args, modifs) {
 
     const prog = args[0];
     const x = evaluateAndVal(args[1]);
+    namespace.pushVstack("*");
     namespace.newvar(lauf);
     namespace.setvar(lauf, CSNumber.add(x, eps));
     let f1 = evaluate(prog);
     namespace.setvar(lauf, CSNumber.sub(x, eps));
     let f2 = evaluate(prog);
     namespace.removevar(lauf);
+    namespace.cleanVstack();
     return CSNumber.div(CSNumber.sub(f1, f2), CSNumber.mult(eps, CSNumber.real(2)));
 };
 
@@ -1582,12 +1598,14 @@ evaluator.tangent$2 = function (args, modifs) {
 
     const prog = args[0];
     const x = evaluateAndVal(args[1]);
+    namespace.pushVstack("*");
     namespace.newvar(lauf);
     namespace.setvar(lauf, CSNumber.add(x, eps));
     let f1 = List.turnIntoCSList([CSNumber.add(x, eps), evaluate(prog), CSNumber.one]);
     namespace.setvar(lauf, CSNumber.sub(x, eps));
     let f2 = List.turnIntoCSList([CSNumber.sub(x, eps), evaluate(prog), CSNumber.one]);
     namespace.removevar(lauf);
+    namespace.cleanVstack();
     if (f1 !== nada && f1 !== nada) {
         let erg = List.cross(f1, f2);
         erg = General.withUsage(erg, "Line");
@@ -3158,6 +3176,7 @@ evaluator.sort$4 = function (args, modifs) {
         }
     }
 
+    namespace.pushVstack("*");
     let indexVar;
     if (args[2] !== null) {
         if (args[2].ctype === "variable") {
@@ -3191,6 +3210,7 @@ evaluator.sort$4 = function (args, modifs) {
     }
 
     namespace.removevar(lauf);
+    namespace.cleanVstack();
 
     erg.sort(General.compareResults);
     const erg1 = [];

--- a/src/js/libcs/Operators.js
+++ b/src/js/libcs/Operators.js
@@ -941,9 +941,15 @@ evaluator.if$3 = function (args, modifs) {
     const v0 = evaluateAndVal(args[0]);
     if (v0.ctype === "boolean") {
         if (v0.value === true) {
-            return evaluate(args[1]);
+            namespace.pushVstack("*");
+            const res = evaluate(args[1]);
+            namespace.cleanVstack();
+            return res;
         } else if (args.length === 3) {
-            return evaluate(args[2]);
+            namespace.pushVstack("*");
+            const res = evaluate(args[2]);
+            namespace.cleanVstack();
+            return res;
         }
     } else {
         printStackTrace("Condition for if is not boolean");

--- a/tests/Scope_tests.js
+++ b/tests/Scope_tests.js
@@ -42,9 +42,23 @@ describe("Scope: global vs regional", function () {
 describe("Scope: regional in loop", function () {
     itCmd("x=0;forall(1..10,regional(t);t=#*#;x=x+t);x", "385");
     itCmd("x=0;forall(1..10,regional(t);t=#*#;x=x+t);t", "___");
+    itCmd("x=0;repeat(10,regional(t);t=#*#;x=x+t);x", "385");
+    itCmd("x=0;repeat(10,regional(t);t=#*#;x=x+t);t", "___");
     itCmd("apply(1..5,regional(t);t=#*#;t)", "[1, 4, 9, 16, 25]");
     itCmd("apply(1..5,regional(t);t=#*#;t);t", "___");
+    itCmd("select(1..5,regional(t);t=#*#;t<10)", "[1, 2, 3]");
+    itCmd("select(1..5,regional(t);t=#*#;t<10);t", "___");
     itCmd("x=0;if(true,regional(x);x=2,x=5);x", "0");
     itCmd("x=0;if(false,regional(x);x=2,x=5);x", "5");
     itCmd("x=0;while(x=x+1;x<5,regional(x);x=10);x", "5");
+    itCmd("x=0;sum(1..10,regional(x);x=#*#;x)", "385");
+    itCmd("x=0;sum(1..10,regional(x);x=#*#;x);x", "0");
+    itCmd("x=0;product(1..5,regional(x);x=#*#;x)", "14400");
+    itCmd("x=0;product(1..5,regional(x);x=#*#;x);x", "0");
+    itCmd("x=0;min(1..5,regional(x);x=#*#;x)", "1");
+    itCmd("x=0;min(1..5,regional(x);x=#*#;x);x", "0");
+    itCmd("x=0;max(1..5,regional(x);x=#*#;x)", "25");
+    itCmd("x=0;max(1..5,regional(x);x=#*#;x);x", "0");
+    itCmd("x=0;sort(1..10,regional(x);x=text(#))", "[1, 10, 2, 3, 4, 5, 6, 7, 8, 9]");
+    itCmd("x=0;sort(1..10,regional(x);x=text(#));x", "0");
 });

--- a/tests/Scope_tests.js
+++ b/tests/Scope_tests.js
@@ -18,7 +18,6 @@ function itCmd(command, expected) {
 
 describe("Scope: argument", function () {
     itCmd("x=nada;x=0;f(x):=(x);f(3)", "3");
-    itCmd("x=nada;x=0;f(x):=(x);f(3,x->12)", "12"); // TODO do we want modifiers to overwrite arguments?
     itCmd("x=nada;f(x):=(x);f(3)", "3");
     itCmd("x=nada;x=0;f(x):=(x=2;);f(3);x", "0");
     itCmd("x=nada;f(x):=(x=2;);f(3);x", "___");

--- a/tests/Scope_tests.js
+++ b/tests/Scope_tests.js
@@ -47,4 +47,5 @@ describe("Scope: regional in loop", function () {
     itCmd("apply(1..5,regional(t);t=#*#;t);t", "___");
     itCmd("x=0;if(true,regional(x);x=2,x=5);x", "0");
     itCmd("x=0;if(false,regional(x);x=2,x=5);x", "5");
+    itCmd("x=0;while(x=x+1;x<5,regional(x);x=10);x", "5");
 });

--- a/tests/Scope_tests.js
+++ b/tests/Scope_tests.js
@@ -1,0 +1,50 @@
+var should = require("chai").should();
+var rewire = require("rewire");
+
+global.navigator = {};
+var CindyJS = require("../build/js/Cindy.plain.js");
+
+var cdy = CindyJS({
+    isNode: true,
+    csconsole: null,
+    geometry: [],
+});
+
+function itCmd(command, expected) {
+    it(command, function () {
+        String(cdy.niceprint(cdy.evalcs(command))).should.equal(expected);
+    });
+}
+
+describe("Scope: argument", function () {
+    itCmd("x=nada;x=0;f(x):=(x);f(3)", "3");
+    itCmd("x=nada;x=0;f(x):=(x);f(3,x->12)", "12"); // TODO do we want modifiers to overwrite arguments?
+    itCmd("x=nada;f(x):=(x);f(3)", "3");
+    itCmd("x=nada;x=0;f(x):=(x=2;);f(3);x", "0");
+    itCmd("x=nada;f(x):=(x=2;);f(3);x", "___");
+});
+
+describe("Scope: modifier", function () {
+    itCmd("x=0;f():=(x);f(x->11)", "11");
+    itCmd("x=0;f():=(x=5);f(x->11)", "5");
+    itCmd("x=0;f():=(x=5);f(x->11);x", "0");
+});
+
+describe("Scope: global vs regional", function () {
+    itCmd("x=0;f():=(x=2);f();x", "2");
+    itCmd("x=0;f():=(regional(x);x=5);f()", "5");
+    itCmd("x=0;f():=(regional(x);x=5);f();x", "0");
+    itCmd("x=0;f():=(x=2;regional(x);x=5);f();x", "2");
+    itCmd("x=nada;f():=(regional(x);x=5);f();x", "___");
+    itCmd("x=0;f():=(regional(x);g();x);g():=(x=11);f()", "11");
+    itCmd("x=0;f():=(regional(x);g();x);g():=(x=11);f();x", "0");
+});
+
+describe("Scope: regional in loop", function () {
+    itCmd("x=0;forall(1..10,regional(t);t=#*#;x=x+t);x", "385");
+    itCmd("x=0;forall(1..10,regional(t);t=#*#;x=x+t);t", "___");
+    itCmd("apply(1..5,regional(t);t=#*#;t)", "[1, 4, 9, 16, 25]");
+    itCmd("apply(1..5,regional(t);t=#*#;t);t", "___");
+    itCmd("x=0;if(true,regional(x);x=2,x=5);x", "0");
+    itCmd("x=0;if(false,regional(x);x=2,x=5);x", "5");
+});


### PR DESCRIPTION
Run the expressions passed to built-in  loop / control-flow  functions (`repeat` `forall` `select` `apply` `while` `if` `sum` `product` `min` `max` `sort` `d` `tangent`) in a separate scope, allowing the use of regional variables within loop-bodies

+ add test-cases for general scoping behavior in CindyScript

----

* should `d` and `tangent` be included in this change, they fit the pattern of functions taking an expression as argument, but are not ready control-flow statements