### PR TITLE
Add CSV-stype String escaping

### DIFF
--- a/src/js/libcs/Parser.js
+++ b/src/js/libcs/Parser.js
@@ -264,7 +264,7 @@ const reNextToken = [
     "(" + subNum + ")", //             subscript
     "(" + supNum + ")", //             superscript
     "(" + reIdentifier + ")", //       identifier
-    '("[^"]*")', //                    string literal
+    '("(?:[^"]|"")*")', //             string literal
     "($)", //                          EOF
 ].join("|");
 
@@ -493,7 +493,7 @@ function parseRec(tokens, closing) {
                 break;
             case "STR":
                 tok.ctype = "string";
-                tok.value = tok.raw.substring(1, tok.raw.length - 1);
+                tok.value = tok.raw.substring(1, tok.raw.length - 1).replaceAll('""', '"');
                 if (seq.length & 1) throw ParseError("Missing operator", tok.start, tok.text);
                 seq.push(tok);
                 break;

--- a/tests/Parser_tests.js
+++ b/tests/Parser_tests.js
@@ -31,7 +31,7 @@ function simpl(expr) {
             break;
         case "void":
             return null;
-            break;
+            break; // eslint-disable-line no-unreachable
         case "error":
             throw expr;
         default:
@@ -91,6 +91,7 @@ describe("CindyScript parser normal operation", function () {
     simplCase("x²", { "^": ["$x", 2] });
     simplCase("x ⁻ ⁰ ¹ ²", { "^": ["$x", -12] });
     simplCase("a₇", { _: ["$a", 7] });
+    simplCase('"String with ""escaped"" quotes"', 'String with "escaped" quotes');
     /* Copy & paste from here:
     simplCase('', );
     */
@@ -124,7 +125,7 @@ describe("CindyScript tokenizer", function () {
             it(input, function () {
                 expect(function () {
                     var tokenizer = new Tokenizer(input);
-                    while (tokenizer.next().toktype !== "EOF") {}
+                    while (tokenizer.next().toktype !== "EOF") {} // eslint-disable-line no-empty
                 }).to.throw(expected);
             });
         } else {
@@ -151,6 +152,7 @@ describe("CindyScript tokenizer", function () {
 
     it("should reconstruct regular expression for unicode letters", function () {
         function esc(s) {
+            /* eslint-disable no-control-regex*/
             return s
                 .replace(/["\\]/g, "\\$&")
                 .replace(/[^\x00-\x7f]/g, function (c) {
@@ -160,6 +162,7 @@ describe("CindyScript tokenizer", function () {
                     return "\\u" + c;
                 })
                 .split("|");
+            /* eslint-enable no-control-regex*/
         }
         var expected;
         // First test, with escapes and splitting the expression


### PR DESCRIPTION
Currently there is no convenient way to create strings containing the character `"`.

This pull request adds minimal string-escaping with similar semantics as the CSV-format, treating `""` within a string as the character `"` instead of ending and restarting a string literal.

Currently strings containing `""` are treated as two consecutive string-literals which is a syntax-error, so this new syntax does not invalidate any existing programs.